### PR TITLE
SessionHost: use config.appName instead of hardcoded "yourworld"

### DIFF
--- a/src/SessionHost.mm
+++ b/src/SessionHost.mm
@@ -137,14 +137,17 @@ static std::string jsonStringValue(const std::string& json, const std::string& k
 // ── ge::run — multi-session server ─────────────────────────────────
 
 void run(Factory factory, const SessionHostConfig& config) {
+    const char* name = (config.appName && *config.appName) ? config.appName : "server";
+
     // Connect to ged sideband (control channel)
-    auto sideband = connectWebSocket("localhost", 42069, "/ws/server?name=yourworld", 2000);
+    auto sideband = connectWebSocket("localhost", 42069,
+        std::string("/ws/server?name=") + name, 2000);
     if (!sideband || !sideband->isOpen()) {
         SPDLOG_WARN("Failed to connect to ged — running standalone");
         return;
     }
     SPDLOG_INFO("Connected to ged sideband");
-    std::string hello = "{\"type\":\"hello\",\"name\":\"yourworld\",\"pid\":"
+    std::string hello = std::string("{\"type\":\"hello\",\"name\":\"") + name + "\",\"pid\":"
         + std::to_string(getpid()) + ",\"version\":"
         + std::to_string(wire::kProtocolVersion) + "}";
     sideband->sendText(hello);


### PR DESCRIPTION
## Summary

The sideband URL (`/ws/server?name=yourworld`) and hello message (`{"name":"yourworld",...}`) in `SessionHost.mm` were hardcoded, which meant any non-yourworld ge-based game misidentified itself to ged.

Fix: use the `SessionHostConfig.appName` field that was already defined in the struct. Falls back to `"server"` when `appName` is unset or empty, matching the original fail-safe behaviour.

Originally spotted in esfera2's local ge checkout (uncommitted diff). It belongs upstream in ge — it's a bug fix, not esfera-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)