### PR TITLE
Restore build-artifact gitignore entries lost in merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 build/
+bin/
+*.o
+*.passed
+math_bench.md
 ged/ged
 ged/web/
 /.claude/*


### PR DESCRIPTION
## Summary

Merge \`87e2eb1\` (Merge multimaze2-session-config into master) silently dropped the \`bin/\`, \`*.o\`, \`*.passed\`, and \`math_bench.md\` patterns added in PR #6 by taking the older-parent version of .gitignore. Re-adds them so the top-level stays tidy after a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)