### PR TITLE
ge: player accepts ged_addr launch param (iOS + Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,38 @@ Module.mk       Build rules and exported variables
 |--------|-------------|
 | `ImageDiff.h` | CPU and GPU pixel comparison (RMS difference) |
 
+## Launching the Player with a Specific Server Address
+
+For automated and scripted launches (CI, matrix testing, agent workflows), pass the ged
+address directly at launch time so the player connects without a QR scan.
+
+**Desktop**
+```bash
+bin/player  # always connects to localhost:42069
+```
+
+**iOS Simulator** — pass `-ged_addr host:port` as a launch argument:
+```bash
+xcrun simctl launch <udid> com.squz.player -ged_addr localhost:42069
+```
+
+**iOS Device** — use `devicectl` with `--console-pty` and pass args after `--`:
+```bash
+xcrun devicectl device process launch --console-pty --device <udid> com.squz.player -- -ged_addr 192.168.1.100:42069
+```
+
+**Android Emulator** — pass `--es ged_addr host:port` to `am start`:
+```bash
+adb shell am start -n com.squz.player/.GeActivity --es ged_addr 10.0.2.2:42069
+```
+
+**Android Device** — same syntax with the Mac's LAN IP:
+```bash
+adb shell am start -n com.squz.player/.GeActivity --es ged_addr 192.168.1.100:42069
+```
+
+If the parameter is absent the player falls back to any saved address, then QR scan.
+
 ## License
 
 See individual files and `vendor/` subdirectories for license terms.

--- a/tools/android/app/src/main/cpp/main.cpp
+++ b/tools/android/app/src/main/cpp/main.cpp
@@ -1,6 +1,12 @@
 // Android ge player entry point.
 // Scans a QR code on startup to discover the game server, then runs the shared
 // player core.
+//
+// Pass --es ged_addr "host:port" to adb am start to connect directly (highest priority):
+//   adb shell am start -n com.squz.player/.GeActivity --es ged_addr "10.0.2.2:42069"
+// Set debug.ge.address system property to connect directly without QR:
+//   adb shell setprop debug.ge.address "192.168.1.100:42069"
+// On the emulator, 10.0.2.2 is automatically used when neither override is present.
 
 #include "player_core.h"
 #include "QRScanner.h"
@@ -8,6 +14,9 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/android_sink.h>
 #include <sys/system_properties.h>
+
+#include <jni.h>
+#include <SDL3/SDL.h>
 
 namespace {
 
@@ -19,22 +28,47 @@ bool isEmulator() {
     return value[0] == '1';
 }
 
-// Check debug.ge.address system property for direct connection (skips QR).
-// Set via: adb shell setprop debug.ge.address "192.168.1.100:42069"
-// Or just: adb shell setprop debug.ge.address "192.168.1.100" (uses default port)
-// Clear:  adb shell setprop debug.ge.address ""
-ge::ScanResult directAddress() {
-    char value[PROP_VALUE_MAX] = {};
-    __system_property_get("debug.ge.address", value);
-    if (value[0] == '\0') return {};
-
-    std::string addr(value);
+// Parse "host:port" or "host" into a ScanResult.
+ge::ScanResult parseAddr(const std::string& addr) {
     auto colon = addr.rfind(':');
     if (colon != std::string::npos) {
         uint16_t port = static_cast<uint16_t>(std::stoi(addr.substr(colon + 1)));
         return {addr.substr(0, colon), port};
     }
     return {addr, static_cast<uint16_t>(kDefaultPort)};
+}
+
+// Retrieve the ged_addr intent extra set by GeActivity.getGedAddr() via JNI.
+// Returns empty string if absent or on JNI error.
+std::string intentGedAddr() {
+    JNIEnv* env = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
+    if (!env) return {};
+
+    jclass cls = env->FindClass("com/squz/player/GeActivity");
+    if (!cls) { env->ExceptionClear(); return {}; }
+
+    jmethodID mid = env->GetStaticMethodID(cls, "getGedAddr", "()Ljava/lang/String;");
+    if (!mid) { env->ExceptionClear(); env->DeleteLocalRef(cls); return {}; }
+
+    jobject obj = env->CallStaticObjectMethod(cls, mid);
+    env->DeleteLocalRef(cls);
+    if (!obj) return {};
+
+    const char* chars = env->GetStringUTFChars(static_cast<jstring>(obj), nullptr);
+    std::string result = chars ? chars : "";
+    env->ReleaseStringUTFChars(static_cast<jstring>(obj), chars);
+    env->DeleteLocalRef(obj);
+    return result;
+}
+
+// Check debug.ge.address system property for direct connection (skips QR).
+// Set via: adb shell setprop debug.ge.address "192.168.1.100:42069"
+// Clear:  adb shell setprop debug.ge.address ""
+ge::ScanResult directAddressProp() {
+    char value[PROP_VALUE_MAX] = {};
+    __system_property_get("debug.ge.address", value);
+    if (value[0] == '\0') return {};
+    return parseAddr(std::string(value));
 }
 
 } // namespace
@@ -46,20 +80,32 @@ int main(int argc, char* argv[]) {
 
     SPDLOG_INFO("ge player (Android) starting...");
 
-    // System property override — fast, non-blocking.
-    auto direct = directAddress();
-    if (!direct.host.empty()) {
-        SPDLOG_INFO("Direct connection via debug.ge.address: {}:{}", direct.host, direct.port);
-        return playerCore(direct.host, direct.port);
+    // Priority 1: ged_addr intent extra (set via adb am start --es ged_addr host:port).
+    {
+        std::string addr = intentGedAddr();
+        if (!addr.empty()) {
+            auto r = parseAddr(addr);
+            SPDLOG_INFO("Intent ged_addr: {}:{}", r.host, r.port);
+            return playerCore(r.host, r.port);
+        }
     }
 
-    // Emulator auto-connect — Android's alias for the host loopback.
+    // Priority 2: System property override — fast, non-blocking.
+    {
+        auto direct = directAddressProp();
+        if (!direct.host.empty()) {
+            SPDLOG_INFO("Direct connection via debug.ge.address: {}:{}", direct.host, direct.port);
+            return playerCore(direct.host, direct.port);
+        }
+    }
+
+    // Priority 3: Emulator auto-connect — Android's alias for the host loopback.
     if (isEmulator()) {
         SPDLOG_INFO("Emulator detected — connecting to 10.0.2.2:{}", kDefaultPort);
         return playerCore("10.0.2.2", kDefaultPort);
     }
 
-    // Physical device — scan QR code presented by ged dashboard.
+    // Priority 4: Physical device — scan QR code presented by ged dashboard.
     SPDLOG_INFO("Physical device — waiting for QR scan...");
     ge::ScanResult result = ge::scanQRCode();
     return playerCore(result.host, result.port);

--- a/tools/android/app/src/main/java/com/squz/player/GeActivity.java
+++ b/tools/android/app/src/main/java/com/squz/player/GeActivity.java
@@ -1,8 +1,39 @@
 package com.squz.player;
 
+import android.content.Intent;
+import android.os.Bundle;
 import org.libsdl.app.SDLActivity;
 
 public class GeActivity extends SDLActivity {
+    // Holds the ged_addr intent extra so native code can retrieve it via JNI.
+    // Set before SDL's native thread starts; cleared after first read.
+    private static volatile String sGedAddr = null;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        // Check for ged_addr intent extra before super.onCreate() loads the
+        // native libraries and starts the SDL thread — this ensures it is
+        // available when SDL_main runs.
+        Intent intent = getIntent();
+        if (intent != null) {
+            String addr = intent.getStringExtra("ged_addr");
+            if (addr != null && !addr.isEmpty()) {
+                sGedAddr = addr;
+            }
+        }
+        super.onCreate(savedInstanceState);
+    }
+
+    // Called from native (JNI) to retrieve the intent-supplied ged address.
+    // Returns the address string (e.g. "192.168.1.100:42069") or null if absent.
+    // Clears the value after the first read so it does not persist across
+    // Activity restarts within the same process.
+    public static String getGedAddr() {
+        String addr = sGedAddr;
+        sGedAddr = null;
+        return addr;
+    }
+
     @Override
     protected String[] getLibraries() {
         return new String[]{"SDL3", "main"};

--- a/tools/ios/main.mm
+++ b/tools/ios/main.mm
@@ -1,8 +1,11 @@
 // iOS ge player entry point.
 // Scans a QR code on startup to discover the game server, then runs the shared player core.
 //
-// Set GE_DAEMON_ADDR=host:port to skip QR scanning and connect directly.
-// Example: xcrun devicectl device process launch -e '{"GE_DAEMON_ADDR":"192.168.1.217:42069"}' ...
+// Pass -ged_addr host:port as a launch argument to connect directly (highest priority).
+// Set GE_DAEMON_ADDR=host:port to connect directly via environment variable.
+// Example (simulator):  xcrun simctl launch <udid> com.squz.player -ged_addr 192.168.1.217:42069
+// Example (device):     xcrun devicectl device process launch --console-pty -- com.squz.player -ged_addr 192.168.1.217:42069
+// Example (env var):    xcrun devicectl device process launch -e '{"GE_DAEMON_ADDR":"192.168.1.217:42069"}' ...
 
 #include <TargetConditionals.h>
 #include "player_core.h"
@@ -64,30 +67,49 @@ int main(int argc, char* argv[]) {
     std::string host;
     uint16_t port = kDefaultPort;
 
-    // Fast, non-blocking overrides first.
-    if (const char* addr = std::getenv("GE_DAEMON_ADDR")) {
-        std::string s(addr);
+    // Helper: parse "host:port" or "host" into host/port.
+    auto parseAddr = [&](const std::string& s) {
         host = s;
         if (auto colon = s.rfind(':'); colon != std::string::npos) {
             host = s.substr(0, colon);
             port = static_cast<uint16_t>(std::stoi(s.substr(colon + 1)));
         }
-        SPDLOG_INFO("GE_DAEMON_ADDR: {}:{}", host, port);
+    };
+
+    // Priority 1: -ged_addr launch argument (xcrun simctl launch … -ged_addr host:port).
+    // simctl stores launch args as NSUserDefaults. Read once and do not persist.
+    @autoreleasepool {
+        NSString* gedAddr = [[NSUserDefaults standardUserDefaults] stringForKey:@"ged_addr"];
+        if (gedAddr && gedAddr.length > 0) {
+            std::string s = gedAddr.UTF8String;
+            parseAddr(s);
+            SPDLOG_INFO("ged_addr launch arg: {}:{}", host, port);
+            // Remove the key so it doesn't persist across launches without the arg.
+            [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"ged_addr"];
+        }
     }
+
+    // Priority 2: GE_DAEMON_ADDR environment variable.
+    if (host.empty()) {
+        if (const char* addr = std::getenv("GE_DAEMON_ADDR")) {
+            parseAddr(std::string(addr));
+            SPDLOG_INFO("GE_DAEMON_ADDR: {}:{}", host, port);
+        }
+    }
+
+    // Priority 3: Platform-specific fallback.
+    if (host.empty()) {
 #if TARGET_OS_SIMULATOR
-    else {
         SPDLOG_INFO("Simulator: using localhost:{}", kDefaultPort);
         host = "localhost";
         port = kDefaultPort;
-    }
 #else
-    else {
         // Blocking QR scan to discover the server.
         ge::ScanResult result = ge::scanQRCode();
         host = result.host;
         port = result.port;
-    }
 #endif
+    }
 
     return playerCore(host, port);
 }

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -814,13 +814,17 @@ cold_launch_player_desktop() {
 cold_launch_ios_sim() {
     local subcheck="cold-launch"
     local bundle_id="$1"; local app_path="$2"; local ff="$3"
+    # $4: optional extra launch args forwarded verbatim to `simctl launch`
+    # (e.g. "-ged_addr localhost:42069" passes ged address as NSUserDefaults key)
+    local extra_launch_args="${4:-}"
 
     SIM_UDID=$(ios_sim_get_udid "$ff") || { fail_check "$subcheck" "no booted iOS sim for $ff"; return 1; }
 
     xcrun simctl terminate "$SIM_UDID" "$bundle_id" 2>/dev/null || true
     run xcrun simctl install "$SIM_UDID" "$app_path" \
         || { fail_check "$subcheck" "simctl install failed"; return 1; }
-    run xcrun simctl launch "$SIM_UDID" "$bundle_id" \
+    # shellcheck disable=SC2086
+    run xcrun simctl launch "$SIM_UDID" "$bundle_id" $extra_launch_args \
         || { fail_check "$subcheck" "simctl launch failed"; return 1; }
 
     sleep "$COLD_LAUNCH_TIMEOUT"
@@ -841,6 +845,8 @@ cold_launch_ios_sim() {
 cold_launch_android_emu() {
     local subcheck="cold-launch"
     local pkg="$1"; local apk="$2"; local ff="$3"; local activity="$4"
+    # $5: optional extra am start args (e.g. "--es ged_addr 10.0.2.2:42069")
+    local extra_am_args="${5:-}"
 
     ANDROID_SERIAL=$(android_get_serial "$ff") \
         || { fail_check "$subcheck" "no Android emulator for $ff"; return 1; }
@@ -848,7 +854,8 @@ cold_launch_android_emu() {
     adb -s "$ANDROID_SERIAL" shell am force-stop "$pkg" 2>/dev/null || true
     run adb -s "$ANDROID_SERIAL" install -r "$apk" \
         || { fail_check "$subcheck" "adb install failed"; return 1; }
-    run adb -s "$ANDROID_SERIAL" shell am start -n "$activity" \
+    # shellcheck disable=SC2086
+    run adb -s "$ANDROID_SERIAL" shell am start -n "$activity" $extra_am_args \
         || { fail_check "$subcheck" "adb am start failed ($activity)"; return 1; }
 
     sleep "$COLD_LAUNCH_TIMEOUT"
@@ -869,6 +876,8 @@ cold_launch_android_emu() {
 cold_launch_android_device() {
     local subcheck="cold-launch"
     local pkg="$1"; local apk="$2"; local ff="$3"; local activity="$4"
+    # $5: optional extra am start args (e.g. "--es ged_addr 192.168.1.100:42069")
+    local extra_am_args="${5:-}"
 
     ANDROID_SERIAL=$(android_device_get_serial "$ff") \
         || { fail_check "$subcheck" "no USB-connected Android device for $ff"; return 1; }
@@ -876,7 +885,8 @@ cold_launch_android_device() {
     adb -s "$ANDROID_SERIAL" shell am force-stop "$pkg" 2>/dev/null || true
     run adb -s "$ANDROID_SERIAL" install -r "$apk" \
         || { fail_check "$subcheck" "adb install failed"; return 1; }
-    run adb -s "$ANDROID_SERIAL" shell am start -n "$activity" \
+    # shellcheck disable=SC2086
+    run adb -s "$ANDROID_SERIAL" shell am start -n "$activity" $extra_am_args \
         || { fail_check "$subcheck" "adb am start failed ($activity)"; return 1; }
 
     sleep "$COLD_LAUNCH_TIMEOUT"
@@ -1352,7 +1362,10 @@ run_ios_sim_player() {
     ensure_ged
     start_server
 
-    cold_launch_ios_sim "$PLAYER_BUNDLE_ID" "$app_path" "$FORM_FACTOR" || { stop_server; return; }
+    # Pass ged address as launch arg so the player connects directly (no QR scan).
+    # The iOS simulator reaches the macOS host via localhost.
+    cold_launch_ios_sim "$PLAYER_BUNDLE_ID" "$app_path" "$FORM_FACTOR" \
+        "-ged_addr localhost:$GED_PORT" || { stop_server; return; }
     check_startup_flash_ios "$SIM_UDID" "$PLAYER_BUNDLE_ID" || true
     check_soak_ios_sim "$SIM_UDID" "$PLAYER_BUNDLE_ID" || true
     check_rotation_ios_sim "$SIM_UDID" "$PLAYER_BUNDLE_ID" || true
@@ -1407,8 +1420,10 @@ run_android_emu_player() {
     ensure_ged
     start_server
 
+    # Pass ged address as intent extra so the player connects directly (no QR scan).
+    # 10.0.2.2 is the Android emulator's alias for the macOS host loopback.
     cold_launch_android_emu "$PLAYER_ANDROID_PKG" "$apk" "$FORM_FACTOR" "$PLAYER_ANDROID_ACTIVITY" \
-        || { stop_server; return; }
+        "--es ged_addr 10.0.2.2:$GED_PORT" || { stop_server; return; }
     check_startup_flash_android "$ANDROID_SERIAL" || true
     check_soak_android "$ANDROID_SERIAL" "$PLAYER_ANDROID_PKG" || true
     check_rotation_android_emu "$ANDROID_SERIAL" "$PLAYER_ANDROID_PKG" || true
@@ -1451,6 +1466,9 @@ run_android_device_player() {
     ensure_ged
     start_server
 
+    # NOTE: physical device cells do not pass ged_addr automatically — the host
+    # LAN IP is not statically known here. Pass --es ged_addr "host:port" manually
+    # or set debug.ge.address via adb setprop for ad-hoc physical device testing.
     cold_launch_android_device "$PLAYER_ANDROID_PKG" "$apk" "$FORM_FACTOR" "$PLAYER_ANDROID_ACTIVITY" \
         || { stop_server; return; }
     check_startup_flash_android "$ANDROID_SERIAL" || true
@@ -1529,7 +1547,8 @@ run_debug_player() {
             ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
             ensure_ged
             start_server
-            cold_launch_ios_sim "$PLAYER_BUNDLE_ID" "$app_path" "phone" || { stop_server; return; }
+            cold_launch_ios_sim "$PLAYER_BUNDLE_ID" "$app_path" "phone" \
+                "-ged_addr localhost:$GED_PORT" || { stop_server; return; }
             check_soak_ios_sim "$SIM_UDID" "$PLAYER_BUNDLE_ID" || true
             check_clean_exit_ios_sim "$SIM_UDID" "$PLAYER_BUNDLE_ID"
             ;;
@@ -1546,7 +1565,7 @@ run_debug_player() {
             ensure_ged
             start_server
             cold_launch_android_emu "$PLAYER_ANDROID_PKG" "$apk" "" "$PLAYER_ANDROID_ACTIVITY" \
-                || { stop_server; return; }
+                "--es ged_addr 10.0.2.2:$GED_PORT" || { stop_server; return; }
             check_soak_android "$ANDROID_SERIAL" "$PLAYER_ANDROID_PKG" || true
             check_clean_exit_android "$ANDROID_SERIAL" "$PLAYER_ANDROID_PKG"
             ;;


### PR DESCRIPTION
## Summary

- iOS player reads `-ged_addr host:port` from `NSUserDefaults` (set by `simctl launch` args or `devicectl`) as highest-priority override, before `GE_DAEMON_ADDR` env var and platform fallbacks. Key is removed after first read to prevent cross-launch persistence.
- Android `GeActivity` reads `ged_addr` intent extra and exposes it via a static JNI method; `main.cpp` retrieves it as the first priority override before the `debug.ge.address` system property and emulator auto-connect fallbacks.
- `matrix-cell.sh` passes the ged address at launch for all player cells: iOS sim gets `-ged_addr localhost:$GED_PORT`, Android emu gets `--es ged_addr 10.0.2.2:$GED_PORT`. `cold_launch_ios_sim`, `cold_launch_android_emu`, and `cold_launch_android_device` each accept an optional extra-args parameter.

## Test plan

- [x] `make cell.ios-sim-tablet-player` — 6/7 pass (cold-launch, startup-flash, soak, rotation, bg/fg, clean-exit all pass; reconnect pre-existing failure on master too, improved vs 3/7 on master)
- [x] `make cell.android-emu-phone-player` — 5/7 pass (cold-launch, soak, rotation, bg/fg, clean-exit; startup-flash/reconnect are pre-existing failures identical to master)
- [ ] Device cells (ios-device, android-device) — blocked by signing/hardware, out of scope for T23

🤖 Generated with [Claude Code](https://claude.com/claude-code)