### PR TITLE
ge: retire 🎯T22 and 🎯T23 in bullseye.yaml

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -362,10 +362,11 @@ targets:
     discovered: 2026-04-19
   T22:
     name: Debug-build matrix cells build and exercise a real debug variant, not a reused release build
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     observable: true
+    actual_cost: 5.0
     acceptance:
     - make ge/<platform>-debug (or equivalent) produces a debug binary / .app / APK distinct from the release build — assertions enabled, debug symbols retained
     - matrix-cell.sh's run_*_debug_* functions build and deploy the debug variant, not the release binary
@@ -374,12 +375,14 @@ targets:
     context: 'The six *-debug-* cells (desktop-debug-dist, desktop-debug-player, ios-debug-dist, ios-debug-player, android-debug-dist, android-debug-player) were added to the canonical 24-cell matrix for scaffolding, but their implementations in tools/matrix-cell.sh currently reuse the release build. That makes them redundant with the release cells. Real value from a debug-cycle cell comes from exercising the debug build (assertions enabled, debug symbols, BX_CONFIG_DEBUG=1) so debug-only regressions are caught by `make check` before release. Short ~10s smoke per cell is enough. Related: the Android form-factor split uses an AVD-name heuristic; a canonical tablet AVD name should be documented in Module.mk.'
     origin: manual
     discovered: 2026-04-19
+    achieved: 2026-04-19
   T23:
     name: Player accepts server connection params from the host launcher — no QR scan required for automated launches
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     observable: true
+    actual_cost: 5.0
     acceptance:
     - Android player reads a `ged_addr` intent extra (e.g. `adb shell am start -n com.squz.player/.GeActivity --es ged_addr host:port`) and connects directly, skipping QR onboarding
     - iOS player reads a `ged_addr` launch argument (`xcrun simctl launch <udid> com.squz.player -ged_addr host:port`, or equivalent for devicectl on physical devices) and connects directly
@@ -399,6 +402,7 @@ targets:
       Blocks both 🎯T21 (device-cell player smokes can't run without this) and any future automated player testing.
     origin: manual
     discovered: 2026-04-19
+    achieved: 2026-04-19
   T3:
     name: Player sends mip cache manifest before rendering begins
     status: identified


### PR DESCRIPTION
Both targets completed in PRs #17 and #16 respectively, but the
retirement state wasn't carried in either PR (bullseye_retire writes
the YAML in the main worktree, not the agent's isolated worktree).
Landing both retirements here.

🎯T22: debug matrix cells exercise real debug variant + GE_ANDROID_TABLET_AVD
🎯T23: player accepts ged_addr launch param (iOS + Android)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
