### PR TITLE
ge: file 🎯T27 — make check under 8 min via 10s soak + multi-sim parallelism

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -469,6 +469,20 @@ targets:
     origin: manual
     discovered: 2026-04-19
     achieved: 2026-04-19
+  T27:
+    name: make check completes in under 8 minutes — per-cell soak cut to 10s + multi-sim/emu parallelism
+    status: identified
+    value: 0.0
+    cost: 0.0
+    observable: true
+    acceptance:
+    - Per-cell soak sub-check runs for ~10s by default
+    - A single dedicated long-soak cell runs the 60s sweep
+    - Cells of the same platform/form-factor can run in parallel via distinct simulators/emulators when available
+    - make -j check CHECK_EXCLUDE='android-device-tablet-*' wall-clock under 8 minutes on an M4 Max with primed caches
+    context: '`make check` currently budgets ~60s soak per cell × 22 active cells ≈ 22 min of mostly-idle wall time. Total wall-clock is estimated 10-20 min. Target: under 8 min. Two levers: (1) cut per-cell soak to 10s, keep one dedicated long-soak cell for the reliability sweep; (2) multi-sim/emu parallelism — booting multiple sims concurrently (iPad Air + iPad Pro for two iOS tablet cells, Pixel 7 + Pixel 9 Pro XL for Android) lets make -j check exercise them in parallel. M4 Max has 128 GB of RAM headroom. matrix-cell.sh already takes the soak timeout as a parameter; ios_sim_get_udid / android_get_serial pick one sim per form factor and need extension to reserve specific sims per cell.'
+    origin: manual
+    discovered: 2026-04-19
   T3:
     name: Player sends mip cache manifest before rendering begins
     status: identified


### PR DESCRIPTION
Per-cell soak currently 60s; 22 cells × 60s ≈ 22 min of mostly-idle
wall time. Target: per-cell 10s soak with one dedicated long-soak
cell, plus concurrent sim/emu usage across cells of the same
platform. M4 Max has headroom for parallel sims.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
