### PR TITLE
ge v0.2.0 — Android lifecycle + dual renderer + screen-frame accel + iOS orientation lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,17 @@ The Vite dev server proxies `/api`, `/ws`, and `/mcp` to ged at `localhost:42069
 
 **iOS and Android player builds are currently broken** — they still reference Dawn/WebGPU and need to be ported to bgfx + H.264 decode. The CMakeLists files and build scripts have been scrubbed of Dawn references and marked TODO.
 
+### iOS orientation lock (iPadOS 26+)
+
+**Do not edit `Info.plist` to lock orientation on iPad. It does not work.** iPadOS 26 ignores `UISupportedInterfaceOrientations`, `UIRequiresFullScreen`, `SDL_HINT_ORIENTATIONS`, and `requestGeometryUpdate` on iPad — every app is treated as resizable for multitasking. This has been tried and failed; see commit `e0da016` ("Revert Info.plist portrait-only experiment").
+
+The **only** working mechanism is the swizzle in [`tools/player_orientation_ios.mm`](tools/player_orientation_ios.mm), which overrides `UIViewController.prefersInterfaceOrientationLocked` (Apple TN3192, the official replacement for `UIRequiresFullScreen`). Commit `5c2f2a5` introduced it; tested working on iPadOS 26.4.
+
+- **Player apps** get this for free — `wire::SessionConfig.orientation` from the server triggers `playerForceOrientation()` automatically.
+- **Direct-render apps** (`DirectRenderHost`-mode, e.g. TiltBuggy) must call `playerForceOrientation(wire::kOrientationLandscape)` themselves at startup, and link `tools/player_orientation_ios.mm` (or its stub on non-iOS) into the app bundle. `DirectRenderHost::applyHints` is the natural call site.
+
+If you find yourself editing `UISupportedInterfaceOrientations` to fix an orientation problem, stop and read this section again.
+
 ## ged Features
 
 ### MCP Server

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 SAMPLE ?= sample/tiltbuggy
 
 # Specific targets the delegator should proxy. `check` is the big one:
-# runs the 24-cell e2e matrix via the sample's Module.mk integration.
+# runs the 25-cell e2e matrix via the sample's Module.mk integration.
 .PHONY: all check matrix-test check-list unit-test init clean ged run
 
 all check matrix-test check-list unit-test clean run:

--- a/Module.mk
+++ b/Module.mk
@@ -160,12 +160,17 @@ ge/RENDER_SHADERS = \
 	$(BUILD_DIR)/ge/shaders/ge_compose_vs.bin \
 	$(BUILD_DIR)/ge/shaders/ge_compose_fs.bin
 
-# OpenGL ES 3.1 variants of the app's and ge's shaders, for Android.
-# Consumed by the Android Gradle build's syncAssets task; deposited
-# into the APK under assets/build/shaders/ at the same paths so the
-# runtime lookup via ge::resource("build/shaders/*.bin") works.
-ge/APP_SHADERS_GLES    = $(patsubst $(BUILD_DIR)/$(ge/SHADER_DIR)/%.bin,$(BUILD_DIR)/$(ge/SHADER_DIR)-gles/%.bin,$(APP_SHADERS))
-ge/RENDER_SHADERS_GLES = $(patsubst $(BUILD_DIR)/ge/shaders/%.bin,$(BUILD_DIR)/ge/shaders-gles/%.bin,$(ge/RENDER_SHADERS))
+# Android shader variants. The APK ships BOTH so the runtime can pick
+# based on the bgfx backend BgfxContext.mm chose for this device:
+#   * shaders-spirv/ — for the Vulkan backend (Apple-Silicon emulator).
+#   * shaders-gles/  — for the OpenGL ES backend (real Adreno/Mali devices).
+# Consumed by the Gradle syncAssets task; both deposited into the APK
+# under assets/build/shaders-{spirv,gles}/ and assets/build/ge/shaders-{spirv,gles}/.
+# Engine helper ge::shaderDir() returns the right suffix at runtime.
+ge/APP_SHADERS_SPIRV    = $(patsubst $(BUILD_DIR)/$(ge/SHADER_DIR)/%.bin,$(BUILD_DIR)/$(ge/SHADER_DIR)-spirv/%.bin,$(APP_SHADERS))
+ge/RENDER_SHADERS_SPIRV = $(patsubst $(BUILD_DIR)/ge/shaders/%.bin,$(BUILD_DIR)/ge/shaders-spirv/%.bin,$(ge/RENDER_SHADERS))
+ge/APP_SHADERS_GLES     = $(patsubst $(BUILD_DIR)/$(ge/SHADER_DIR)/%.bin,$(BUILD_DIR)/$(ge/SHADER_DIR)-gles/%.bin,$(APP_SHADERS))
+ge/RENDER_SHADERS_GLES  = $(patsubst $(BUILD_DIR)/ge/shaders/%.bin,$(BUILD_DIR)/ge/shaders-gles/%.bin,$(ge/RENDER_SHADERS))
 
 # Texture encoder (used by precompute tools, NOT part of libge.a)
 ge/TEXTURE_ENCODER_SRC = $(ge)/src/TextureEncoder.cpp
@@ -388,42 +393,66 @@ $(BUILD_DIR)/ge/shaders/%_fs.bin: $(ge/RENDER_SHADER_DIR)/%_fs.sc $(ge/RENDER_SH
 	    --varyingdef $(ge/RENDER_SHADER_DIR)/varying.def.sc \
 	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/RENDER_SHADER_DIR)
 
-# SPIRV variants — for the Android Vulkan backend. Output lives in
-# $(BUILD_DIR)/shaders-gles/ and $(BUILD_DIR)/ge/shaders-gles/. The
-# Android Gradle syncAssets task flattens these into assets/build/shaders/
-# so runtime lookups continue to work via ge::resource("build/shaders/...").
-#
-# NOTE: Using spirv (not 310_es or 300_es). The Android backend uses
-# bgfx's Vulkan renderer (not GLES). The Android emulator's Apple-Metal-
-# backed EGL translator only exposes GLES 3.0; requesting 3.1 triggers
-# EGL_BAD_CONFIG → bgfx fatal. Vulkan on the emulator works cleanly.
-# SPIRV shaders also bypass the glsl-optimizer, which has a known
-# vec4-constructor bug in 300_es that sets the w component to -Infinity.
-$(BUILD_DIR)/$(ge/SHADER_DIR)-gles/%_vs.bin: $(ge/SHADER_DIR)/%_vs.sc $(ge/SHADERC_VARYINGDEF) $(ge/SHADERC)
+# SPIR-V variants — for the Android Vulkan backend (Apple-Silicon AVD).
+# Output lives in $(BUILD_DIR)/shaders-spirv/ and $(BUILD_DIR)/ge/shaders-spirv/.
+# Bypasses the glsl-optimizer (known vec4-constructor bug in 300_es that
+# sets the w component to -Infinity).
+$(BUILD_DIR)/$(ge/SHADER_DIR)-spirv/%_vs.bin: $(ge/SHADER_DIR)/%_vs.sc $(ge/SHADERC_VARYINGDEF) $(ge/SHADERC)
 	@mkdir -p $(dir $@)
 	$(ge/SHADERC) -f $< -o $@ --type vertex \
 	    --platform android -p spirv \
 	    --varyingdef $(ge/SHADERC_VARYINGDEF) \
 	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/SHADER_DIR)
 
-$(BUILD_DIR)/$(ge/SHADER_DIR)-gles/%_fs.bin: $(ge/SHADER_DIR)/%_fs.sc $(ge/SHADERC_VARYINGDEF) $(ge/SHADERC)
+$(BUILD_DIR)/$(ge/SHADER_DIR)-spirv/%_fs.bin: $(ge/SHADER_DIR)/%_fs.sc $(ge/SHADERC_VARYINGDEF) $(ge/SHADERC)
 	@mkdir -p $(dir $@)
 	$(ge/SHADERC) -f $< -o $@ --type fragment \
 	    --platform android -p spirv \
 	    --varyingdef $(ge/SHADERC_VARYINGDEF) \
 	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/SHADER_DIR)
 
-$(BUILD_DIR)/ge/shaders-gles/%_vs.bin: $(ge/RENDER_SHADER_DIR)/%_vs.sc $(ge/RENDER_SHADER_DIR)/varying.def.sc $(ge/SHADERC)
+$(BUILD_DIR)/ge/shaders-spirv/%_vs.bin: $(ge/RENDER_SHADER_DIR)/%_vs.sc $(ge/RENDER_SHADER_DIR)/varying.def.sc $(ge/SHADERC)
 	@mkdir -p $(dir $@)
 	$(ge/SHADERC) -f $< -o $@ --type vertex \
 	    --platform android -p spirv \
 	    --varyingdef $(ge/RENDER_SHADER_DIR)/varying.def.sc \
 	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/RENDER_SHADER_DIR)
 
-$(BUILD_DIR)/ge/shaders-gles/%_fs.bin: $(ge/RENDER_SHADER_DIR)/%_fs.sc $(ge/RENDER_SHADER_DIR)/varying.def.sc $(ge/SHADERC)
+$(BUILD_DIR)/ge/shaders-spirv/%_fs.bin: $(ge/RENDER_SHADER_DIR)/%_fs.sc $(ge/RENDER_SHADER_DIR)/varying.def.sc $(ge/SHADERC)
 	@mkdir -p $(dir $@)
 	$(ge/SHADERC) -f $< -o $@ --type fragment \
 	    --platform android -p spirv \
+	    --varyingdef $(ge/RENDER_SHADER_DIR)/varying.def.sc \
+	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/RENDER_SHADER_DIR)
+
+# OpenGL ES 3.1 variants — for the Android GLES backend (real Adreno/Mali).
+# Output lives in $(BUILD_DIR)/shaders-gles/ and $(BUILD_DIR)/ge/shaders-gles/.
+# Profile is 310_es (not 300_es) to dodge the glsl-optimizer vec4 bug.
+$(BUILD_DIR)/$(ge/SHADER_DIR)-gles/%_vs.bin: $(ge/SHADER_DIR)/%_vs.sc $(ge/SHADERC_VARYINGDEF) $(ge/SHADERC)
+	@mkdir -p $(dir $@)
+	$(ge/SHADERC) -f $< -o $@ --type vertex \
+	    --platform android -p 310_es \
+	    --varyingdef $(ge/SHADERC_VARYINGDEF) \
+	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/SHADER_DIR)
+
+$(BUILD_DIR)/$(ge/SHADER_DIR)-gles/%_fs.bin: $(ge/SHADER_DIR)/%_fs.sc $(ge/SHADERC_VARYINGDEF) $(ge/SHADERC)
+	@mkdir -p $(dir $@)
+	$(ge/SHADERC) -f $< -o $@ --type fragment \
+	    --platform android -p 310_es \
+	    --varyingdef $(ge/SHADERC_VARYINGDEF) \
+	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/SHADER_DIR)
+
+$(BUILD_DIR)/ge/shaders-gles/%_vs.bin: $(ge/RENDER_SHADER_DIR)/%_vs.sc $(ge/RENDER_SHADER_DIR)/varying.def.sc $(ge/SHADERC)
+	@mkdir -p $(dir $@)
+	$(ge/SHADERC) -f $< -o $@ --type vertex \
+	    --platform android -p 310_es \
+	    --varyingdef $(ge/RENDER_SHADER_DIR)/varying.def.sc \
+	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/RENDER_SHADER_DIR)
+
+$(BUILD_DIR)/ge/shaders-gles/%_fs.bin: $(ge/RENDER_SHADER_DIR)/%_fs.sc $(ge/RENDER_SHADER_DIR)/varying.def.sc $(ge/SHADERC)
+	@mkdir -p $(dir $@)
+	$(ge/SHADERC) -f $< -o $@ --type fragment \
+	    --platform android -p 310_es \
 	    --varyingdef $(ge/RENDER_SHADER_DIR)/varying.def.sc \
 	    -i $(ge/SHADERC_BGFX_INCLUDE) -i $(ge/RENDER_SHADER_DIR)
 
@@ -486,7 +515,7 @@ ge/ios: $(APP_SHADERS) $(ge/RENDER_SHADERS)
 # ── Consuming app's Android build ──────────────────────────────────
 
 .PHONY: ge/android
-ge/android: $(ge/APP_SHADERS_GLES) $(ge/RENDER_SHADERS_GLES)
+ge/android: $(ge/APP_SHADERS_SPIRV) $(ge/RENDER_SHADERS_SPIRV) $(ge/APP_SHADERS_GLES) $(ge/RENDER_SHADERS_GLES)
 	@if [ ! -d android ]; then \
 	    echo "android/ not found — run 'make ge/android-init APP_ID=... APP_NAME=...' first"; \
 	    exit 1; \
@@ -714,7 +743,7 @@ ge/player-ios-device: ge/player-ios
 # Release cells use ge/android-release; debug cells use ge/android.
 
 .PHONY: ge/android-release
-ge/android-release: $(ge/APP_SHADERS_GLES) $(ge/RENDER_SHADERS_GLES)
+ge/android-release: $(ge/APP_SHADERS_SPIRV) $(ge/RENDER_SHADERS_SPIRV) $(ge/APP_SHADERS_GLES) $(ge/RENDER_SHADERS_GLES)
 	@if [ ! -d android ]; then \
 	    echo "android/ not found — run 'make ge/android-init APP_ID=... APP_NAME=...' first"; \
 	    exit 1; \

--- a/Module.mk
+++ b/Module.mk
@@ -748,9 +748,26 @@ GE_ANDROID_TABLET_AVD ?= Pixel_Tablet
 GE_IOS_TABLET_DEVICE ?= Pippa
 GE_IOS_PHONE_DEVICE ?=
 
-# Canonical 24-cell list. Cells are grouped for readability.
+# Per-cell iOS simulator UDID pins for parallelism.
+# When set, matrix-cell.sh uses the specified simulator directly instead of
+# auto-selecting, allowing two cells of the same form factor to run concurrently
+# on distinct simulators under `make -j check`.
+# Override with e.g.: make check GE_IOS_SIM_PHONE_UDID=<UDID> GE_IOS_SIM_TABLET_UDID=<UDID>
+GE_IOS_SIM_PHONE_UDID  ?=
+GE_IOS_SIM_TABLET_UDID ?=
+
+# Per-cell Android emulator serial pins for parallelism.
+# When set, matrix-cell.sh targets the given emulator serial instead of
+# auto-selecting, allowing phone and tablet cells to run concurrently.
+# Override with e.g.: make check GE_ANDROID_EMU_PHONE_SERIAL=emulator-5554 GE_ANDROID_EMU_TABLET_SERIAL=emulator-5556
+GE_ANDROID_EMU_PHONE_SERIAL  ?=
+GE_ANDROID_EMU_TABLET_SERIAL ?=
+
+# Canonical 25-cell list. Cells are grouped for readability.
+# desktop-long-soak is the dedicated 60s reliability sweep; all other cells
+# use the default 10s soak for speed.
 ge/CELLS := \
-    desktop-dist desktop-player \
+    desktop-dist desktop-player desktop-long-soak \
     ios-sim-phone-dist ios-sim-phone-player \
     ios-sim-tablet-dist ios-sim-tablet-player \
     ios-device-phone-dist ios-device-phone-player \
@@ -775,18 +792,19 @@ ge/CHECK_CELLS := $(filter-out $(ge/CHECK_EXCLUDE_PATTERNS),$(ge/CELLS))
 .PHONY: $(addprefix cell.,$(ge/CELLS))
 cell.desktop-dist:               ; $(ge)/tools/matrix-cell.sh desktop-dist
 cell.desktop-player:             ; $(ge)/tools/matrix-cell.sh desktop-player
-cell.ios-sim-phone-dist:         ; $(ge)/tools/matrix-cell.sh ios-sim-phone-dist
-cell.ios-sim-phone-player:       ; $(ge)/tools/matrix-cell.sh ios-sim-phone-player
-cell.ios-sim-tablet-dist:        ; $(ge)/tools/matrix-cell.sh ios-sim-tablet-dist
-cell.ios-sim-tablet-player:      ; $(ge)/tools/matrix-cell.sh ios-sim-tablet-player
+cell.desktop-long-soak:          ; $(ge)/tools/matrix-cell.sh desktop-long-soak
+cell.ios-sim-phone-dist:         ; GE_IOS_SIM_UDID=$(GE_IOS_SIM_PHONE_UDID) $(ge)/tools/matrix-cell.sh ios-sim-phone-dist
+cell.ios-sim-phone-player:       ; GE_IOS_SIM_UDID=$(GE_IOS_SIM_PHONE_UDID) $(ge)/tools/matrix-cell.sh ios-sim-phone-player
+cell.ios-sim-tablet-dist:        ; GE_IOS_SIM_UDID=$(GE_IOS_SIM_TABLET_UDID) $(ge)/tools/matrix-cell.sh ios-sim-tablet-dist
+cell.ios-sim-tablet-player:      ; GE_IOS_SIM_UDID=$(GE_IOS_SIM_TABLET_UDID) $(ge)/tools/matrix-cell.sh ios-sim-tablet-player
 cell.ios-device-phone-dist:      ; GE_IOS_PHONE_DEVICE=$(GE_IOS_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-phone-dist
 cell.ios-device-phone-player:    ; GE_IOS_PHONE_DEVICE=$(GE_IOS_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-phone-player
 cell.ios-device-tablet-dist:     ; GE_IOS_TABLET_DEVICE=$(GE_IOS_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-tablet-dist
 cell.ios-device-tablet-player:   ; GE_IOS_TABLET_DEVICE=$(GE_IOS_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-tablet-player
-cell.android-emu-phone-dist:     ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) $(ge)/tools/matrix-cell.sh android-emu-phone-dist
-cell.android-emu-phone-player:   ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) $(ge)/tools/matrix-cell.sh android-emu-phone-player
-cell.android-emu-tablet-dist:    ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) $(ge)/tools/matrix-cell.sh android-emu-tablet-dist
-cell.android-emu-tablet-player:  ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) $(ge)/tools/matrix-cell.sh android-emu-tablet-player
+cell.android-emu-phone-dist:     ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) GE_ANDROID_EMU_SERIAL=$(GE_ANDROID_EMU_PHONE_SERIAL) $(ge)/tools/matrix-cell.sh android-emu-phone-dist
+cell.android-emu-phone-player:   ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) GE_ANDROID_EMU_SERIAL=$(GE_ANDROID_EMU_PHONE_SERIAL) $(ge)/tools/matrix-cell.sh android-emu-phone-player
+cell.android-emu-tablet-dist:    ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) GE_ANDROID_EMU_SERIAL=$(GE_ANDROID_EMU_TABLET_SERIAL) $(ge)/tools/matrix-cell.sh android-emu-tablet-dist
+cell.android-emu-tablet-player:  ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) GE_ANDROID_EMU_SERIAL=$(GE_ANDROID_EMU_TABLET_SERIAL) $(ge)/tools/matrix-cell.sh android-emu-tablet-player
 cell.android-device-phone-dist:  ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) $(ge)/tools/matrix-cell.sh android-device-phone-dist
 cell.android-device-phone-player: ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) $(ge)/tools/matrix-cell.sh android-device-phone-player
 cell.android-device-tablet-dist: ; GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) $(ge)/tools/matrix-cell.sh android-device-tablet-dist

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -556,10 +556,11 @@ targets:
     discovered: 2026-04-19
   T28:
     name: AccelSynth (Shift-mouse) works in every host context lacking a real accelerometer
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     showcase: true
+    demonstration: 'TiltBuggy distribution build on iOS Simulator (T28.3) demonstrated Shift-drag mouse tilt driving the buggy via screen recording. macOS desktop distribution (T28.1, T28.2 family) verified earlier in the same lineage. T28.4 (Android emu) was deliberately set aside on 2026-05-02: the AVD''s built-in virtual sensors (Extended Controls → Virtual sensors) supersede AccelSynth''s Shift+drag path on emu, so Android-emu tilt input flows through the regular real-sensor pipeline rather than the synth. With three of four sub-targets achieved and the fourth covered by an alternative mechanism, T28''s user-visible outcome — "tilt-driven gameplay works in every host context lacking a real accelerometer" — is satisfied.'
     acceptance:
     - In a tilt-driven sample app (e.g. tiltbuggy) built as distribution (in-process DirectRenderHost, no ged/player), Shift-drag of the mouse tilts the viewport and drives gameplay identically to the player binary's behaviour
     - 'Works on: macOS desktop distribution build, iOS simulator distribution build, Android emulator distribution build'
@@ -568,6 +569,7 @@ targets:
     context: AccelSynth (src/render/AccelSynth.h) synthesises SDL_EVENT_SENSOR_UPDATE from Shift-gated mouse motion. It is wired into PlayerRender (player binary) where it works, and constructed by DirectRenderHost (distribution modality) but not fully driven — events are not routed through synth->handle() in pumpEvents, update() per frame is not called, and the viewport tilt composite is not driven by synth tilt. Supersedes 🎯T12 (⌥WASD uniform synthesis) and 🎯T13 (⌥-gated mouse) — both described an earlier design abandoned in favour of AccelSynth's single-file Shift-mouse model.
     origin: user request 2026-04-19
     discovered: 2026-04-19
+    achieved: 2026-05-02
   T28.1:
     name: DirectRenderHost routes events through AccelSynth::handle() and drives update() per frame
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 3
 targets:
   T1:
     name: Game servers can run inside the player via WebAssembly
@@ -27,7 +27,7 @@ targets:
     discovered: 2026-04-12
   T10:
     name: ge has a sample app that exercises engine features
-    status: identified
+    status: achieved
     value: 8.0
     cost: 5.0
     acceptance:
@@ -44,108 +44,178 @@ targets:
       It also serves as the canonical integration test for the server/player architecture. Early candidate: a TiltBuggy port — tilt-controlled car with Box2D physics. References the 2013 Chipmunk prototype at ~/work/mirrors/marcelo-mbpr/work/TiltBuggy.
     origin: user request
     discovered: 2026-04-15
+    achieved: 2026-04-26
   T11:
-    name: ged uses pigeon for all networking between server, player, and daemon
-    status: identified
+    name: ge's player↔server transport runs on pigeon (E2E-encrypted relay) instead of plain WebSocket through ged
+    status: set_aside
     value: 13.0
     cost: 20.0
+    set_aside_reason: Deferred while pigeon's redesign is in flight (longer than the original 1-2 day estimate). Player↔server transport on pigeon is the right architecture but pigeon isn't ready and ge's current focus is the demo-on-every-non-player-platform/sim/emu/device path, which doesn't depend on pigeon. Re-activate when pigeon's redesign lands.
     acceptance:
-    - No WebSocket code remains in ged or ge client code (coder/websocket removed from go.mod, Asio WS framing removed from WebSocketClient.cpp)
-    - Server↔ged and player↔ged connections use pigeon streams
-    - H.264 video frames flow over pigeon (streams or datagrams)
-    - Input events flow back from player to server over pigeon
-    - Dashboard sideband (logs, preview, tweaks) works over pigeon
-    - LAN mode works without a relay when server and player are colocated
-    - Existing ge::run() API contract unchanged — apps don't need modification
-    context: Replace ged's hand-rolled WebSocket stack (coder/websocket in Go, Asio TCP+WS framing in C++) with pigeon (github.com/marcelocantos/pigeon). Pigeon provides QUIC/WebTransport relay with E2E encryption, LAN upgrade, and native SDKs for Go, Swift, and Kotlin — eliminating the need for ged to be on the same LAN, enabling mobile players to connect over the internet, and removing the custom WebSocket framing code.
+    - The player connects to the game server via pigeon's relay (Register/Connect or LAN bypass) — not via a WebSocket through ged. Wire framing is pigeon's stream + datagram protocol; payloads are ciphertext at the relay layer. ged's role is reduced to (a) issuing PairingArtifacts via pigeon.PairingHost so newly-installed players can establish first-contact with a server, and (b) the dashboard. ged is no longer on the runtime data path between server and player.
+    - All session traffic is end-to-end encrypted via pigeon's X25519 ECDH + AES-256-GCM channel. Neither ged nor the relay can read plaintext. The QR scan that today carries a server name + port now carries a pigeon PairingArtifact (base64url) — one-time-use, TTL-bound (default 30 days), persistable on the player so reconnects skip the ceremony.
+    - H.264 video frames flow over pigeon datagram channels (with pigeon's automatic fragmentation and reassembly), not the reliable stream. Keyframes optionally promoted to streams if measured packet loss makes pure-datagram delivery insufficient. Input events flow over reliable streams.
+    - Multiple players can attach to the same server via pigeon's per-instance fan-out (one Register on the server side, multiple Connects from players, each with an independent encrypted channel). Replaces ged's current per-session WebSocket multiplexing.
+    - 'LAN bypass is enabled: when player and server are on the same Wi-Fi, pigeon''s LANServer is used and the relay round-trip is skipped. Falls back to relay automatically on LAN failure or NAT crossing. Visible in logs and ideally via a player UI indicator.'
+    - ge/include/ge/Protocol.h's hand-rolled magic-number constants and MessageHeader struct are replaced by a pigeon protocol/ YAML declaration that generates Go (server-side / ged), Swift (iOS player), Kotlin (Android player), and C (mobile bgfx-direct player) bindings. No more parallel definitions of kVideoStreamMagic / kSdlEventMagic etc. across files.
+    - All WebSocket plumbing — ge/src/bridge/WebSocketClient.cpp, ge/src/bridge/PlayerWireBridge.cpp, ge/src/bridge/SessionHost_brokered.mm's WS code path, ged's gorilla/websocket dependency — is removed once every consumer (server, player, ged dashboard) has cut over.
+    - 'End-to-end test: a fresh player install scans a QR (or imports a PairingArtifact), connects to a server (via relay or LAN), receives video, sends input, disconnects, reconnects later (within TTL) without rescanning. Reproducible via ge''s matrix-cell.sh on at least one mobile platform.'
+    context: 'Rewritten 2026-04-26. The original T11 (''ged uses pigeon for all networking between server, player, and daemon'') and its sub-targets imagined pigeon as a daemon-style backend that ged would register against. Pigeon-as-it-actually-exists at v0.20.0 is structurally different: it''s an importable library across Go / Swift / Kotlin / C / TypeScript that does relay + E2E crypto + pairing + a runtime channel API as a single integrated story. Applications import pigeon as a library and call pigeon.Register / pigeon.Connect; the abstraction is at the runtime layer — point-to-point reliable streams and unreliable datagrams over E2E-encrypted, possibly-relayed QUIC. Applications speak their own wire protocols over those channels as opaque bytes; pigeon doesn''t care what the bytes are.\n\nKey shifts in pigeon''s surface that motivate the rewrite:\n- pigeon.Register() / pigeon.Connect() are application-level calls. The relay (cmd/pigeon, deployable as carrier-pigeon.fly.dev) is just QUIC bridging — it doesn''t know about ged at all. ged''s role under the new model is reduced to pairing-artifact issuance + dashboard, off the runtime data path.\n- E2E encryption is built in: X25519 ECDH + AES-256-GCM with monotonic-counter nonces. Neither relay nor any intermediary sees plaintext. Solves a security gap ge currently doesn''t address (today it relies on WebSocket TLS to a trusted ged).\n- PairingArtifact (v0.19.0) is a persistable, expirable envelope around a pairing record. Wire format is snake_case JSON / base64url text, portable across all SDKs. Player paired once can reconnect later within TTL without redoing the ceremony.\n- pigeon.PairingHost is the server-side artifact minter. The ''pigeon pair'' CLI subcommand exposes the same.\n- Reliable streams + unreliable datagrams in one channel. Datagrams have automatic fragmentation/reassembly with a 5-second discard window for incomplete sets. Video frames belong on datagrams; input events on streams.\n- LAN bypass: pigeon.Config.LANServer enables direct peer-to-peer when on the same network, falls back to relay otherwise. Saves the relay round-trip in the common ''phone+laptop'' scenario.\n- Multiple clients per instance ID. The relay maintains independent bridges per client. One server can fan out to N players without doing the multiplexing itself.\n- C library (dist/pigeon.h + libsodium + ngtcp2 transport) means iOS/Android player binaries can speak pigeon natively without a Go runtime — important for ge''s bgfx-direct mobile players that currently have no networking at all on the direct path.\n\nNote on internal pigeon machinery: pigeon implements its own protocol layer (pairing ceremony, session lifecycle, path switching) using a YAML-declared state-machine framework with a code generator (cmd/protogen). This is internal infrastructure, NOT a public codegen surface for pigeon consumers. ge''s own wire-protocol codegen needs are independent and tracked separately under 🎯T11.1, which is now tool-agnostic (protobuf / FlatBuffers / Cap''n Proto / bespoke — to be decided at implementation time).\n\nged''s role under the new model:\n- Pairing-artifact issuer: ged''s web dashboard mints a PairingArtifact via pigeon.PairingHost, presents it as a QR, and the player imports. Replaces today''s name+port QR.\n- Optional management dashboard. Today ged is on the runtime data path; under the new model it''s just the pairing/discovery service — once player and server are paired, all traffic flows directly through pigeon, ged is not needed at runtime.\n\nReadiness considerations:\n- pigeon v0.20.0 just shipped; not 1.0 eligible until 2026-06-25 minimum (settling clock reset by v0.19.0''s Swift PairingRecord JSON wire format change). PairingArtifact API is ''Needs Review'' — wants real-world consumer feedback before freezing. ge would be an ideal first consumer, with the caveat that the surface may shift slightly before 1.0.\n- pigeon''s TypeScript/web pairing-artifact parity is explicitly out of scope until web stabilises — relevant if the ge dashboard wants to embed pigeon-pairable web players. Defer that until pigeon ships it.\n- The C library is Fluid — stabilisation depends on real consumer feedback. ge mobile is again an ideal first consumer.\n\nDecomposition (sub-targets T11.1–T11.6) is rewritten to match this model.'
+    tags:
+    - pigeon
+    - transport
+    - encryption
+    - pairing
+    - wire-protocol
+    - architecture
     origin: user request
     discovered: 2026-04-12
   T11.1:
-    name: pigeon is vendored as a Go dependency in ged
-    status: identified
+    name: ge's wire protocol has a single source of truth — magic numbers and message structs are generated for Go (ged), C / C++ (engine + Apple .mm), Kotlin / Java (Android), and Swift (iOS) instead of hand-rolled in parallel
+    status: set_aside
     value: 3.0
     cost: 2.0
+    set_aside_reason: Deferred. The wire protocol's single-source-of-truth codegen only matters for player/server interaction, which is itself deferred while pigeon's redesign is in flight. Re-activate when player work resumes.
     acceptance:
-    - go.mod has pigeon dependency with replace directive pointing to local checkout
-    - go build succeeds
-    context: Add github.com/marcelocantos/pigeon to ged's go.mod. ged lives at ge/ged/ with its own go.mod. Pigeon is at ../../marcelocantos/pigeon — use a replace directive for local dev.
+    - 'A single canonical declaration of ge''s wire protocol exists in the repo — file format and tool choice are open (candidates: protobuf with `protoc`, FlatBuffers with `flatc`, Cap''n Proto, a small bespoke YAML+templated generator, or a hand-written C/C++ header authored as the source of truth and exported to other languages by tooling). The declaration covers every message currently defined in include/ge/Protocol.h: DeviceInfo, SafeAreaUpdate, AspectLock, MessageHeader, plus the eleven magic-number constants (kVideoStreamMagic, kSdlEventMagic, kSessionEndMagic, kStreamStartMagic, kStreamStopMagic, kServerAssignedMagic, kSafeAreaMagic, kAspectLockMagic, kSqlpipeMsgMagic, kDeviceInfoMagic, kProtocolVersion).'
+    - A make-rule (or equivalent) regenerates language bindings from the canonical source. ge's build wires it as a normal codegen step; CI fails if the generated outputs are out of sync with the source.
+    - 'Generated outputs land in a discoverable location per language, replacing the parallel hand-rolled equivalents: Go bindings under ged''s module (e.g. internal/wire); C / C++ headers consumed by the engine and Apple .mm files; Kotlin or Java for the Android player; Swift for the iOS player and any sample iOS apps that link the wire surface.'
+    - 'include/ge/Protocol.h is deleted (or trimmed to a thin compatibility shim that just includes the generated header). Every existing #include or import of Protocol.h''s constants and structs across ge/src/bridge/, ge/src/render/, ged''s Go code, and consumer projects (multimaze2, sample/tiltbuggy where applicable) is replaced with the generated equivalent.'
+    - 'Adding a new message becomes a one-place change: edit the canonical declaration, regenerate, the new constant + struct appears in every binding. No more searching for parallel definitions across .mm files, Go code, and Protocol.h.'
+    - The choice of codegen tool is documented (in CLAUDE.md or a dedicated docs page) along with the rationale and the wire-format compatibility commitment — once chosen and shipped, the tool and the on-the-wire byte layout are stable contract.
+    context: 'Rewritten 2026-04-26 after the original framing turned out to rest on a misreading of pigeon''s design. The original T11.1 (''declare in pigeon-protocol YAML; bindings generated via cmd/protogen'') was filed assuming pigeon''s protogen was a public codegen surface for consumers. It isn''t — protogen is internal pigeon infrastructure for generating pigeon''s own pairing/session/pathswitch state-machine code. The abstraction pigeon offers third-party users is at the runtime layer (Conn, StreamChannel, DatagramChannel for streams and datagrams); applications speak their own wire protocols over those channels as opaque bytes.\n\nge''s actual problem is real: the same eleven magic numbers and four message structs are hand-defined in parallel across include/ge/Protocol.h (C/C++), ge/src/bridge/PlayerWireBridge.cpp / SessionHost_brokered.mm / ServerWireBridge.mm (Apple platforms), ged''s Go code (server side), and any client SDKs (Android, iOS, web dashboard). Adding a new message requires edits in every place; drift is silent until something breaks at runtime.\n\nWhat T11.1 is NOT: a particular tool choice. The original framing baked ''pigeon protogen'' into the target name, which forced the wrong shape on the work. The rewrite leaves the codegen-tool choice open. Reasonable candidates worth considering during implementation:\n\n- Protocol Buffers (protoc): mature, multi-language, well-documented wire format, tooling on every platform. Adds a dependency but a well-understood one.\n- FlatBuffers: zero-copy reads, smaller runtime, similar codegen story. Used in some game engines.\n- Cap''n Proto: similar tradeoffs to FlatBuffers, less common.\n- Bespoke YAML + small generator script: minimal external dep, full control over wire format. Most work to maintain but can match ge''s existing on-the-wire byte layout exactly (8-byte sequence number, 16-byte AES-GCM tag etc. in MessageHeader).\n- Hand-written C/C++ header as source of truth + small extractor scripts to emit Swift / Kotlin / Go from it. Closest to the status quo; cheapest to bootstrap.\n\nTradeoff to be settled at implementation time:\n- Do we change ge''s on-the-wire byte layout to match whatever the codegen tool produces, or keep the current layout exactly and shape the tool around it? Latter is more work but keeps the wire format stable for any external consumer that''s already speaking it.\n\nRelation to 🎯T11 parent: T11 is the migration of ge''s transport from WebSocket to pigeon. T11.1 (this) is the source-of-truth-for-message-shape work. They''re related but independent in tooling — T11.1 doesn''t require T11, and T11 doesn''t require T11.1. If T11.1 happens first, T11 picks up the cleaner Protocol bindings as a bonus; if T11 happens first, T11.1 still has the same parallel-definitions problem to solve.\n\nNote: ge PR #45 (now closed) made a partial start on this with pigeon-protogen YAML and committed the codegen outputs. The closure removes those artefacts; this target starts fresh with no commitment to which tool replaces them.'
+    depends_on:
+    - T11
+    tags:
+    - wire-protocol
+    - codegen
+    - protocol-h
+    - single-source-of-truth
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.2:
-    name: ged registers as a pigeon backend and accepts client connections
-    status: identified
+    name: First-contact between player and server uses pigeon's PairingArtifact (QR scan delivers the artifact; player persists it for reconnect)
+    status: set_aside
     value: 8.0
     cost: 5.0
+    set_aside_reason: Deferred while pigeon's redesign is in flight. PairingArtifact is pigeon-specific; can't proceed until pigeon ships its redesign.
     acceptance:
-    - ged starts a pigeon LANServer and logs its instance ID
-    - A pigeon client can connect to ged's instance ID
-    - ged distinguishes game vs player connections via initial message
-    context: ged calls pigeon.Register() on startup (LAN mode, no relay). Games and players connect via pigeon.Connect(). ged accepts connections and identifies them as game or player based on the initial handshake message. This replaces the WebSocket Accept on /ws/server and /ws/wire. The HTTP server (dashboard, REST API, MCP) stays on the existing port unchanged.
+    - ged's web dashboard mints a PairingArtifact via pigeon.PairingHost.Mint() for each newly-launched server (server-side PairingRecord stored in ged's state). The QR code displayed by the dashboard now encodes the artifact (base64url text, ~few hundred bytes), not a name+port pair.
+    - Player on first launch scans the QR, parses the PairingArtifact, calls pigeon.ConnectWithArtifact(), and is now in an E2E-encrypted session with the server.
+    - Player persists the PairingArtifact via pigeon's CredentialStore (FileCredentialStore on desktop; platform-appropriate equivalent on iOS Keychain / Android Keystore on mobile). On subsequent launches, the player loads the stored artifact and reconnects without re-scanning — unless the artifact is expired (default 30-day TTL) or the user explicitly re-pairs.
+    - Player surfaces the 6-digit confirmation code from pigeon's pairing ceremony during first-contact (and only first-contact). User compares it visually to the code shown by the dashboard and confirms or rejects. MitM attempts are caught by code mismatch.
+    - Server-side PairingRecord storage in ged survives ged restarts — paired players continue to reconnect after the daemon process bounces.
+    context: 'Replaces the previous T11.2 (''ged registers as a pigeon backend and accepts client connections''). ged isn''t a pigeon backend; pigeon backends are individual servers. ged''s role under the new model is pairing-artifact issuer, not relay endpoint.\n\nBenefits over the current ''QR carries name+port'' model:\n- Persistent across reconnects: today the player has to re-scan a QR (or rely on cached config) every time the server restarts. PairingArtifact + CredentialStore makes re-pair a one-time event.\n- MitM resistance: today a malicious actor on the same network could MitM the WebSocket. The 6-digit confirmation code rules this out.\n- Cross-platform pairing wire format: snake_case JSON / base64url text matches Go/Swift/Kotlin SDKs, so an artifact minted on the server can be read by any player.\n\nNotably, this target is technically achievable BEFORE the rest of T11 — the artifact-driven pairing can be deployed under today''s WebSocket transport as a first step (use the artifact''s pairing record to derive a key for WS-payload encryption), then the underlying transport gets swapped to pigeon in T11.3+. Allows incremental cutover instead of a big bang.'
     depends_on:
-    - T11.1
+    - T11
+    tags:
+    - pigeon
+    - pairing
+    - PairingArtifact
+    - qr
+    - e2e-crypto
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.3:
-    name: Game server sideband uses pigeon channel instead of WebSocket
-    status: identified
+    name: 'Server↔player runtime traffic flows over pigeon channels: video on datagrams, input/control on reliable streams'
+    status: set_aside
     value: 5.0
     cost: 5.0
+    set_aside_reason: Deferred while pigeon's redesign is in flight. Datagram channels are pigeon-specific.
     acceptance:
-    - Game server connects to ged via pigeon and opens a sideband channel
-    - JSON control messages flow over the pigeon channel
-    - No /ws/server WebSocket endpoint remains
-    context: 'Replace the game server''s /ws/server WebSocket connection with a pigeon channel. The sideband carries JSON control messages: hello, log, preview, accel, tweaks, player_attached, player_detached. Game connects to ged via pigeon.Connect(), opens a sideband channel. ged side: replace handleServerSideband WebSocket handler with pigeon channel accept. C++ side: replace WebSocketClient.cpp Asio+TCP WS framing with pigeon (needs a C/C++ wrapper or cgo bridge).'
+    - The H.264 NAL-unit stream from server to player rides on a pigeon DatagramChannel. Pigeon's automatic fragmentation handles NAL units larger than the QUIC datagram MTU; the 5-second incomplete-set discard window is acceptable because lost frames are recoverable via the next keyframe.
+    - Input events (SdlEvent, SafeAreaUpdate) from player to server ride on a pigeon reliable StreamChannel. Loss of an input event is unacceptable; reliable framing matches.
+    - Control messages (SessionConfig, StreamStart/Stop, ServerAssigned, SessionEnd, AspectLock) ride on a separate reliable StreamChannel. Control isolation prevents head-of-line blocking from queued video frames or input bursts.
+    - Each channel uses an independently-keyed pigeon Channel (HKDF-derived from the pairing record's shared secret with channel-specific info strings). Different channels can't decrypt each other's messages even if a shared key were leaked.
+    - Measured throughput meets or exceeds today's WebSocket-based path on a controlled local network. End-to-end frame latency is comparable; tail latency improves under packet loss because video doesn't wait for retransmits.
+    context: 'Replaces the previous T11.3 + T11.4 (''Game server sideband uses pigeon channel instead of WebSocket'' + ''Per-session wire uses pigeon channel instead of WebSocket''). The old framing assumed two parallel WebSocket-equivalent channels; pigeon''s reliable+unreliable model is a better fit and lets us split video off the reliable path entirely.\n\nMaps directly onto pigeon''s channel API: OpenChannel() for reliable, DatagramChannel() for unreliable. Each channel gets its own keys via PairingRecord.DeriveChannel(sendInfo, recvInfo).\n\nThe video-on-datagrams decision is the headline win: today''s WebSocket path waits for retransmits even on lost video frames, which is wasted because we''re going to send another frame imminently anyway. Datagrams let dropped video frames just fall through, while keyframes act as natural resync points.\n\nLow-priority follow-up worth noting: if measurement shows datagrams alone are insufficient under high loss (say, >5% sustained), the design can fall back to streaming keyframes specifically, rather than abandoning the datagram path. Don''t optimise for that until we measure it.'
     depends_on:
+    - T11.1
     - T11.2
+    tags:
+    - pigeon
+    - transport
+    - datagram
+    - video
+    - channel
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.4:
-    name: Per-session wire uses pigeon channel instead of WebSocket
-    status: identified
+    name: LAN-co-located peers bypass the relay via pigeon's LAN server; falls back automatically when the network changes
+    status: set_aside
     value: 8.0
     cost: 5.0
+    set_aside_reason: Deferred while pigeon's redesign is in flight. LAN bypass is a pigeon-side feature.
     acceptance:
-    - H.264 frames flow over pigeon channel from game to ged
-    - Input events flow over pigeon channel from ged to game
-    - No /ws/server/wire/{sessionID} endpoint remains
-    context: Replace /ws/server/wire/{sessionID} with a pigeon channel per session. When ged tells a game server "player attached", the game opens a new pigeon channel for that session's wire traffic (H.264 frames server→ged, input events ged→server). ged bridges this to the player's pigeon channel.
+    - When player and server detect they're on the same Wi-Fi (or wired LAN), pigeon's LAN bypass kicks in via pigeon.Config.LANServer + LAN-IP discovery. Traffic goes peer-to-peer over QUIC, the relay sees only the initial introduction handshake.
+    - 'Player surfaces the connection mode in its UI (or at least logs it): ''connected via LAN'' vs ''connected via relay''. Useful for debugging and for users to understand performance characteristics.'
+    - When the LAN connection drops (peer leaves the network, Wi-Fi switches, etc.), pigeon's automatic FallbackToRelay() restores connectivity over the relay without dropping the session. Visible in logs; not user-visible if seamless.
+    - Latency on LAN is measurably lower than via the relay (relay adds the round-trip to carrier-pigeon.fly.dev). Confirm with a basic measurement on at least one platform.
+    - The transition relay→LAN→relay survives an active video stream without visible glitches — pigeon handles the underlying reconnect transparently to ge's application layer.
+    context: 'Net-new sub-target. The original T11 family didn''t have LAN-bypass; pigeon''s LAN-server feature only landed later. Highly relevant to ge''s most-common use case: phone-as-player + laptop-as-server on the same Wi-Fi at home or in a meeting room.\n\nThe relay round-trip to carrier-pigeon.fly.dev (presumably us-west or similar) adds 50–200 ms depending on the user''s location. Eliminating it for the LAN-co-located case is a meaningful UX improvement, especially for input latency in interactive games.\n\nTechnically pigeon does most of the work; ge''s job is mostly to enable LAN mode in pigeon.Config and to surface the resulting state in the player UI / logs.'
     depends_on:
     - T11.3
+    tags:
+    - pigeon
+    - lan
+    - latency
+    - transport
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.5:
-    name: Player connects to ged via pigeon instead of WebSocket
-    status: identified
+    name: Mobile players (bgfx-direct iOS + Android distribution builds) speak pigeon natively via the C library, with no Go runtime
+    status: set_aside
     value: 8.0
     cost: 5.0
+    set_aside_reason: Deferred while pigeon's redesign is in flight. Pigeon's C library is the pigeon-side runtime that ge mobile would link.
     acceptance:
-    - Desktop player connects to ged via pigeon
-    - H.264 frames arrive at player over pigeon
-    - Input events flow from player to ged over pigeon
-    - No /ws/wire WebSocket endpoint remains
-    context: Replace /ws/wire player WebSocket with pigeon. Player connects via pigeon's C API (pigeon_connect), sends DeviceInfo, receives H.264 stream, sends input events back. Desktop player (tools/player.cpp) links libpigeon. ged bridges the player's pigeon channel to the game's wire channel. Same C API available for game server side (SessionHost.mm), eliminating WebSocketClient.cpp entirely.
+    - The bgfx-direct iOS and Android distribution players link pigeon's C library (dist/pigeon.h + dist/pigeon.c) plus libsodium and ngtcp2 (vendored as submodules under ge/vendor/github.com/<org>/, per CLAUDE.md). No Go runtime is shipped to the device.
+    - 'The mobile player can connect to a server via a stored PairingArtifact and run a session end-to-end: receive video, send input, decode, render. Functional parity with the desktop player on the same server.'
+    - Pigeon's C library generates the same wire-protocol bindings (T11.1) and the same pairing-ceremony state machine (T11.2) that the Swift/Kotlin/Go SDKs use, via pigeon's protocol/ codegen. No hand-translated state machines on the C side.
+    - ge/CMakeLists.txt's Android branch and the iOS xcframework story include pigeon's C library + libsodium + ngtcp2 as transitive deps of `ge`. Consumer apps still consume ge via add_subdirectory(ge) (T30 principle) — pigeon is one more thing they get for free.
+    - 'Apk / ipa size impact is acceptable: libsodium (~200KB), ngtcp2 (~500KB), pigeon (~100KB), generated state machines (~50KB) — about 1MB additional vs the current direct-mode build. Confirm with a measurement; reject the design if it''s more than ~3MB.'
+    context: 'Net-new sub-target. The original T11 family assumed the player would always have access to a Go runtime (via gomobile or similar). The pigeon C library makes it possible to ship a fully-native mobile player with no Go.\n\nWhy this matters for ge:\n- Today''s bgfx-direct mobile players (sample/tiltbuggy/android, sample/tiltbuggy/ios) have NO networking. They render locally only. There''s currently no path to add multiplayer / streaming to a direct-mode mobile build without either (a) shipping a Go runtime via gomobile (~10MB+) or (b) writing a custom networking layer per platform.\n- pigeon''s C library is the missing piece that lets ge''s direct-mode mobile builds participate in a pigeon session as a client. Server-side pigeon would still be Go (where the H.264 encoder lives anyway), but the player is C — small footprint, no GC pauses, no cross-language FFI.\n- The C library is currently ''Fluid'' per pigeon''s STABILITY.md — stabilisation depends on real consumer feedback. ge mobile would be an ideal first consumer and would help drive pigeon''s C surface to stable.\n\nTransport stack on the C side: ngtcp2 for QUIC, libsodium for crypto primitives, pigeon''s C glue on top. Both deps are vendored per CLAUDE.md (substantial libraries get git submodules under vendor/github.com/<org>/<repo>).'
     depends_on:
-    - T11.4
+    - T11.1
+    - T11.2
+    - T11.3
+    tags:
+    - pigeon
+    - c-library
+    - ios
+    - android
+    - direct-mode
+    - mobile
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.6:
-    name: WebSocket code removed from ged and ge client
-    status: identified
+    name: All WebSocket plumbing is removed from ge and ged once every consumer has cut over to pigeon
+    status: set_aside
     value: 3.0
     cost: 3.0
+    set_aside_reason: Deferred. Cleanup tail of the WebSocket→pigeon migration; can't happen until T11.3/T11.4/T11.5 land, which are themselves deferred until pigeon's redesign lands.
     acceptance:
-    - coder/websocket removed from go.mod
-    - WebSocketClient.cpp deleted or gutted
-    - No /ws/server or /ws/wire routes in ged
-    - Dashboard /ws/logs, /ws/preview, /ws/stream still work
-    context: 'Final cleanup: remove coder/websocket from go.mod, remove WebSocketClient.cpp and Asio WS framing, remove all /ws/* route registrations (except dashboard WS endpoints which stay as-is). Dashboard WebSocket endpoints (/ws/logs, /ws/preview, /ws/stream) remain — they serve the browser and don''t need pigeon.'
+    - ge/src/bridge/WebSocketClient.cpp and the matching WebSocketClient.h are deleted. No remaining call sites in ge.
+    - PlayerWireBridge.cpp's WebSocket-specific code paths are deleted (the class itself may still exist as a thin wrapper around pigeon, or be replaced entirely — author's discretion).
+    - SessionHost_brokered.mm's WebSocket code path is replaced by pigeon channel calls. The class either retains its name as a pigeon wrapper or is renamed; either is fine.
+    - ged's gorilla/websocket dependency is removed from go.mod. The dashboard's WS endpoints (/ws/wire) are deleted; the dashboard still exists as the pairing-artifact issuer + management UI, just without WebSocket plumbing.
+    - The 'Wire format' / 'Steady-State Messages' section in ge/CLAUDE.md is rewritten to document the pigeon-channel layout instead of WebSocket framing. The per-message magic-number table is replaced by a pointer to the protocol YAML.
+    - ge/vendor/include/ws.h (and any WebSocket-specific transitive deps) are removed from vendor/ if not used elsewhere.
+    context: 'Carryover from the original T11.6 — same intent, slightly broader scope. The cleanup target. Lands AFTER all the cut-over targets (T11.2 through T11.5) so that no consumer is left needing the WebSocket path.\n\nIntentionally last in the chain so the migration can be incremental: each prior sub-target can land independently with WebSocket fallback still available, and only when every consumer is on pigeon does the WebSocket code go.\n\nAlso drives the CLAUDE.md documentation refresh — today''s wire-protocol section is one of the larger blocks and is heavily WebSocket-shaped. Once removed, the new pigeon-shaped doc should be considerably shorter (most of the framing detail moves into pigeon''s STABILITY.md by reference).'
     depends_on:
+    - T11.3
+    - T11.4
     - T11.5
+    tags:
+    - pigeon
+    - websocket-removal
+    - cleanup
+    - documentation
     origin: decomposed from T11
     discovered: 2026-04-12
   T12:
     name: ge's render subsystem synthesises ⌥WASD accelerometer events uniformly across all host contexts
-    status: identified
+    status: achieved
     value: 5.0
     cost: 5.0
     acceptance:
@@ -161,9 +231,10 @@ targets:
       Fix: extract the synthesis logic (detect-no-accel + keyboard-to-SDL_EVENT_SENSOR_UPDATE + orientation rotation) into a reusable ge helper, and invoke it from every render-subsystem host: player_core.cpp AND ge's direct-mode render path. "No accelerometer" detection should be programmatic — SDL sensor enumeration plus runtime platform check for simulator/emulator.
     origin: discovered during 🎯T10 tiltbuggy work when writing main.cpp input handling
     discovered: 2026-04-16
+    achieved: 2026-04-19
   T13:
     name: ⌥-gated mouse movement simulates accelerometer (replaces or supplements ⌥WASD)
-    status: identified
+    status: achieved
     value: 3.0
     cost: 2.0
     acceptance:
@@ -183,9 +254,10 @@ targets:
     - T12
     origin: user suggestion during tiltbuggy architecture validation
     discovered: 2026-04-16
+    achieved: 2026-04-19
   T14:
     name: Render subsystem visibly tilts the viewport in response to synthesised accelerometer input
-    status: identified
+    status: achieved
     value: 3.0
     cost: 3.0
     acceptance:
@@ -208,6 +280,7 @@ targets:
     - T12
     origin: user suggestion during tiltbuggy architecture validation
     discovered: 2026-04-16
+    achieved: 2026-04-26
   T15:
     name: Player binary restructured around named PlayerWireBridge + PlayerRender classes
     status: achieved
@@ -232,9 +305,10 @@ targets:
     achieved: 2026-04-17
   T16:
     name: TiltBuggy vehicle dynamics feel right
-    status: identified
+    status: set_aside
     value: 3.0
     cost: 3.0
+    set_aside_reason: Deferred. "TiltBuggy vehicle dynamics feel right" is design-iteration territory that depends on a working tiltbuggy demo across the matrix; the matrix is the current focus. Re-activate once the demo runs cleanly on every non-player platform/sim/emu/device combo and there's a stable surface to iterate on feel against.
     acceptance:
     - Tilting in a steady direction produces a smooth predictable arc with no oscillation
     - Releasing tilt lets the buggy decelerate without strange angular spinning
@@ -289,7 +363,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 2.0
     acceptance:
     - 'All 6 automated matrix-test cells pass on current hardware: desktop-dist, desktop-player, ios-sim-dist, ios-sim-player, android-emu-dist, android-emu-player'
@@ -321,9 +395,10 @@ targets:
     achieved: 2026-04-19
   T2:
     name: Smoke test validates network connectivity between laptop and device
-    status: identified
+    status: set_aside
     value: 1.0
     cost: 2.0
+    set_aside_reason: Mostly subsumed by 🎯T33.1's spyder-CLI rewrite (now merged), which surfaces device-not-connected as exit code 12 and routes through `spyder devices`/`spyder resolve` for diagnosis. The remaining specific piece — a `ge-probe` iOS app for definitive device→laptop HTTP connectivity testing — is a player-shaped artefact and follows the player-deferral. Re-activate as a smaller, ge-probe-specific target when player work resumes.
     acceptance:
     - '`smoke-test.sh` detects when the device cannot reach ged over the network, before any player launch or code debugging begins. Reports the specific failure (no WiFi IP, firewall blocking, device unreachable, or device→laptop path broken) with actionable remediation.'
     context: 'Lost 2+ hours debugging code when the actual problem was laptop WiFi silently stopped accepting incoming connections. All local checks passed (ged listening, device registered via USB). The device→laptop network path was broken but nothing detected it. Need two layers: local network sanity checks (WiFi IP, firewall, ping device) and a `ge-probe` iOS app for definitive device→laptop HTTP connectivity testing.'
@@ -334,7 +409,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 1.0
     acceptance:
     - rotation-stability-test.sh --platform ios-sim --app-id com.squz.tiltbuggy --cycles 10 reports PASS end-to-end against the iPad Air M4 simulator
@@ -349,7 +424,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - 'iPhone: dist + player smoke pass (cold launch, 60s soak, no crashes)'
@@ -367,7 +442,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - make ge/<platform>-debug (or equivalent) produces a debug binary / .app / APK distinct from the release build — assertions enabled, debug symbols retained
@@ -383,7 +458,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - Android player reads a `ged_addr` intent extra (e.g. `adb shell am start -n com.squz.player/.GeActivity --es ged_addr host:port`) and connects directly, skipping QR onboarding
@@ -410,7 +485,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - '`make cell.android-emu-phone-dist` and `make cell.android-debug-dist` both pass end-to-end on the current canonical phone AVD'
     - Failure mode (GL-context error) either fixed at the bgfx config layer or worked around with a documented AVD requirement in Module.mk
@@ -431,20 +506,16 @@ targets:
     achieved: 2026-04-19
   T25:
     name: Player-mode cells pass the reconnect sub-check on iOS sim and Android emu
-    status: identified
+    status: set_aside
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
+    set_aside_reason: Deferred. Player-mode reconnect sub-check; player-mode work as a class is deferred until pigeon's redesign lands. The current focus is non-player matrix cells (-dist mode) which don't exercise the reconnect path.
     acceptance:
     - '`make cell.ios-sim-tablet-player` passes the reconnect sub-check end-to-end'
     - '`make cell.android-emu-phone-player` passes the reconnect sub-check end-to-end'
     - If the bug was in matrix-cell.sh, the fix explains what signal is actually reliable; if in the player, root cause is documented in the fix commit
-    context: |-
-      Both `ios-sim-tablet-player` and `android-emu-phone-player` fail the `reconnect` sub-check in matrix-cell.sh: kill the desktop server, wait 5s, verify the player reconnects by polling ged for a new session. Pre-existing — agents flagged this on both the 🎯T22 and 🎯T23 verification runs, and it's present on master prior to those PRs too.
-
-      Reconnect is an important property for the server/player architecture — games restart during development and the player should transparently pick up the new server. If this sub-check is broken but the underlying reconnect logic works, the bug is in the test. If the logic is broken, it's a real regression from the recent ged / pigeon / session-handshake work.
-
-      First diagnostic step: read `check_reconnect_ios_sim_player` / `check_reconnect_android_emu_player` in matrix-cell.sh and understand what signal it looks for. Second: manually test — start `bin/tiltbuggy`, launch the player, kill tiltbuggy, start a fresh `bin/tiltbuggy`, verify the player reconnects visually. If yes, the matrix-cell check is wrong. If no, there's a real reconnect bug.
+    context: 'Root cause found: player cells start the desktop server without --brokered, so tiltbuggy runs in direct/standalone mode and never connects to ged. server_attached_sessions() always returns 0, so wait_for_server_sessions never fires. Fix: add SERVER_ARGS global, set to --brokered in all player cell runners (run_desktop_player, run_ios_sim_player, run_android_emu_player, run_ios_device_player, run_android_device_player, run_debug_player), and thread it through start_server and all reconnect helpers. This is a pure test/matrix-cell.sh fix — the player reconnect logic itself works correctly.'
     origin: manual
     discovered: 2026-04-19
   T26:
@@ -452,7 +523,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 3.0
     acceptance:
     - '`make cell.android-emu-phone-player` passes the startup-flash sub-check end-to-end with no false positive and no genuine flash'
@@ -474,7 +545,7 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - Per-cell soak sub-check runs for ~10s by default
     - A single dedicated long-soak cell runs the 60s sweep
@@ -483,19 +554,409 @@ targets:
     context: '`make check` currently budgets ~60s soak per cell × 22 active cells ≈ 22 min of mostly-idle wall time. Total wall-clock is estimated 10-20 min. Target: under 8 min. Two levers: (1) cut per-cell soak to 10s, keep one dedicated long-soak cell for the reliability sweep; (2) multi-sim/emu parallelism — booting multiple sims concurrently (iPad Air + iPad Pro for two iOS tablet cells, Pixel 7 + Pixel 9 Pro XL for Android) lets make -j check exercise them in parallel. M4 Max has 128 GB of RAM headroom. matrix-cell.sh already takes the soak timeout as a parameter; ios_sim_get_udid / android_get_serial pick one sim per form factor and need extension to reserve specific sims per cell.'
     origin: manual
     discovered: 2026-04-19
+  T28:
+    name: AccelSynth (Shift-mouse) works in every host context lacking a real accelerometer
+    status: identified
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - In a tilt-driven sample app (e.g. tiltbuggy) built as distribution (in-process DirectRenderHost, no ged/player), Shift-drag of the mouse tilts the viewport and drives gameplay identically to the player binary's behaviour
+    - 'Works on: macOS desktop distribution build, iOS simulator distribution build, Android emulator distribution build'
+    - Real sensor detection remains correct — synth stays OFF on devices that have a real accelerometer (iOS/Android hardware)
+    - Engine-side code (games) is unchanged — only SDL_EVENT_SENSOR_UPDATE is observed
+    context: AccelSynth (src/render/AccelSynth.h) synthesises SDL_EVENT_SENSOR_UPDATE from Shift-gated mouse motion. It is wired into PlayerRender (player binary) where it works, and constructed by DirectRenderHost (distribution modality) but not fully driven — events are not routed through synth->handle() in pumpEvents, update() per frame is not called, and the viewport tilt composite is not driven by synth tilt. Supersedes 🎯T12 (⌥WASD uniform synthesis) and 🎯T13 (⌥-gated mouse) — both described an earlier design abandoned in favour of AccelSynth's single-file Shift-mouse model.
+    origin: user request 2026-04-19
+    discovered: 2026-04-19
+  T28.1:
+    name: DirectRenderHost routes events through AccelSynth::handle() and drives update() per frame
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - DirectRenderHost::pumpEvents routes each SDL event through synth->handle() (when synth is active) before forwarding to the user event handler; consumed events are NOT forwarded
+    - DirectRenderHost drives synth->update() once per frame (beginFrame or endFrame) so the ease-back after Shift-release animates
+    - On a macOS desktop distribution build of sample/tiltbuggy (or equivalent tilt-driven app), Shift+mouse-drag produces SDL_EVENT_SENSOR_UPDATE events that reach the engine's onEvent callback
+    - Unit or integration test (where feasible) covers the routing + update path; otherwise a manual verification note lives in the PR description
+    context: DirectRenderHost.mm:138-164 constructs AccelSynth when config.sensors requests an accelerometer and no real sensor is available, and DirectRenderHost::setEventHandler wires synth->setEmit. But pumpEvents (~line 183) doesn't call synth->handle(), and there's no per-frame synth->update() call, so the Shift-mouse → sensor-event path is inert in the distribution modality. Compare to PlayerRender.cpp for the working pattern.
+    origin: decomposed from T28
+    discovered: 2026-04-19
+    achieved: 2026-04-19
+  T28.2:
+    name: DirectRenderHost viewport tilt composite responds to AccelSynth tilt (parity with PlayerRender)
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - In a distribution build using DirectRenderHost, Shift-dragging produces a visible viewport tilt matching the player binary's visual behaviour on the same app
+    - The tilt compose shader in DirectRenderHost is fed the current AccelSynth tilt each frame (same convention as PlayerRender.cpp ~line 346)
+    - When Shift is released, the composite eases back to neutral alongside the sensor values
+    context: PlayerRender.cpp has a viewport tilt composite driven by AccelSynth::current(). DirectRenderHost has compose shaders (DirectRenderHost.mm:117, submitCompose at ~line 262) but they're not currently driven by synth tilt. Need to plumb synth->current() into submitCompose's (tx, ty) arguments each frame so visual parity with the player is achieved.
+    depends_on:
+    - T28.1
+    origin: decomposed from T28
+    discovered: 2026-04-19
+    achieved: 2026-04-19
+  T28.3:
+    name: iOS simulator distribution build exposes working AccelSynth
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    actual_cost: 2.0
+    demonstration: 'Built TiltBuggy at -configuration Release -sdk iphonesimulator (xcodeproj at sample/tiltbuggy/ios/build/xcode/), installed to the iPad Air 11-inch (M4) sim (UDID 127D48D1-99EC-475D-8B40-26DEDE4DD173, iOS 26.4) via xcrun simctl, launched (PID 34364). User drove Shift+mouse-drag inside the sim window across multiple directions; viewport tilt response captured on a 662 MB QuickTime recording at /tmp/t28.3-accelsynth-ios-sim-20260502-130739.mp4. Confirms: SDL sensor enumeration returns 0 in distribution mode → AccelSynth activates; Shift+drag delivery via the GCKeyboard/GCMouse path works in Release configuration; tilt composite renders correctly. One pre-condition fix during setup: bgfx submodule had an accidental `x` keystroke at vendor/github.com/bkaradzic/bgfx/3rdparty/metal-cpp/metal.hpp:766 (pre-session WIP), reverted before build.'
+    acceptance:
+    - On an iOS simulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors and AccelSynth activates
+    - Shift+mouse-drag inside the simulator window tilts the viewport and drives sensor-driven gameplay
+    - On a real iOS device (same app), AccelSynth stays OFF and real Core Motion sensors drive the game (no regression)
+    context: |-
+      iOS simulator has no Core Motion accelerometer — SDL sensor enumeration should return zero sensors, so AccelSynth::realSensorAvailable() returns false and synth activates. Verify: AccelSynth is actually constructed when running on iOS-sim distribution builds, the key/mouse events reach synth->handle() through SDL's iOS input path (Shift key must be delivered by simulator's keyboard passthrough), and the tilt composite renders correctly in portrait/landscape. Depends on T28.2 for the visual parity path. Smoke-test via ge/tools/smoke-test.sh --platform ios-sim --device tablet --install &lt;app&gt;.
+
+      Investigation (2026-04-19): Build exists and app launches cleanly on iPad Air 11-inch M4 sim (iOS 26.4). Rendering confirmed — buggy (yellow) and ground (blue) visible. AccelSynth activation path verified by code analysis: SDL_INIT_SENSOR is never called so SDL_GetSensors() returns 0 → realSensorAvailable() returns false → synth is constructed. Shift+mouse event delivery chain is sound: iOS sim surfaces a GCKeyboard (Mac keyboard) + GCMouse, SDL's UIKit backend registers for GCKeyboardDidConnectNotification and GCMouseDidConnectNotification, both fire on sim. GCMouse mouseMovedHandler only fires SDL_SendMouseMotion when SDL_GCMouseRelativeMode() is true — which AccelSynth enables via SDL_SetWindowRelativeMouseMode when Shift is held. Full chain is coherent. Remaining gap: interactive verification (actual Shift+drag → tilt response) not yet confirmed programmatically — simctl cannot inject GCKeyboard Shift events. Requires manual or XCUITest-based confirmation.
+    depends_on:
+    - T28.2
+    origin: decomposed from T28
+    discovered: 2026-04-19
+    achieved: 2026-05-02
+  T28.4:
+    name: Android emulator distribution build exposes working AccelSynth
+    status: set_aside
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    set_aside_reason: 'Strategy change 2026-05-02. The Android emulator''s virtual accelerometer/gyroscope sensors (driven via the emulator''s "tilt the phone" UI in Extended Controls → Virtual sensors) are good enough for tilt-driven gameplay on emu — AccelSynth''s Shift+mouse-drag activation isn''t needed there. Investigation found that getting Shift+drag to work would also require non-trivial coordinate-system reconciliation between AccelSynth''s screen-space-displacement model and the AVD''s gravity-vector model. Deferred. Re-activate if a future workflow needs Shift+drag specifically on emulator. Investigation residue: AccelSynth.h gained an emulator-detection prototype via __system_property_get(ro.kernel.qemu / ro.boot.qemu) and DirectRenderHost.mm got a corresponding gate; both reverted before this set-aside since the emulator''s virtual sensors are now the canonical input on emu.'
+    acceptance:
+    - On an Android emulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors (or emulator's virtual sensors pass a simulator-detection check) and AccelSynth activates
+    - Shift+mouse-drag inside the emulator window tilts the viewport and drives sensor-driven gameplay
+    - On a real Android device (same app), AccelSynth stays OFF and real sensors drive the game (no regression)
+    context: Android emulator ostensibly reports virtual sensors via AVD. If SDL sees them, AccelSynth::realSensorAvailable() returns true and synth stays off — we may need a runtime emulator-detection fallback (e.g. check Build.FINGERPRINT via JNI) to force synth on. Confirm behaviour first; extend detection if needed. Shift + mouse drag from the host is delivered to the emulator via the emulator window; verify SDL receives the events. Smoke-test via ge/tools/smoke-test.sh --platform android-emu --package <pkg> --install <apk>.
+    depends_on:
+    - T28.2
+    - T30
+    origin: decomposed from T28
+    discovered: 2026-04-19
+  T29:
+    name: smoke-test.sh default bundle ID is updated to com.squz.tiltbuggy
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - smoke-test.sh --platform ios-sim works for tiltbuggy without requiring --bundle-id override
+    - Default bundle ID in smoke-test.sh is either parameterised from the project or set to com.squz.tiltbuggy
+    context: smoke-test.sh hardcodes default bundle ID as com.squz.yourworld2 (line 47). Running it against tiltbuggy without --bundle-id causes launch to fail with the wrong app ID. Discovered while verifying T28.3.
+    origin: discovered while working on T28.3
+    discovered: 2026-04-19
+    achieved: 2026-04-26
   T3:
     name: Player sends mip cache manifest before rendering begins
-    status: identified
+    status: set_aside
     value: 8.0
     cost: 5.0
+    set_aside_reason: Deferred. Mip cache manifest is a player↔server protocol concern; player-mode work as a class is deferred until pigeon's redesign lands. Re-activate when player work resumes.
     acceptance:
     - On connect, player sends all cached mip hash values to the server (via ge) before the first wire command. Server skips texture upload commands for any mip already cached on the device. Rendering pipeline is only mutated for uncached textures. Reconnection with a fully-cached device produces no texture upload wire commands.
     context: Currently the server sends all texture data and the player reactively checks its local mip cache (hit/miss). This still mutates the rendering pipeline with large WriteTexture commands even when the player already has the data. For ~270MB of initial textures, this dominates reconnection time. A preemptive cache manifest exchange would let the server skip cached uploads entirely.
     origin: migrated from docs/targets.md
     discovered: 2026-04-12
+  T30:
+    name: ge has a single integration path on every platform — consumers do add_subdirectory(ge) and get everything
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'On every supported platform (macOS, iOS, Android — Windows/Linux when added), a consuming app integrates ge via exactly one pattern: add_subdirectory(ge) followed by target_link_libraries(app PRIVATE ge). No hand-picked GE_SOURCES lists, no per-consumer source-level workarounds.'
+    - libge on every platform exposes the full public API from include/ge/ — Text, FontLoader, BgfxContext, SessionHost, tweaks, animation, etc. No subsystem is silently Apple-only or desktop-only.
+    - CLAUDE.md's 'Integrating ge into a New App' section documents this one path and explicitly warns against hand-picking engine sources.
+    - sample/tiltbuggy and multimaze2 (and any other consumer) build on Android via the uniform path, with Text.cpp compiled and linked.
+    context: 'Discovered 2026-04-19 while investigating Android tilt testing. ge currently has two Android integration paths: (a) add_subdirectory(ge) + link ge — the documented path, used by multimaze2, broken because ge''s Android CMakeLists branch doesn''t link SDL3_ttf and Text.cpp''s FontLoader dependency is Apple-only; (b) hand-picked GE_SOURCES list — used by sample/tiltbuggy/android, works by explicitly omitting Text.cpp and FontLoader_apple.mm (see sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt:76-78). Having two paths is the bug — consumers have to reason about which subset of ge is safe on which platform, and bit-rot is inevitable (multimaze2''s Android CMakeLists already omits Text.cpp quietly). Principle: one path, everyone gets everything. Decomposes into T30.1 (SDL3_ttf + deps for Android), T30.2 (FontLoader_android implementation so Text.cpp compiles cross-platform), T30.3 (migrate sample/tiltbuggy Android to add_subdirectory(ge)), and a CLAUDE.md doc update baked into acceptance.'
+    origin: 'forked-from: 🎯T28.4 / Android tilt-testing investigation 2026-04-19'
+    discovered: 2026-04-19
+    achieved: 2026-05-02
+  T30.1:
+    name: ge's Android build links SDL3_ttf + freetype/harfbuzz/plutosvg/plutovg
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - SDL_ttf is vendored under ge/vendor/github.com/libsdl-org/SDL_ttf — added as a git submodule (matching the existing SDL submodule at the same parent path) pinned to release-3.2.2 (requires SDL ≥ 3.2.6; ge's SDL is 3.4.0 so compatible)
+    - ge/CMakeLists.txt's Android branch (currently lines 217-234) does add_subdirectory for SDL_ttf and links SDL3_ttf::SDL3_ttf into the ge target via PUBLIC
+    - SDLTTF_VENDORED is set so freetype, harfbuzz, plutosvg, plutovg are picked up transitively from SDL_ttf's own vendored external sources — no separate prebuilt .a vendoring
+    - NOTICES.md is updated to attribute SDL_ttf + freetype + harfbuzz + plutosvg + plutovg
+    - A CMake configure targeting Android (cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake ...) completes without errors for the ge target, confirming SDL_ttf resolves. Full build-and-link verification follows naturally once T30.2 and T30.3 land.
+    context: First of the two leaves under T30. Source-build approach (not prebuilt .a) for parity with existing SDL3/SDL3_image strategy on Android and to avoid prebuilt drift. This alone doesn't close T30 — FontLoader_android (T30.2) is the paired piece that makes Text.cpp actually compile and work.
+    origin: 'forked-from: T30 on 2026-04-19'
+    discovered: 2026-04-19
+    achieved: 2026-04-20
+  T30.2:
+    name: FontLoader has a non-Apple implementation so Text.cpp compiles on every platform
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - A FontLoader implementation exists that works on Android (and is portable to desktop Linux/Windows if/when those are added) — likely FontLoader_sdl.cpp using SDL_IOStream + SDL_ttf directly, or FontLoader_android.cpp using AAssetManager. Name and approach at author's discretion.
+    - 'ge/CMakeLists.txt selects the right FontLoader source per platform (FontLoader_apple.mm on Apple, the new one everywhere else) — no #ifdef sprawl inside a single file'
+    - ge/src/Text.cpp compiles and links on Android without needing consumers to omit it from source lists
+    - A ge unit test or Android smoke path exercises loading a font and rendering a glyph on Android, so regressions are caught
+    context: Second of the two leaves under T30. The tiltbuggy Android CMakeLists explicitly acknowledges this gap at sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt:76-78 ('FontLoader_apple.mm is Apple-only \u2014 Android would need its own FontLoader implementation'). Pairs with T30.1 \u2014 SDL3_ttf libs alone aren't useful without a FontLoader that can feed them font bytes.
+    depends_on:
+    - T30.1
+    origin: 'forked-from: T30 on 2026-04-19'
+    discovered: 2026-04-19
+    achieved: 2026-04-20
+  T30.3:
+    name: sample/tiltbuggy Android build consumes ge via add_subdirectory(ge), not a hand-picked source list
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    demonstration: sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt.in collapsed from 145 lines of hand-picked engine sources to ~45 lines of `add_subdirectory(ge)`; regenerated tiltbuggy android/ from the new template, built libmain.so end-to-end via NDK 29 (49 MB ELF aarch64, no missing symbols), confirmed clean link, demonstrated parity with the prior hand-picked path. Closes the T30 single-path-integration principle.
+    acceptance:
+    - sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt calls add_subdirectory(${GE_ROOT}) and target_link_libraries(main PRIVATE ge)
+    - The inline GE_SOURCES block (currently lines 79-96) and its accompanying Apple-only comment (lines 76-78) are deleted
+    - The bgfx/bx/bimg/box2d add_library blocks (currently lines 23-73) are deleted — those libraries come from the ge target transitively
+    - The tiltbuggy Android APK still builds and launches on an Android emulator, and the smoke test passes
+    context: Final leaf under T30 \u2014 the migration that actually proves the single-path principle for the sample app. Gated by T30.2 because the current hand-picked approach exists specifically to dodge the missing Android FontLoader; once the engine can build end-to-end on Android, the workaround can go.
+    depends_on:
+    - T30.2
+    origin: 'forked-from: T30 on 2026-04-19'
+    discovered: 2026-04-19
+    achieved: 2026-05-02
+  T31:
+    name: Triangle's non-commercial licence is investigated and either removed, replaced, or formally cleared
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - 'Confirmed where Triangle code actually lands. Inventory: vendor/src/triangle.c + vendor/include/triangle.h are vendored in ge''s repo; Module.mk exposes ge/TRIANGLE_OBJ as an opt-in object (built with -DTRILIBRARY -DREAL=double -DANSI_DECLARATORS -DNO_TIMER); no ge/src/ file #includes triangle.h or calls triangulate(); ge/CMakeLists.txt does not compile triangle.c into libge; the only known consumer is yourworld/yourworld2/tools/precompute.cpp (build-time tool, not a runtime artifact)'
+    - 'Confirmed exactly what the licence permits and forbids. The text in vendor/src/triangle.c grants free use for private, research, and institutional use; permits redistribution if (a) copyright notices are kept, (b) no compensation is received for redistribution, (c) modifications keep original copyright + free source/object availability; **explicitly forbids distribution as part of a commercial system without direct arrangement with Shewchuk (jrs@cs.berkeley.edu)**, with one carve-out: if you don''t supply the code directly to the customer but instead point them at a free download, no arrangement needed'
+    - 'Decided which scenarios are at risk. At minimum: (i) any commercial app that statically links ge/TRIANGLE_OBJ into its shipped binary; (ii) ambiguously, ge itself being publicly distributed (the ''free download'' loophole probably covers this since ge is open-source); (iii) precompute tool outputs (derived mesh data) are almost certainly *not* covered by the licence — derived data isn''t redistribution of Triangle code'
+    - 'Picked a resolution path and executed it. Options, ranked by preference: (1) remove Triangle from ge/vendor entirely and move precompute-style use into yourworld2/tools where it''s actually consumed (clean licence boundary, ge becomes commercially-clean); (2) replace Triangle with earcut.hpp (already vendored, ISC-licensed) for any polygon triangulation — viable if precompute only needs simple polygon triangulation, *not* viable if it needs constrained Delaunay or quality refinement that only Triangle provides; (3) keep Triangle but explicitly document the constraint in CLAUDE.md + NOTICES.md and add a build-time guard (e.g. require an opt-in -DGE_USES_TRIANGLE flag) so it''s impossible to accidentally link into a commercial app without conscious choice; (4) negotiate a commercial arrangement with Shewchuk — last resort, expensive, and brittle'
+    - NOTICES.md and README.md updated to reflect the chosen resolution. If Triangle is removed, both files no longer mention it and the 'Licensing gaps and warnings' section shrinks accordingly. If retained, the warning becomes more prominent and explicit about which builds are safe for commercial use
+    context: 'Surfaced 2026-04-19 during the FFmpeg/LGPL discussion under \ud83c\udfafT30. NOTICES.md already flags Triangle as ''non-standard, restrictive licence'' but the implications weren''t fully internalised \u2014 the licence text in vendor/src/triangle.c forbids commercial distribution without direct arrangement with the author. ge is positioned as a reusable game engine, so any consumer that ships a paid game (i.e. most consumers) is at risk if they end up linking Triangle code into their binary. Initial reconnaissance shows ge does not currently link Triangle into libge.a (only Module.mk''s opt-in ge/TRIANGLE_OBJ exposes it, and no ge source file uses it); the only confirmed user is yourworld2''s build-time precompute tool. So the realistic exposure may be small \u2014 but it needs verification, not assumption. The target is investigation-led: confirm the exposure, then act. The natural endpoint is option (1) \u2014 remove Triangle from ge entirely and let consumers vendor it themselves if they need it, since (a) ge doesn''t use it, (b) the only known consumer is a build tool that lives in a different repo, and (c) the licence makes ge less commercially-friendly than its other deps. earcut.hpp is already vendored as the permissive fallback for simple cases.'
+    origin: 'forked-from: NOTICES.md audit during \ud83c\udfafT30.1 work, 2026-04-19'
+    discovered: 2026-04-20
+    achieved: 2026-04-20
+  T32:
+    name: Android H.264 colour-space conversion happens in the fragment shader, not in a CPU loop
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - VideoDecoder's frame callback on Android delivers NV12 planar data (Y plane + interleaved UV plane with their respective strides), not pre-converted BGRA. The hand-rolled nv12ToBgra() function and reusable frameBuffer member in src/bridge/VideoDecoder_android.cpp (and the equivalent libswscale conversion in src/bridge/VideoDecoder_ffmpeg.cpp) are deleted
+    - PlayerRender uploads Y as a bgfx R8 texture (w×h) and UV as a bgfx RG8 texture (w/2 × h/2) with proper pitch handling for MediaCodec's row stride
+    - 'The fragment shader on Android samples both planes and computes YUV→RGB inline. Implementation: either a separate Android-only shader variant, or a uniform flag on the existing shader — whichever keeps the platform branching cleaner'
+    - iOS and macOS paths are completely untouched. VideoDecoder_apple.mm continues to request kCVPixelFormatType_32BGRA from VideoToolbox, PlayerRender uploads a single BGRA texture, and the original shader path serves Apple unchanged
+    - Validated on the Android emulator and at least one real Android device (Pippa-equivalent, or whichever device is the current Android test target). Visual output matches the existing CPU-converted result — no green tints, no chroma offset, no bias from getting the YUV→RGB matrix coefficients (BT.601 vs BT.709) wrong
+    context: 'Surfaced 2026-04-19 during the FFmpeg/MediaCodec discussion. The Android decode pipeline currently runs a per-pixel CPU loop (src/bridge/VideoDecoder_android.cpp:30-55 nv12ToBgra, plus the libswscale BGRA conversion inside src/bridge/VideoDecoder_ffmpeg.cpp) to convert NV12 to BGRA before texture upload. Wins from moving this to the fragment shader: (1) ~62% less texture-upload bandwidth (3.1MB vs 8.3MB per 1080p frame, ~155MB/s saved at 30fps); (2) eliminates ~2M iterations per frame of CPU work; (3) GPU cost of the YUV\u2192RGB matrix multiply is negligible; (4) two textures instead of one, slightly more state but trivial. The change is decoder-agnostic \u2014 same shader works whether the underlying Android decoder is FFmpeg today or hardware MediaCodec later (so this is a useful step independently of any MediaCodec rewrite). Apple path stays as-is because VideoToolbox + Apple silicon does CSC in dedicated hardware; the conversion is reliable and free there. The conversion problem is genuinely Android-specific and the fix should be too \u2014 no cross-platform unification creep.'
+    origin: 'forked-from: \ud83c\udfafT31 / FFmpeg-vs-MediaCodec discussion 2026-04-19'
+    discovered: 2026-04-20
+    achieved: 2026-04-20
+  T33:
+    name: ge's mobile test infrastructure runs on spyder CLI — exit-code-driven, reservation-safe, with device-state post-run validation
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'ge/tools/smoke-test.sh and ge/tools/matrix-cell.sh shell out to `spyder` for every device-touching operation: device discovery, install, launch, terminate, screenshot, log retrieval, crash retrieval, reservation acquire/release. No direct calls to `xcrun simctl`, `xcrun devicectl`, `pymobiledevice3`, `idevice_id`, `adb`, or platform-branched equivalents remain in those scripts.'
+    - Cells use `spyder run --device <alias> --as <cell-id>` to acquire a reservation under their own owner identity (e.g. owner=ios-sim-tablet-dist), perform work, release on exit, and forward exit codes. Parallel cells targeting different devices proceed concurrently; cells racing for the same device receive exit code 13 (reservation-conflict) and either back off with retry or fail loudly per the cell's policy.
+    - 'Scripts branch on spyder''s exit-code taxonomy (cliexit constants) instead of grepping prose: 10 daemon-unreachable → fail loudly with setup-instructions; 11 device-not-found → emit the alias spyder didn''t recognise; 12 device-not-connected → distinguishable from 11 in the report; 30 timeout → cell-level retry budget; 40/41/42 (trust/developer-mode/locked) → human-gate prompt. The `set -e` + `case $? in` pattern replaces the current ad hoc grep-stderr.'
+    - 'Visual regression: matrix cells that produce a renderable frame call `spyder screenshot <device>` (returns just a file path on stdout, script-friendly), feed it into `spyder diff --suite=<cell-id> --case=<scenario>` for SSIM/pixel comparison against committed baselines. Baseline updates land via `spyder baseline_update` invoked from a separate `make update-baselines` rule, reviewed in PR like any other diff.'
+    - Soak-style cells (matrix-cell-long-soak, the 🎯T25 reconnect sub-check, 🎯T28.4 Android AccelSynth) call `spyder device_power_state <device>` immediately before exit. If the device's screen has fallen asleep mid-soak (autoawake faltered, KeepAwake crashed, profile expired), the cell reports it explicitly rather than silently passing or failing for the wrong reason.
+    - Pre-warmed sim/emu pool reduces per-cell startup time. ~/.spyder/pool.yaml is checked into ge's repo (or generated from a ge-controlled template) so contributors get the same pool layout. matrix-cell.sh prefers `spyder reserve --on platform=ios-sim,...` over creating new sims per run; the pool maintains warm instances of the matrix's standard targets. Per-cell startup time drops by the sim/emu boot cost (~10–30 s on a cold sim).
+    - make check completes faster than the current ~8 minute target (🎯T27). Concrete number to be measured during the migration; expect at least 30% improvement from pool warming alone, more if reservation-based cell parallelism can be raised beyond the current per-platform cap.
+    - 'Documentation: ge/CLAUDE.md''s `## Mobile smoke testing` section is rewritten to describe the spyder-CLI-based workflow. The ''Always exhaust programmatic checks first'' directive becomes more concrete because spyder''s exit codes give scripts more diagnostic signal before falling back to user prompts.'
+    context: 'Filed 2026-04-26 after spyder v0.17.0 landed the CLI overhaul (🎯T37 in spyder, decomposed across T37.1–T37.7 in v0.16.0). The CLI surface that landed there is the precondition that turns ''spyder is useful for ge testing'' from speculation into a concrete migration.\n\nKey spyder v0.16.0 features that unlock this:\n- 17-code exit taxonomy (cliexit package) — distinct codes for daemon-unreachable, device-not-found, device-not-connected, reservation-conflict, not-reserved-by-you, app-not-installed, install/launch/terminate/PID-verify failures, timeout, trust-not-granted, developer-mode-disabled, device-locked. Means scripts can branch deterministically on $? without parsing prose.\n- Universal --timeout DURATION on every subcommand with sensible defaults (10s reads, 60s launch ops, 5m install, 10m deploy, 30s screenshot/reserve, 60s record, 0 for log --follow).\n- spyder reserve --on PREDICATE selectors (parse_string in internal/selector) parsing the same key=value grammar as the MCP reserve tool: platform=ios,os>=17,tags=phone+test,attr.serial=ABC.\n- spyder run --device --as -- <cmd> wraps a child command in an auto-acquired reservation, opportunistically renews during long runs, releases on exit, forwards exit code. Owner defaults to filepath.Base(cwd). Replaces hand-rolled reserve/release-in-trap patterns.\n- spyder screenshot prints just the file path on stdout (script-friendly OUT=$(spyder screenshot Pippa)); human-readable size+mime on stderr behind -v.\n- spyder diff and spyder baseline now reachable (were defined but unregistered pre-v0.16.0).\n- Hermeticity: TestCLIHermeticity verifies postTool doesn''t write to ~/.spyder/. Scripts can rely on spyder not littering state.\n\nv0.17.0 added device_power_state (🎯T29) — the mechanical signal for ''is the device''s display on/off/asleep'' via DVT Screenshot probe (which doesn''t itself reset the idle timer, ruling out the ioregistry false-positive trap). Returns awake|display_off|asleep|unknown. Lets soak-style cells distinguish ''completed normally with screen on'' from ''autoawake faltered, screen went off, results invalid''.\n\nv0.17.0 also fixed brewservices-supervised tunneld loopback hiccups (🎯T36) and stale-install recovery on Code=1002 (🎯T34) — the kind of fragility that would have plagued ge''s matrix runs without these fixes.\n\nWhat this target does NOT include (deferred / out of scope):\n- Network shaping for iOS sim / physical devices (still Android emu only in spyder; Apple Link Conditioner is host-level not per-sim).\n- Screen recording on iOS physical devices (pmd3/devicectl don''t expose a clean CLI path).\n- Replacing ge''s existing imgdiff binary — spyder''s diff uses SSIM and an unimplemented VLM interface; ge''s pixel-RMS imgdiff might still be the right tool for some cells. Use both side-by-side.\n- Wholesale removal of platform-specific tooling from ge: certain things (e.g. xcodebuild for iOS app builds, gradle for Android APKs) stay where they are. spyder is for runtime device interaction, not build orchestration.\n\nDecomposition follows in T33.1–T33.5.'
+    tags:
+    - spyder
+    - testing
+    - cli
+    - matrix
+    - automation
+    origin: manual
+    discovered: 2026-04-26
+    achieved: 2026-05-02
+  T33.1:
+    name: smoke-test.sh shells out to spyder CLI for device discovery, install, launch, log/crash retrieval — no direct platform tooling
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - ge/tools/smoke-test.sh's --platform branches (ios-sim, ios-device, android-emu, android-device, desktop) collapse into a unified flow that calls `spyder devices --json` for discovery and `spyder` subcommands for everything device-side. The --device flag's per-platform meaning (form-factor for ios-sim, name/UDID for ios-device, serial/model substring for android) is replaced by spyder's selector grammar passed via --on.
+    - Direct calls to xcrun simctl, xcrun devicectl, pymobiledevice3, idevice_id, and adb are removed from smoke-test.sh. The only platform-specific shells that remain are for the build steps (xcodebuild, gradle) — runtime device interaction goes through spyder.
+    - Each check (ged reachable, game-server running, device reachable, app deployed and running, player connected, player logs) is implemented as a function that returns a spyder exit code or an internal sentinel; the script's PASS/FAIL/WARN summary keys off those codes deterministically.
+    - smoke-test.sh's --install <path> flag becomes `spyder deploy_app --device <selector> --path <path>` (atomic terminate→install→launch→verify-pid). The current per-platform install branches are deleted.
+    - Help text and CLAUDE.md's mobile-smoke-testing section are updated to reflect the spyder-CLI-driven flow. The 'don't ask the user about visual output until smoke test passes' directive remains, with spyder-CLI exit codes called out as the diagnostic surface.
+    context: First leaf of 🎯T33. Replaces ge/tools/smoke-test.sh's platform-branched plumbing with spyder CLI calls. Pure mechanical migration — no semantic change, just substituting the implementation. Validates that spyder's CLI is sufficient for ge's smoke needs and surfaces any gaps before the more invasive matrix-cell migration in T33.2.
+    depends_on:
+    - T33
+    tags:
+    - spyder
+    - smoke-test
+    - cli-migration
+    origin: manual
+    discovered: 2026-04-26
+    achieved: 2026-05-02
+  T33.2:
+    name: matrix-cell.sh wraps each cell in `spyder run` so reservations are race-safe under parallel make
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - matrix-cell.sh's per-cell entry point becomes `spyder run --device <selector> --as <cell-id> --timeout <budget> -- <inner-cell-cmd>`. Reservation acquire/release is no longer hand-rolled in the script; spyder run handles it including opportunistic renewal during long-running cells.
+    - Cells use selector predicates (--on platform=ios-sim,model_family=iPad,os>=17) instead of pinned device names where appropriate, so the matrix can target a class of devices and let spyder pick from the available pool.
+    - Parallel make rules can launch multiple matrix cells without races. Cells targeting different devices proceed concurrently; cells targeting the same device serialise via spyder's reservation queue. Cells losing a reservation race receive exit code 13 (reservation-conflict) and either back off or fail per their policy.
+    - matrix-cell.sh removes its hand-rolled `lsof | xargs kill` cleanup of stuck device processes (and similar). spyder's reservation cleanup on cell exit handles port/process hygiene transitively (via release → autoawake re-armed → no leaked DVT sessions).
+    - 'make check''s parallelism cap is lifted from ''one cell per platform'' to ''one cell per device.'' Concretely: with 2 booted iOS sims + 1 booted Android emu + 1 desktop, four cells run concurrently. Confirmed by timing or by a debug log showing concurrent-cell IDs.'
+    context: Second leaf of 🎯T33. The reservation-based concurrency story. Builds on T33.1 (matrix-cell already calling spyder for device ops) by adding the `spyder run` wrapper that makes parallel cells safe. Pre-condition for the `make check` time-reduction acceptance criterion in T33's parent acceptance.
+    depends_on:
+    - T33.1
+    tags:
+    - spyder
+    - matrix-cell
+    - reservations
+    - parallelism
+    origin: manual
+    discovered: 2026-04-26
+    achieved: 2026-05-02
+  T33.3:
+    name: Visual regression cells use spyder screenshot + spyder diff against committed baselines, with `make update-baselines` for refresh
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - At least one matrix cell (e.g. ios-sim-tablet-dist or android-emu-dist) captures a screenshot via `spyder screenshot <device>` after rendering reaches a known-stable point, then calls `spyder diff --suite=<cell> --case=<scenario>` to compare against a baseline stored in spyder's baseline directory.
+    - Baselines are committed to spyder's baseline tree (or to a ge-controlled location, depending on layout — pick whichever keeps the diff visible in PR review). Baseline format is whatever spyder's `baseline_update` produces (PNG + manifest).
+    - A `make update-baselines` rule runs the same cells but invokes `spyder baseline_update` instead of `spyder diff`, regenerating the baselines. Reviewers see baseline changes as image diffs in PR.
+    - spyder diff's exit code (success / pixel-mismatch / SSIM-below-threshold) drives the cell's pass/fail. The cell's failure output points to spyder's diff report path so a reviewer can see the visual difference.
+    - Where spyder's SSIM-based diff is insufficient (some cells need pixel-exact comparison), ge's existing imgdiff utility is invoked instead — both can coexist; spyder for high-level visual regression, imgdiff for byte-level checks.
+    context: 'Third leaf of 🎯T33. Visual regression infrastructure. Worth doing because ge has a non-trivial render-correctness surface (bgfx-on-mobile, the YUV→RGB shader path from 🎯T32, the AccelSynth tilt composite from 🎯T28, the iOS rotation magenta-flash issue) that today has no programmatic check beyond ''agent looks at a screenshot.'' Spyder''s diff infrastructure was wired but unregistered before v0.16.0; both diff and baseline subcommands are reachable now.\n\nNote: spyder''s STABILITY.md flags diff as ''Needs Review — SSIM stubbed (NaN); VLM interface unimplemented; report shape expected to gain fields.'' So this target rides on spyder evolution; ge can adopt a basic version now and benefit from upstream improvements automatically.'
+    depends_on:
+    - T33.1
+    tags:
+    - spyder
+    - visual-regression
+    - screenshot
+    - baseline
+    origin: manual
+    discovered: 2026-04-26
+    achieved: 2026-05-02
+  T33.4:
+    name: Soak-style cells call `spyder device_power_state` post-run to distinguish 'screen-asleep' false-pass from real success
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - matrix-cell-long-soak, the 🎯T25 reconnect sub-check cell, the 🎯T28.4 Android AccelSynth distribution cell, and any other cell with a soak phase >60 s call `spyder device_power_state <device>` immediately before exit (or before the success-marker is emitted).
+    - 'If the post-run state is `display_off` or `asleep` on a cell that should have kept the device awake throughout, the cell exits with a distinct code (suggested: 50 or similar — outside spyder''s reserved 10–42 range) and the report flags the device-state regression rather than reporting the cell as a normal pass or fail.'
+    - The `unknown` state (returned when device_power_state can't be determined — e.g. tunneld unavailable, developer mode off) is logged but does not flip the cell to fail; treat as 'no signal,' continue with the prior pass/fail decision.
+    - Documentation in matrix-cell.sh and the ge CLAUDE.md mobile-smoke section explains the post-run device_power_state check and the distinction between 'cell failed' and 'cell passed but device fell asleep.'
+    context: Fourth leaf of 🎯T33. Closes a real diagnostic gap in soak runs. Today, if autoawake falters (KeepAwake crashes, profile expires, the bridge hits the EHOSTUNREACH window before T36 was fixed), a soak cell can complete 'successfully' against a device that's been asleep most of the time — meaning the test result is meaningless. spyder v0.17.0's device_power_state gives ge a way to detect this without any per-platform plumbing.\n\nThe DVT-Screenshot-based probe (the only path that actually works without resetting the idle timer — see spyder docs/papers/t29-device-state-detection.md) is the right primitive here. ge's role is just to call it and branch.
+    depends_on:
+    - T33.1
+    tags:
+    - spyder
+    - device-power-state
+    - soak-test
+    - diagnostics
+    origin: manual
+    discovered: 2026-04-26
+    achieved: 2026-05-02
+  T33.5:
+    name: Pre-warmed sim/emu pool reduces matrix-cell startup time; pool config lives in ge's repo
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'A pool.yaml file is committed to ge (under tools/ or a similar discoverable location) declaring the matrix''s sim and emu templates: at minimum the iOS tablet sim, iOS phone sim, Android phone emu (Pixel 9 Pro XL AVD per 🎯T24), each with a target warm count.'
+    - ge's `make init` (or a dedicated `make pool-init`) symlinks tools/pool.yaml to ~/.spyder/pool.yaml, or copies it, or invokes `spyder pool_warm` per template — whichever path keeps the developer setup minimal. CLAUDE.md documents the one-time setup.
+    - matrix-cell.sh prefers reserving from the pool (selectors that match pool templates) over creating fresh sims/emus per run. `spyder reserve --on platform=ios-sim,model_family=iPad,os>=17` returns a pre-warmed instance from the pool when available.
+    - Per-cell startup time on a cell that previously created+booted a fresh sim drops by ~10–30 s (the sim boot cost). Cells that previously reused a sim see no change. Net `make check` reduction measurable; expect ~20–40 % depending on cell mix.
+    - Pool drain happens automatically on `make check` exit (or via a separate `make pool-drain` rule for manual cleanup). Released-but-still-warm instances don't pile up across runs.
+    context: 'Fifth leaf of 🎯T33. The biggest direct attack on 🎯T27 (`make check` under 8 min). Sim/emu boot is the dominant cost in cold-cell scenarios; pre-warming amortises it. spyder''s pool infrastructure (T24 in spyder) is in place but has no default config — pool_list returns ''pool not configured'' until ~/.spyder/pool.yaml exists. This target makes the pool config part of ge''s source tree so contributors get the same warming behaviour out of the box.\n\nDeferred / out of scope: dynamic pool sizing based on observed concurrency (ge uses fixed warm counts); cross-host pool sharing (single-developer-laptop assumption holds for now).'
+    depends_on:
+    - T33.2
+    tags:
+    - spyder
+    - pool
+    - performance
+    - make-check
+    origin: manual
+    discovered: 2026-04-26
+    achieved: 2026-05-02
+  T34:
+    name: The player is a regular ge app — bespoke networking and decoding stay, but rendering, windowing, and per-platform entry points come from ge like any other consumer
+    status: set_aside
+    value: 0.0
+    cost: 0.0
+    set_aside_reason: Deferred. Player-as-ge-app refactor; player work as a class is deferred until pigeon's redesign lands. Re-activate after pigeon resumes.
+    acceptance:
+    - 'The player''s main() is a thin ge app that calls ge::run(Factory) and returns a RunConfig with onUpdate / onRender / onEvent / onShutdown. ge owns the SDL window, the bgfx context, the frame loop, the SDL event pump, the tilt composite. The player''s app code provides only: wire connection setup, decoder management, the per-frame texture upload, and the bgfx draw call.'
+    - tools/player.cpp and tools/player_core.cpp are deleted. The player's source moves to a ge-app layout (probably sample/player/main.cpp + sample/player/Net.cpp/h or similar) that mirrors how sample/tiltbuggy is laid out. The player has its own Makefile / android/ / ios/ trees the way every ge app does — generated from ge's templates via tools/init-android.sh / tools/init-ios.sh, not hand-maintained.
+    - tools/ios/main.mm, tools/android/app/src/main/cpp/main.cpp, tools/ios/CMakeLists.txt, tools/android/* — the bespoke per-platform entry points that exist solely because the current player isn't a ge app — are deleted. The player rides on ge's standard iOS xcframework path and Android add_subdirectory(ge) path established by 🎯T30.
+    - 'src/render/PlayerRender.cpp and include/ge/PlayerRender.h are deleted. The functionality those provided (window, video texture upload, aspect-fit blit, portrait-in-landscape rotation, tilt composite, event coordinate mapping) is replaced by: (a) ge''s existing render layer (window, bgfx draw, tilt composite already shared with DirectRenderHost), (b) a small per-frame YUV/BGRA texture upload in the player''s onRender, (c) event coordinate mapping that becomes a small ge-provided utility if it isn''t already (since other apps may want it too).'
+    - The player no longer uses SDL_Renderer for video display. The decoded frame is uploaded as a bgfx texture (via the YUV multi-plane path from 🎯T32 on platforms that support it, BGRA fallback otherwise) and drawn via a normal bgfx textured-quad pass. The 'no bgfx — just blits a video texture via SDL_RenderGeometry' comment in PlayerRender.h disappears with the file.
+    - 'Bespoke surfaces that stay bespoke: the WebSocket / pigeon wire connection, ged handshake, pairing-artifact handling, H.264 decoder lifecycle (VideoDecoder_apple.mm and VideoDecoder_ffmpeg.cpp), and the upstream-event forwarding. These are app code, not engine code, and live in the player''s source tree the way Physics.cpp lives in multimaze2''s source tree.'
+    - 'tools/AudioPlayer.h/.cpp moves into the player''s app code (or is deleted if ge''s audio surface absorbs it). The dormancy noted in 🎯T7''s PR #43 (AudioPlayer not currently compiled into any build target) resolves naturally: the player either uses ge''s audio path or carries AudioPlayer as part of its own sources.'
+    - ge's server-side bgfx-encode path (the headless modality that turns onRender output into an H.264 stream) is unchanged. A player app instance running in headless server mode will encode whatever its onRender drew — i.e. the upstream video stream — and emit it. This is the precondition for 🎯T34.1's recursion test-bed; no changes are needed to ge's server side to make it work.
+    - 'CLAUDE.md''s ''Server/player architecture'' section is rewritten to describe the new shape: ge apps can run in either server mode (headless, encoding for streaming) or windowed mode (rendering locally); the player happens to be a ge app whose onRender blits a video texture and whose app code handles the wire/decoder. The ''two parallel rendering frameworks'' framing goes away.'
+    context: 'Filed 2026-04-26 after a design conversation. The player is currently a bespoke application: tools/player.cpp + tools/player_core.cpp + tools/ios/main.mm + tools/android/.../main.cpp + src/render/PlayerRender.cpp + include/ge/PlayerRender.h. It has its own SDL window setup, its own SDL_Renderer-based drawing path, its own per-platform entry points, its own tilt-composite math (parallel to DirectRenderHost.mm), its own event coordinate mapping, and its own iOS/Android bootstrap.\n\nThe insight: that''s an enormous amount of plumbing that ge already provides to every other consumer. tiltbuggy / multimaze2 / yourworld and any future ge consumer get window + frame loop + bgfx + tilt composite + event delivery + per-platform mobile builds for free, because ge is exactly the framework designed to make app authoring easy across iOS / Android / desktop. The player is just another ge app whose onRender happens to draw a video texture instead of simulated geometry, and whose app code happens to manage a wire connection and an H.264 decoder instead of a physics simulation.\n\nWhat changes:\n- The player''s main() becomes a ~50-line ge app that calls ge::run(Factory) the same way tiltbuggy does.\n- The bespoke parts (network, decoder, wire framing, pairing-artifact handling, upstream event forwarding) stay bespoke. They live in the player''s app code, not in ge. ge has no notion of ''player mode'' — the player is just a ge app whose onUpdate pumps the wire and whose onRender blits a texture.\n- The platform-specific bootstrap (tools/ios/main.mm, tools/android/app/src/main/cpp/main.cpp) goes away. The player gets iOS xcframework + Android add_subdirectory(ge) builds for free, the same way every ge consumer does.\n- src/render/PlayerRender.cpp and the SDL_Renderer-based path go away. bgfx is the rendering layer.\n- The tilt composite stops being duplicated between PlayerRender.cpp and DirectRenderHost.mm. ge''s existing render-side tilt composite (used by direct-mode samples) serves the player too.\n- The YUV multi-plane texture upload from 🎯T32 lives natively in the player''s onRender (since bgfx is now the renderer, not SDL_Renderer).\n\nNon-goals:\n- ge does NOT gain a ''client mode'' or ''player mode'' role. ge::run is unchanged. The player is a regular ge app, period.\n- The wire protocol, decoder, and connection logic are NOT moved into ge. They''re app code, owned by the player''s source tree.\n- Performance characteristics stay the same or improve — the bgfx path replaces SDL_Renderer, which means the YUV-on-shader and tilt-composite paths get the engine''s normal performance instead of the player-specific bypass.\n\nRelation to other in-flight targets:\n- 🎯T7 audio-pause: AudioPlayer is currently dormant (per PR #43). Resolution: AudioPlayer either folds into the player''s app code, or ge''s audio surface absorbs the lifecycle, or AudioPlayer is deleted in favour of whichever path makes the player''s audio the same as any other ge app''s audio. T34 settles this naturally.\n- 🎯T11 pigeon migration: when ge''s transport switches to pigeon, the player picks it up automatically because the player''s bespoke wire code consumes whichever transport ge surfaces. The pigeon migration becomes simpler — there''s no separate ''now port the player'' phase.\n- 🎯T30 single-path-integration: the player retiring its bespoke entry points and consuming ge via add_subdirectory(ge) is exactly the principle T30 closed for tiltbuggy applied to the player. T34 inherits T30''s plumbing for free.\n- 🎯T32 YUV-on-shader: the player gains the YUV path natively when SDL_Renderer goes away.\n\nSequencing: substantial refactor; comparable in scope to T30''s single-path work or larger. Probably best landed after the 🎯T33 test-infrastructure family is in (so the new player can be exercised by the new spyder-driven matrix cells immediately), but before any pigeon migration so the pigeon work has only one player-shape to reason about.'
+    tags:
+    - player
+    - architecture
+    - ge-app
+    - single-path
+    - render-unification
+    origin: manual
+    discovered: 2026-04-26
+  T34.1:
+    name: 'The player-as-ge-app enables recursion-as-test-bed: a player connects to another player''s headless-server output, all the way down'
+    status: set_aside
+    value: 0.0
+    cost: 0.0
+    set_aside_reason: Deferred. Recursion test-bed depends on T34, which is deferred until pigeon's redesign lands.
+    acceptance:
+    - 'A matrix cell exists that runs three processes on the same host: a server (e.g. tiltbuggy in headless mode), a player A that connects to the server, and a player B that connects to player A in *its* headless mode. Player B''s framebuffer should match (within visual-regression tolerance) the server''s framebuffer, modulo encode/decode round-trips.'
+    - 'The cell is implemented via spyder reservations and the visual-regression infrastructure from 🎯T33.3 (committed baselines, spyder diff). End-to-end coverage: if any change to ge''s wire format, encoder, decoder, or render layer breaks the round trip, this cell catches it.'
+    - A debugging mode (or just a `make demo-recursion` target) lets a developer launch the same three-process stack interactively. Useful for the latency-stack measurement use case (timing each hop independently) and for the showcase demonstration ('phone watching laptop watching iPad watching laptop').
+    context: 'Sub-target of 🎯T34. Once the player is a regular ge app, ge''s existing server-side bgfx-encode path (the headless modality that turns onRender output into an H.264 stream) applies to the player without any extra work — running the player in headless mode means it encodes whatever its onRender drew, which IS the upstream video stream. A second player connecting to that headless first player would see the first player''s video (which is itself the original server''s video).\n\nNo player-side networking changes are needed for this. The player''s app code is unchanged — it still has its bespoke connect-to-upstream-server logic. What''s new is that ge''s existing ''server'' role applies to it equally well; it''s a ge app, ge can encode it.\n\nWhy it''s useful (not just a curiosity):\n- Wire-protocol invariant test bed: any assumption that ''I''m one or the other'' breaks immediately when the player runs as both encoder and decoder simultaneously.\n- Latency-stack measurement: stack three deep (server → A → B) and measure each hop independently. Relevant to 🎯T11.4 LAN-bypass evaluation.\n- End-to-end test cells: matrix cells assert on the final framebuffer, exercising the full encode → wire → decode → render → encode → wire → decode → render path with no mocking.\n- Showcase demonstration: viscerally communicates ge''s symmetry. Plays well in release videos.\n\nDeferred: optimisations specific to the recursion case (e.g. could the inner player skip re-encode if it knows downstream wants the same H.264 stream? Probably yes, but that''s an optimisation target, not a correctness target).'
+    depends_on:
+    - T34
+    tags:
+    - player
+    - recursion
+    - test-bed
+    - wire-protocol
+    - showcase
+    origin: manual
+    discovered: 2026-04-26
+  T35:
+    name: Three player iOS variants exist with narrowed Info.plists for orientation control
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'tools/ios/ produces three .app bundles: player-any, player-portrait, player-landscape'
+    - 'Each bundle''s UISupportedInterfaceOrientations matches its name (any: all four; portrait: Portrait+PortraitUpsideDown; landscape: LandscapeLeft+LandscapeRight)'
+    - All three variants link tools/player_orientation_ios.mm and honour SessionConfig.orientation post-launch
+    - Selection mechanism documented (consuming app chooses variant at install time, OR ged routes by server-declared preference)
+    - 'Verified on iPad: portrait variant launches portrait regardless of device orientation; landscape variant launches landscape; any variant adopts device orientation at launch'
+    context: |-
+      Direct-render apps (e.g. TiltBuggy) get deterministic launch orientation by narrowing UISupportedInterfaceOrientations in their own Info.plist, then locking with the prefersInterfaceOrientationLocked swizzle in tools/player_orientation_ios.mm. Player-mediated apps can't do this — the player binary serves any consuming app, so its Info.plist has to permit every orientation. Result: post-launch lock works (via SessionConfig from server → playerForceOrientation), but launch orientation is whatever the device is held in.
+
+      Decision: ship three player iOS variants with narrowed plists — player-any (all four), player-portrait, player-landscape. The consuming app (or a ged-side hint) chooses which variant to direct connections to. Defer until a player-mediated app actually needs deterministic launch orientation.
+
+      Background: see today's TiltBuggy work and the comments in tools/player_orientation_ios.mm and sample/tiltbuggy/ios/Info.plist for the underlying iPadOS 26 mechanism (TN3192).
+    origin: forked-from T28 — surfaced while wiring orientation lock for TiltBuggy on Pippa
+    discovered: 2026-05-02
   T4:
     name: playerLoop takes a config struct with named fields
-    status: identified
+    status: achieved
     value: 3.0
     cost: 2.0
     acceptance:
@@ -503,11 +964,13 @@ targets:
     context: '`playerLoop` accumulated parameters across iterations (discover → checkOverride + discover + name). Positional args are opaque at call sites. Named fields via a config struct make the API self-documenting and easier to extend.'
     origin: migrated from docs/targets.md
     discovered: 2026-04-12
+    achieved: 2026-04-26
   T5:
     name: Player has a connection management screen
-    status: identified
+    status: set_aside
     value: 3.0
     cost: 3.0
+    set_aside_reason: Deferred. Player UI work; player as a class is deferred until pigeon's redesign lands.
     acceptance:
     - Player has a gesture-accessible screen to scan a new QR code, manually enter a server address, or forget the saved address. Accessible from the connected state (not just on startup).
     context: The persistence mechanism works (player remembers server address), but there's no UI for the user to manage saved connections.
@@ -515,9 +978,10 @@ targets:
     discovered: 2026-04-12
   T6:
     name: Player can switch between active servers without QR
-    status: identified
+    status: set_aside
     value: 2.0
     cost: 2.0
+    set_aside_reason: Deferred. Player navigation feature; player as a class is deferred until pigeon's redesign lands.
     acceptance:
     - Dashboard has a "move player to server" control. Player switches seamlessly via `kServerAssignedMagic`. No disconnect/reconnect visible to user.
     context: With persistent address, player auto-connects to saved server. If two servers are on the same network, player has no reason to fall back to QR. Dashboard is the natural control plane.
@@ -525,7 +989,7 @@ targets:
     discovered: 2026-04-12
   T7:
     name: Audio pauses when the app is backgrounded
-    status: identified
+    status: achieved
     value: 5.0
     cost: 2.0
     acceptance:
@@ -533,11 +997,13 @@ targets:
     context: User reported music keeps playing when the iOS app is backgrounded. Currently `ge::Audio` (server-side) sends play/stop/volume commands, and `AudioPlayer` (player-side, wire mode) or equivalent direct-mode playback handles them. Neither layer responds to app lifecycle events. The engine should intercept `SDL_EVENT_DID_ENTER_BACKGROUND` / `SDL_EVENT_DID_ENTER_FOREGROUND` and pause/resume audio automatically. In wire mode this means the player pauses its `AudioPlayer`; in direct mode the session or audio subsystem does it directly.
     origin: manual (user-reported from yourworld)
     discovered: 2026-04-12
+    achieved: 2026-05-02
   T8:
     name: Distribution iOS builds support accelerometer simulation in the simulator
-    status: identified
+    status: set_aside
     value: 3.0
     cost: 5.0
+    set_aside_reason: Subsumed by 🎯T28.3 (iOS simulator distribution build exposes working AccelSynth). T8 was filed pre-AccelSynth — about Apple's built-in ⌥+WASD sim accelerometer in distribution builds. T28.3 covers the equivalent capability via ge's own AccelSynth (Shift-mouse). Same user-visible outcome via the modern path.
     acceptance:
     - ⌥+WASD tilts the simulated device's accelerometer in distribution/release iOS Simulator builds (not just Debug builds)
     - Test on a Release-configuration iOS Simulator build of any ge-based app
@@ -546,9 +1012,10 @@ targets:
     discovered: 2026-04-15
   T9:
     name: ge exposes device tilt as optional parallax input to games
-    status: identified
+    status: set_aside
     value: 5.0
     cost: 5.0
+    set_aside_reason: Deferred. Device-tilt-as-parallax-input is a player-mode feature (Core Motion attitude is captured by the player and forwarded to the server). Player work as a class is deferred until pigeon's redesign lands.
     acceptance:
     - RunConfig has a parallaxFactor field (float, default 0)
     - When parallaxFactor > 0, the player captures Core Motion attitude and sends deltas to the server

--- a/include/ge/BgfxContext.h
+++ b/include/ge/BgfxContext.h
@@ -27,6 +27,20 @@ public:
     bool shouldQuit() const;
     SDL_Window* window() const;
 
+    // Android-only lifecycle: when the activity moves to background the
+    // SurfaceView's ANativeWindow becomes invalid; on foreground a NEW
+    // one is allocated. Call onBackground() in response to
+    // SDL_EVENT_DID_ENTER_BACKGROUND to pause rendering, and onForeground()
+    // in response to SDL_EVENT_DID_ENTER_FOREGROUND to re-acquire the new
+    // native window and rebuild the swap chain. No-op on Apple platforms,
+    // where the CAMetalLayer survives backgrounding.
+    void onBackground();
+    void onForeground();
+
+    // True between onBackground() and onForeground(); host should skip
+    // beginFrame/endFrame work while paused.
+    bool paused() const;
+
 private:
     struct M;
     std::unique_ptr<M> m;

--- a/include/ge/RenderHost.h
+++ b/include/ge/RenderHost.h
@@ -69,6 +69,13 @@ public:
     // True when the render subsystem has signalled shutdown (window close,
     // wire closed, SIGINT, etc.).
     virtual bool shouldQuit() const = 0;
+
+    // True while the render path is suspended (Android: activity in
+    // background, swap chain torn down). The engine's run loop must
+    // skip beginFrame / onRender / bgfx::frame / endFrame while this
+    // is true — bgfx::frame() against a dead Android swap chain crashes.
+    // Default false; only DirectRenderHost on Android ever returns true.
+    virtual bool paused() const { return false; }
 };
 
 } // namespace ge

--- a/include/ge/Resource.h
+++ b/include/ge/Resource.h
@@ -8,4 +8,17 @@ namespace ge {
 // On desktop, prepends the binary's parent directory (project root).
 std::string resource(const std::string& relativePath);
 
+// Path component identifying the renderer-appropriate shader directory.
+// Games construct shader paths as resource(shaderDir() + "/foo_vs.bin").
+//   * Apple platforms (Metal)             → "build/shaders"
+//   * Android (Vulkan, on emulator)       → "build/shaders-spirv"
+//   * Android (OpenGL ES, real devices)   → "build/shaders-gles"
+// Must be called AFTER bgfx is initialised (BgfxContext constructed).
+std::string shaderDir();
+
+// Same as shaderDir() but for ge's internal compose-pass shaders, which
+// live under "build/ge/shaders" (Apple) or "build/ge/shaders-{spirv,gles}"
+// (Android).
+std::string renderShaderDir();
+
 } // namespace ge

--- a/sample/tiltbuggy/src/Renderer.cpp
+++ b/sample/tiltbuggy/src/Renderer.cpp
@@ -160,11 +160,15 @@ void Renderer::drawFrame(const Scene& scene, int width, int height,
         pushRect(verts, surf.l, surf.b, surf.r, surf.t, color);
     }
 
-    // 3. Buggy: 1.0 × 0.5 m, rotated.
+    // 3. Buggy — sized in proportion to the world (kept at 1/20 of the
+    // arena half-extent to match the Box2D shape, so when the world is
+    // shrunk to speed up physics, the rendered chassis tracks it).
     const Pose pose = scene.buggyPose();
+    const float hw = scene.halfExtent() * 0.05f;
+    const float hh = hw * 0.5f;
     pushRotatedRect(verts,
         pose.x, pose.y,
-        /*hw=*/0.5f, /*hh=*/0.25f,
+        hw, hh,
         pose.angle,
         rgb(0xFF, 0xCC, 0x33));
 

--- a/sample/tiltbuggy/src/Scene.cpp
+++ b/sample/tiltbuggy/src/Scene.cpp
@@ -69,7 +69,11 @@ struct Scene::Impl {
         }
 
         // ------------------------------------------------------------------
-        // Chassis — 1.0 × 0.5 m rectangle, starts at origin
+        // Chassis — 0.5 × 0.25 m rectangle, starts at origin
+        // (Half real-world size + 2× viewport zoom = same on-screen size as
+        // a 1.0 × 0.5 m chassis would have at the original scale, but
+        // physics traverse the smaller arena 2× faster under the same
+        // 9.81 m/s² gravity — see kWorldHalfExtent in main.cpp.)
         // ------------------------------------------------------------------
         {
             b2BodyDef bdef = b2DefaultBodyDef();
@@ -80,7 +84,7 @@ struct Scene::Impl {
             bdef.enableSleep = false;  // gravity changes must always take effect
             chassisId = b2CreateBody(worldId, &bdef);
 
-            b2Polygon box = b2MakeBox(0.5f, 0.25f); // half-extents
+            b2Polygon box = b2MakeBox(0.03125f, 0.015625f); // half-extents (1/16 of original)
             b2ShapeDef sdef = b2DefaultShapeDef();
             sdef.density = 1.0f;
             sdef.material.friction = 0.8f;
@@ -96,8 +100,8 @@ struct Scene::Impl {
         // Surface sensor patches
         // ------------------------------------------------------------------
 
-        // Ice patch: upper-centre, x∈[-3,3], y∈[2,6]
-        iceL = -3.0f; iceB = 2.0f; iceR = 3.0f; iceT = 6.0f;
+        // Ice patch: upper-centre — sized at 1/16 of the original layout.
+        iceL = -0.1875f; iceB = 0.125f; iceR = 0.1875f; iceT = 0.375f;
         {
             float hw = (iceR - iceL) * 0.5f;
             float hh = (iceT - iceB) * 0.5f;

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -3,9 +3,9 @@
 //
 // TiltBuggy — a ge sample driving a 2D buggy with tilt gravity.
 // Stage 2: Box2D physics + bgfx rendering. On a real device the
-// accelerometer drives gravity. On desktop/simulator/emulator the
-// player synthesises accelerometer events from ⌥WASD when the game
-// requests the sensor — no special key handling needed here.
+// accelerometer drives gravity. On desktop/simulator/emulator
+// AccelSynth synthesises SDL_EVENT_SENSOR_UPDATE events from
+// Shift-gated mouse drag — hold Shift and drag to tilt the world.
 
 #include "Renderer.h"
 #include "Scene.h"
@@ -16,6 +16,43 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>  // required on iOS/Android; no-op on desktop
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/base_sink.h>
+
+#ifdef GE_IOS
+// TEMP: T28.3 diagnostic — route spdlog through NSLog so logs appear in
+// xcrun simctl spawn log stream output.
+#import <Foundation/Foundation.h>
+template <typename Mutex>
+class nslog_sink : public spdlog::sinks::base_sink<Mutex> {
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        spdlog::memory_buf_t buf;
+        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, buf);
+        NSString* s = [[NSString alloc] initWithBytes:buf.data()
+                                               length:buf.size()
+                                             encoding:NSUTF8StringEncoding];
+        NSLog(@"%@", s);
+    }
+    void flush_() override {}
+};
+#endif  // GE_IOS
+
+#ifdef __ANDROID__
+// TEMP: T28.4 diagnostic — route spdlog through Android's log so logs
+// appear in logcat.
+#include <android/log.h>
+template <typename Mutex>
+class android_sink : public spdlog::sinks::base_sink<Mutex> {
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        spdlog::memory_buf_t buf;
+        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, buf);
+        std::string s(buf.data(), buf.size());
+        __android_log_print(ANDROID_LOG_INFO, "tiltbuggy", "%s", s.c_str());
+    }
+    void flush_() override {}
+};
+#endif  // __ANDROID__
 
 #include <cstring>
 #include <memory>
@@ -34,6 +71,26 @@ struct State {
 } // namespace
 
 int main(int argc, char* argv[]) {
+#ifdef GE_IOS
+    // TEMP: T28.3 diagnostic — install NSLog sink so spdlog output is visible.
+    {
+        auto sink = std::make_shared<nslog_sink<std::mutex>>();
+        auto logger = std::make_shared<spdlog::logger>("tiltbuggy", sink);
+        logger->set_level(spdlog::level::info);
+        spdlog::set_default_logger(logger);
+    }
+#endif  // GE_IOS
+
+#ifdef __ANDROID__
+    // TEMP: T28.4 diagnostic — install Android log sink so spdlog output is visible.
+    {
+        auto sink = std::make_shared<android_sink<std::mutex>>();
+        auto logger = std::make_shared<spdlog::logger>("tiltbuggy", sink);
+        logger->set_level(spdlog::level::info);
+        spdlog::set_default_logger(logger);
+    }
+#endif  // __ANDROID__
+
     bool brokered = false;  // default: direct/distribution modality
     for (int i = 1; i < argc; i++) {
         if (std::strcmp(argv[i], "--brokered") == 0) brokered = true;
@@ -84,6 +141,7 @@ int main(int argc, char* argv[]) {
         .headless = brokered,
         .appName = "tiltbuggy",
         .sensors = wire::kSensorAccelerometer,
+        .orientation = wire::kOrientationLandscape,
         .disableScreenSaver = true,
     });
 }

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -59,7 +59,7 @@ protected:
 
 namespace {
 
-constexpr float kWorldHalfExtent = 10.0f;
+constexpr float kWorldHalfExtent = 0.625f;
 
 struct State {
     std::unique_ptr<tiltbuggy::Scene> scene;
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
             },
             .onRender = [&](int w, int h) {
                 if (!state.rendererInited) {
-                    state.renderer->init(ge::resource("build/shaders").c_str());
+                    state.renderer->init(ge::resource(ge::shaderDir()).c_str());
                     state.rendererInited = true;
                 }
                 state.renderer->drawFrame(*state.scene, w, h);
@@ -123,9 +123,14 @@ int main(int argc, char* argv[]) {
             .onEvent = [&](const SDL_Event& e) {
                 SPDLOG_INFO("onEvent type=0x{:x}", e.type);
                 if (e.type == SDL_EVENT_SENSOR_UPDATE) {
-                    state.gravity.x = e.sensor.data[0];
-                    state.gravity.y = e.sensor.data[1];
-                    SPDLOG_INFO("  → gravity=[{:.2f},{:.2f}]",
+                    // Engine delivers device acceleration in screen frame.
+                    // The world/board accelerates in that direction, so the
+                    // buggy (free on the board) experiences gravity in the
+                    // opposite direction — hence the negation.
+                    state.gravity.x = -e.sensor.data[0];
+                    state.gravity.y = -e.sensor.data[1];
+                    SPDLOG_INFO("ACCEL accel=[{:+.2f},{:+.2f},{:+.2f}] gravity=[{:+.2f},{:+.2f}]",
+                                e.sensor.data[0], e.sensor.data[1], e.sensor.data[2],
                                 state.gravity.x, state.gravity.y);
                 }
             },

--- a/sample/tiltcal/Makefile
+++ b/sample/tiltcal/Makefile
@@ -1,0 +1,21 @@
+# TiltCal — accelerometer calibration sample.
+#
+# Quick & dirty: single-source app that reads SDL3's accelerometer and
+# logs each pose's reading. Used to characterise the SDL3 sensor
+# contract on iOS / iPadOS / Android.
+
+ge := ../..
+
+APP_NAME    := tiltcal
+APP_DISPLAY_NAME := TiltCal
+APP_ID      := com.squz.tiltcal
+APP_SRC     := src/main.cpp
+APP_SHADERS :=
+
+# Default to FREE orientation lock for desktop builds; iOS builds set
+# their own value in CMakeLists.txt per variant.
+APP_CXXFLAGS := -DTILTCAL_LOCK=0
+
+-include $(ge)/Module.mk
+$(ge)/Module.mk:
+	git submodule update --init --recursive

--- a/sample/tiltcal/src/main.cpp
+++ b/sample/tiltcal/src/main.cpp
@@ -1,0 +1,182 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// TiltCal — raw SDL3 accelerometer readout, monster text. No state
+// machine, no orientation lock — just X / Y / Z values continually.
+
+#include <ge/Protocol.h>
+#include <ge/SessionHost.h>
+
+#include <bgfx/bgfx.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+#include <cstdio>
+#include <cstring>
+
+#ifdef GE_IOS
+#import <Foundation/Foundation.h>
+#endif
+
+namespace {
+
+float g_data[3] = {0, 0, 0};
+
+// 7×5 bitmap font for the characters we need: 0-9, '.', '+', '-', ':',
+// 'X', 'Y', 'Z', and ' '. Each glyph is 7 rows of 5 columns; bit 4 (0x10)
+// is the leftmost pixel.
+struct Glyph { uint8_t rows[7]; };
+constexpr Glyph kFont[] = {
+    // '0'
+    {{0b01110, 0b10001, 0b10011, 0b10101, 0b11001, 0b10001, 0b01110}},
+    // '1'
+    {{0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110}},
+    // '2'
+    {{0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0b01000, 0b11111}},
+    // '3'
+    {{0b11110, 0b00001, 0b00001, 0b01110, 0b00001, 0b00001, 0b11110}},
+    // '4'
+    {{0b00010, 0b00110, 0b01010, 0b10010, 0b11111, 0b00010, 0b00010}},
+    // '5'
+    {{0b11111, 0b10000, 0b11110, 0b00001, 0b00001, 0b10001, 0b01110}},
+    // '6'
+    {{0b00110, 0b01000, 0b10000, 0b11110, 0b10001, 0b10001, 0b01110}},
+    // '7'
+    {{0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b01000, 0b01000}},
+    // '8'
+    {{0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110}},
+    // '9'
+    {{0b01110, 0b10001, 0b10001, 0b01111, 0b00001, 0b00010, 0b01100}},
+    // '.'
+    {{0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b01100, 0b01100}},
+    // '+'
+    {{0b00000, 0b00100, 0b00100, 0b11111, 0b00100, 0b00100, 0b00000}},
+    // '-'
+    {{0b00000, 0b00000, 0b00000, 0b11111, 0b00000, 0b00000, 0b00000}},
+    // ':'
+    {{0b00000, 0b01100, 0b01100, 0b00000, 0b01100, 0b01100, 0b00000}},
+    // 'X'
+    {{0b10001, 0b10001, 0b01010, 0b00100, 0b01010, 0b10001, 0b10001}},
+    // 'Y'
+    {{0b10001, 0b10001, 0b01010, 0b00100, 0b00100, 0b00100, 0b00100}},
+    // 'Z'
+    {{0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b10000, 0b11111}},
+    // ' '
+    {{0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b00000}},
+};
+
+const Glyph* glyphFor(char c) {
+    switch (c) {
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+        return &kFont[c - '0'];
+    case '.': return &kFont[10];
+    case '+': return &kFont[11];
+    case '-': return &kFont[12];
+    case ':': return &kFont[13];
+    case 'X': return &kFont[14];
+    case 'Y': return &kFont[15];
+    case 'Z': return &kFont[16];
+    default:  return &kFont[17];  // space / unknown
+    }
+}
+
+// Print a string at (cellRow, cellCol) using `█` blocks per glyph pixel,
+// scaled by `scale` (each glyph pixel becomes scale×scale dbgText cells).
+void drawBig(int row, int col, const char* s, int scale, uint8_t color) {
+    constexpr int glyphW = 5;
+    constexpr int glyphH = 7;
+    constexpr char kBlock = (char)0xDB;  // █
+    char rowbuf[256];
+
+    int len = (int)std::strlen(s);
+    int strideCols = (glyphW + 1) * scale;  // +1 pixel gap between glyphs
+
+    for (int gy = 0; gy < glyphH; ++gy) {
+        for (int sy = 0; sy < scale; ++sy) {
+            int outCol = 0;
+            std::memset(rowbuf, ' ', sizeof(rowbuf));
+            for (int i = 0; i < len; ++i) {
+                const Glyph* g = glyphFor(s[i]);
+                uint8_t bits = g->rows[gy];
+                for (int gx = 0; gx < glyphW; ++gx) {
+                    bool on = (bits >> (glyphW - 1 - gx)) & 1;
+                    char ch = on ? kBlock : ' ';
+                    for (int sx = 0; sx < scale; ++sx) {
+                        if (outCol < (int)sizeof(rowbuf) - 1) {
+                            rowbuf[outCol++] = ch;
+                        }
+                    }
+                }
+                // Inter-glyph gap.
+                for (int sx = 0; sx < scale; ++sx) {
+                    if (outCol < (int)sizeof(rowbuf) - 1) {
+                        rowbuf[outCol++] = ' ';
+                    }
+                }
+            }
+            rowbuf[outCol] = 0;
+            int textRow = row + gy * scale + sy;
+            bgfx::dbgTextPrintf(col, textRow, color, "%s", rowbuf);
+        }
+    }
+    (void)strideCols;
+}
+
+}  // namespace
+
+int main(int /*argc*/, char* /*argv*/[]) {
+    ge::run([&](ge::Context /*ctx*/) -> ge::RunConfig {
+        bgfx::setDebug(BGFX_DEBUG_TEXT);
+        return {
+            .onUpdate = [&](float /*dt*/) {},
+            .onRender = [&](int w, int h) {
+                bgfx::setViewClear(0, BGFX_CLEAR_COLOR, 0xff00ffff, 1.0f, 0);  // diag: magenta clear
+                bgfx::setViewRect(0, 0, 0, (uint16_t)w, (uint16_t)h);
+                bgfx::touch(0);
+                bgfx::dbgTextClear();
+
+                int cols = w / 8;     // dbgText cell is 8x16 px
+                int rows = h / 16;
+
+                // Pick the largest scale that fits 3 lines of "X: +9.99"
+                // (8 chars wide, 5+1=6 glyph-cols each = 48 glyph-cols,
+                // plus 7 glyph-rows tall × 3 lines + gaps).
+                int maxScaleW = cols / (8 * 6);              // 48 glyph-cols
+                int maxScaleH = rows / (3 * (7 + 2));        // 3 lines, 9 glyph-rows each
+                int scale = maxScaleW < maxScaleH ? maxScaleW : maxScaleH;
+                if (scale < 1) scale = 1;
+
+                int blockW = 8 * 6 * scale;
+                int blockH = 3 * (7 + 2) * scale;
+                int col0 = (cols - blockW) / 2;
+                int row0 = (rows - blockH) / 2;
+                if (col0 < 0) col0 = 0;
+                if (row0 < 0) row0 = 0;
+
+                char line[32];
+                for (int axis = 0; axis < 3; ++axis) {
+                    char label = "XYZ"[axis];
+                    std::snprintf(line, sizeof(line), "%c: %+05.1f", label, g_data[axis]);
+                    int r = row0 + axis * (7 + 2) * scale;
+                    drawBig(r, col0, line, scale, 0x0F);
+                }
+            },
+            .onEvent = [&](const SDL_Event& e) {
+                if (e.type == SDL_EVENT_SENSOR_UPDATE) {
+                    g_data[0] = e.sensor.data[0];
+                    g_data[1] = e.sensor.data[1];
+                    g_data[2] = e.sensor.data[2];
+                }
+            },
+            .onShutdown = [] {},
+        };
+    }, {
+        .width = 1024, .height = 768,
+        .headless = false,
+        .appName = "tiltcal",
+        .sensors = wire::kSensorAccelerometer,
+        .orientation = 0,  // no lock
+        .disableScreenSaver = true,
+    });
+}

--- a/src/BgfxContext.mm
+++ b/src/BgfxContext.mm
@@ -3,7 +3,8 @@
 //
 // Platform-specific bgfx init:
 //   Apple (macOS, iOS)  → Metal backend via CAMetalLayer
-//   Android             → OpenGL ES 3.1 backend via SDL's ANativeWindow
+//   Android (real)      → OpenGL ES 3.1 backend (Adreno/Mali Vulkan stalls)
+//   Android (emulator)  → Vulkan backend (Apple-Silicon AVD EGL is only 3.0)
 //
 // Kept in a single .mm file with #ifdef branches so the public API
 // (BgfxContext) stays identical across platforms. On Android, the build
@@ -26,6 +27,11 @@
 #if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
 #endif
+#endif
+
+#if defined(__ANDROID__)
+#include <sys/system_properties.h>
+#include <cstring>
 #endif
 
 namespace ge {
@@ -127,14 +133,29 @@ BgfxContext::BgfxContext(const BgfxConfig& config)
         }
     }
 #elif defined(__ANDROID__)
-    // Vulkan on Android. bgfx loads libvulkan.so dynamically and creates
-    // its own swap-chain from the ANativeWindow*. This avoids the EGL GLES
-    // path entirely, which is necessary because the Android emulator's
-    // Apple-Metal-backed EGL translator only supports GLES 3.0 — requesting
-    // a 3.1 context triggers EGL_BAD_CONFIG → bgfx fatal on all AVDs running
-    // on macOS Apple Silicon. SPIRV shaders (compiled with -p spirv) bypass
-    // the glsl-optimizer and work cleanly with the Vulkan backend.
-    init.type = bgfx::RendererType::Vulkan;
+    // Renderer choice on Android is mutually-exclusive between two
+    // failure modes — pick at runtime:
+    //
+    //   * Real Adreno / Mali devices: bgfx's Vulkan path stalls after
+    //     the first present (Adreno 830 documented in
+    //     docs/papers/adreno-830-bgfx-vulkan-crash.md; Mali shows the
+    //     same symptom). OpenGL ES is the working path.
+    //   * Apple-Silicon AVD emulator: Android's Apple-Metal-backed EGL
+    //     translator only exposes GLES 3.0; requesting GLES 3.1 (which
+    //     bgfx needs to compile its draw-call streams) trips
+    //     EGL_BAD_CONFIG → bgfx fatal. Vulkan is the working path.
+    //
+    // Both bgfx backends are compiled in (see template CMakeLists);
+    // we just steer init.type via Android system properties.
+    char qemu[PROP_VALUE_MAX] = {};
+    char hw[PROP_VALUE_MAX]   = {};
+    __system_property_get("ro.kernel.qemu", qemu);
+    __system_property_get("ro.hardware",    hw);
+    const bool isEmulator = (qemu[0] == '1') ||
+                            (std::strcmp(hw, "ranchu") == 0) ||
+                            (std::strcmp(hw, "goldfish") == 0);
+    init.type = isEmulator ? bgfx::RendererType::Vulkan
+                           : bgfx::RendererType::OpenGLES;
 
     const char* title = (config.title && *config.title) ? config.title : "ge";
     // Android: ask for a fullscreen surface. Passing non-fullscreen

--- a/src/BgfxContext.mm
+++ b/src/BgfxContext.mm
@@ -50,7 +50,7 @@ BgfxContext::BgfxContext(const BgfxConfig& config)
 
     ge::installSignalHandlers();
 
-    if (!SDL_Init(SDL_INIT_VIDEO)) {
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_SENSOR)) {
         SPDLOG_ERROR("SDL_Init failed: {}", SDL_GetError());
         return;
     }

--- a/src/BgfxContext.mm
+++ b/src/BgfxContext.mm
@@ -40,6 +40,8 @@ struct BgfxContext::M {
     int width, height;
     bool headless;
     SDL_Window* window = nullptr;
+    uint32_t resetFlags = 0;  // remembered for onForeground() rebuild
+    bool paused = false;      // true between onBackground / onForeground
 
     ~M() {
         bgfx::shutdown();
@@ -199,7 +201,8 @@ BgfxContext::BgfxContext(const BgfxConfig& config)
 
     // Backbuffer/swap-chain resize after init. On Android Vulkan the
     // native window size isn't fully reflected until reset() is called.
-    bgfx::reset(m->width, m->height, init.resolution.reset);
+    m->resetFlags = init.resolution.reset;
+    bgfx::reset(m->width, m->height, m->resetFlags);
 
     SPDLOG_INFO("BgfxContext: {}x{} {} {}",
                 m->width, m->height,
@@ -218,5 +221,42 @@ int BgfxContext::width() const { return m->width; }
 int BgfxContext::height() const { return m->height; }
 bool BgfxContext::shouldQuit() const { return ge::shouldQuit(); }
 SDL_Window* BgfxContext::window() const { return m->window; }
+bool BgfxContext::paused() const { return m->paused; }
+
+void BgfxContext::onBackground() {
+    // No-op on Apple — the CAMetalLayer survives backgrounding and
+    // rendering can resume on foreground without a swap-chain rebuild.
+    // On Android, just flip the flag; the host will skip beginFrame /
+    // endFrame and SDL3 will block the main loop until foreground anyway.
+    m->paused = true;
+    SPDLOG_INFO("BgfxContext: backgrounded (paused)");
+}
+
+void BgfxContext::onForeground() {
+#if defined(__ANDROID__)
+    // Re-fetch the new ANativeWindow from SDL — the old one is invalid
+    // because SurfaceView destroyed the surface during background.
+    if (m->window) {
+        SDL_PropertiesID props = SDL_GetWindowProperties(m->window);
+        void* nwh = SDL_GetPointerProperty(props,
+            SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER, nullptr);
+        if (nwh) {
+            bgfx::PlatformData pd{};
+            pd.nwh = nwh;
+            bgfx::setPlatformData(pd);
+        }
+        // Pick up any resize the OS may have applied while we were away.
+        int w = 0, h = 0;
+        if (SDL_GetWindowSizeInPixels(m->window, &w, &h) && w > 0 && h > 0) {
+            m->width = w;
+            m->height = h;
+        }
+        bgfx::reset(uint32_t(m->width), uint32_t(m->height), m->resetFlags);
+        SPDLOG_INFO("BgfxContext: foregrounded, swap-chain rebuilt {}x{}",
+                    m->width, m->height);
+    }
+#endif
+    m->paused = false;
+}
 
 } // namespace ge

--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -1,5 +1,6 @@
 #include <ge/Resource.h>
 #include <SDL3/SDL.h>
+#include <bgfx/bgfx.h>
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif
@@ -34,6 +35,29 @@ std::string resource(const std::string& relativePath) {
     }();
 
     return base + relativePath;
+}
+
+namespace {
+const char* shaderProfileSuffix() {
+#if defined(__ANDROID__)
+    switch (bgfx::getRendererType()) {
+    case bgfx::RendererType::Vulkan:   return "-spirv";
+    case bgfx::RendererType::OpenGLES: return "-gles";
+    default: break;  // shouldn't happen on Android
+    }
+    return "-gles";   // safer fallback (no SPIR-V mismatch)
+#else
+    return "";        // Apple → Metal, single canonical "shaders/" dir
+#endif
+}
+}
+
+std::string shaderDir() {
+    return std::string("build/shaders") + shaderProfileSuffix();
+}
+
+std::string renderShaderDir() {
+    return std::string("build/ge/shaders") + shaderProfileSuffix();
 }
 
 } // namespace ge

--- a/src/SessionHost.mm
+++ b/src/SessionHost.mm
@@ -73,6 +73,18 @@ static void runDirect(Factory factory, const SessionHostConfig& config) {
         last = now;
         if (dt > 0.1f) dt = 0.1f;
 
+        // While the host is paused (Android backgrounded, swap chain
+        // torn down), skip the entire render bracket — bgfx::frame()
+        // against a dead surface crashes. SDL3 also blocks the main
+        // loop on Android during background, but we belt-and-brace the
+        // gate here. Game's onUpdate keeps running so timers don't
+        // freeze; reset `last` so the first foreground frame doesn't
+        // see a multi-second dt.
+        if (host.paused()) {
+            last = SDL_GetPerformanceCounter();
+            continue;
+        }
+
         if (rc.onUpdate) rc.onUpdate(dt);
 
         host.beginFrame();

--- a/src/render/AccelSynth.h
+++ b/src/render/AccelSynth.h
@@ -5,6 +5,10 @@
 // mouse motion when no real accelerometer is available (desktop, iOS
 // simulator, Android emulator).
 //
+// On iOS sim and Android emu, the mouse button must also be held — the
+// platforms only deliver motion via touch synthesis, which requires a
+// "finger down". On desktop, the button is irrelevant.
+//
 // Belongs to the render subsystem. Both DirectRenderHost (in-process)
 // and the player binary's render loop use it. The engine subsystem
 // only ever sees SDL_EVENT_SENSOR_UPDATE events; whether they originate
@@ -19,6 +23,11 @@
 #pragma once
 
 #include <SDL3/SDL.h>
+#include <spdlog/spdlog.h>  // TEMP: T28.3 diagnostic
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 #include <cmath>
 #include <functional>
@@ -50,15 +59,29 @@ public:
     // Returns true if the event was consumed by the synthesis (caller
     // should NOT forward it). Returns false if the event passes through.
     bool handle(const SDL_Event& e) {
+        // TEMP: T28.3 diagnostic — log key/mouse events to verify arrival
+        if (e.type == SDL_EVENT_KEY_DOWN || e.type == SDL_EVENT_KEY_UP ||
+            e.type == SDL_EVENT_MOUSE_MOTION || e.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+            e.type == SDL_EVENT_MOUSE_BUTTON_UP) {
+            SPDLOG_INFO("AccelSynth: event type=0x{:x} shiftDown={}", e.type, shiftDown_);
+        }
+
         if ((e.type == SDL_EVENT_KEY_DOWN || e.type == SDL_EVENT_KEY_UP)
             && (e.key.scancode == SDL_SCANCODE_LSHIFT ||
                 e.key.scancode == SDL_SCANCODE_RSHIFT)) {
             const bool newShift = (e.type == SDL_EVENT_KEY_DOWN);
             if (newShift != shiftDown_) {
                 shiftDown_ = newShift;
+                SPDLOG_INFO("AccelSynth: shift {}", shiftDown_);  // TEMP: T28.3 diagnostic
+                // Relative mouse mode pins the cursor so drag can continue
+                // past the window edge (desktop). On iOS simulator it causes
+                // a stuck-touch indicator when the mouse button is released,
+                // and motion is delivered via touch synthesis anyway — skip.
+#if !(defined(__APPLE__) && TARGET_OS_IOS)
                 if (window_) {
                     SDL_SetWindowRelativeMouseMode(window_, shiftDown_);
                 }
+#endif
                 if (shiftDown_) {
                     // Fresh capture — start from zero, no easing.
                     tilt_ = {};
@@ -75,6 +98,8 @@ public:
         if (e.type == SDL_EVENT_MOUSE_MOTION && shiftDown_) {
             tilt_.x += e.motion.xrel;
             tilt_.y += e.motion.yrel;
+            SPDLOG_INFO("AccelSynth: motion xrel={} yrel={} tilt=({},{})",  // TEMP: T28.3 diagnostic
+                        e.motion.xrel, e.motion.yrel, tilt_.x, tilt_.y);
             emitSensorFromTilt();
             return true;  // consume motion-while-tilting
         }
@@ -130,6 +155,7 @@ private:
             gx =  kG * s * tilt_.x / mag;
             gy = -kG * s * tilt_.y / mag;
         }
+        SPDLOG_INFO("AccelSynth: emit g=({},{})", gx, gy);  // TEMP: T28.3 diagnostic
         SDL_Event se{};
         se.type = SDL_EVENT_SENSOR_UPDATE;
         se.sensor.data[0] = gx;

--- a/src/render/DirectRenderHost.h
+++ b/src/render/DirectRenderHost.h
@@ -26,6 +26,7 @@ public:
     int width() const override;
     int height() const override;
     DeviceClass deviceClass() const override;
+    bool paused() const override;
 
     void send(const wire::SessionConfig&) override;
     void setEventHandler(std::function<void(const SDL_Event&)>) override;

--- a/src/render/DirectRenderHost.mm
+++ b/src/render/DirectRenderHost.mm
@@ -235,6 +235,7 @@ DirectRenderHost::~DirectRenderHost() {
 int DirectRenderHost::width() const  { return i_->width; }
 int DirectRenderHost::height() const { return i_->height; }
 DeviceClass DirectRenderHost::deviceClass() const { return DeviceClass::Desktop; }
+bool DirectRenderHost::paused() const { return i_->bgfxCtx && i_->bgfxCtx->paused(); }
 
 void DirectRenderHost::send(const wire::SessionConfig& cfg) {
     // iPadOS 26 ignores Info.plist orientation restrictions on iPad — the
@@ -257,6 +258,35 @@ void DirectRenderHost::pumpEvents() {
     while (SDL_PollEvent(&e)) {
         if (e.type == SDL_EVENT_QUIT) {
             i_->quit = true;
+            continue;
+        }
+        // Activity lifecycle on Android. SDL3 doesn't deliver the
+        // higher-level SDL_EVENT_DID_ENTER_BACKGROUND/_FOREGROUND
+        // events to the C side on Android (only iOS); we use the
+        // window-level focus + minimize/restore events instead.
+        // FOCUS_LOST is the earliest signal we get when the activity
+        // starts backgrounding — gate bgfx immediately to avoid the
+        // BLAST BufferQueue-abandoned spam from a dead surface.
+        // RESTORED / FOCUS_GAINED is the resumption signal — re-acquire
+        // the new ANativeWindow and rebuild the swap chain.
+        // Both no-op on Apple (BgfxContext::onForeground is #if Android).
+        if (e.type == SDL_EVENT_WINDOW_FOCUS_LOST ||
+            e.type == SDL_EVENT_WINDOW_HIDDEN     ||
+            e.type == SDL_EVENT_WINDOW_MINIMIZED) {
+            i_->bgfxCtx->onBackground();
+            continue;
+        }
+        if (e.type == SDL_EVENT_WINDOW_RESTORED   ||
+            e.type == SDL_EVENT_WINDOW_FOCUS_GAINED ||
+            e.type == SDL_EVENT_WINDOW_SHOWN) {
+            i_->bgfxCtx->onForeground();
+            // bgfxCtx may have picked up a resized backbuffer; sync our
+            // view of it so the next frame's viewports match.
+            i_->width  = i_->bgfxCtx->width();
+            i_->height = i_->bgfxCtx->height();
+            // Offscreen pipeline references the old swap chain — drop it
+            // so it's recreated on demand against the new backbuffer.
+            i_->destroyOffscreen();
             continue;
         }
         // Any event that could signal a drawable-size change. On iOS the
@@ -293,6 +323,13 @@ void DirectRenderHost::pumpEvents() {
 }
 
 void DirectRenderHost::beginFrame() {
+    // While the activity is backgrounded the swap chain is gone (Android)
+    // and any bgfx::reset / view setup we do here will reference a stale
+    // ANativeWindow and crash on next bgfx::frame(). Skip everything; SDL3
+    // also blocks the main loop on Android during background, so this
+    // path is mostly a no-op until the OS resumes us.
+    if (i_->bgfxCtx->paused()) return;
+
     // Apply any staged resize at the frame boundary so all bgfx state
     // (backbuffer, offscreen RT, view rects) moves together.
     if (i_->pendingResize) {

--- a/src/render/DirectRenderHost.mm
+++ b/src/render/DirectRenderHost.mm
@@ -9,6 +9,8 @@
 #include <ge/Resource.h>
 #include <ge/Signal.h>
 
+#include "../../tools/player_orientation.h"
+
 #include <iterator>
 #include <vector>
 
@@ -72,6 +74,7 @@ struct DirectRenderHost::Impl {
     bool quit = false;
 
     std::optional<AccelSynth> synth;
+    SDL_Sensor* accelSensor = nullptr;
 
     // Offscreen pipeline — lazily created on first non-zero tilt.
     bool offscreenReady = false;
@@ -153,17 +156,38 @@ DirectRenderHost::DirectRenderHost(const SessionHostConfig& config)
     if (i_->bgfxCtx->width()  > 0) i_->width  = i_->bgfxCtx->width();
     if (i_->bgfxCtx->height() > 0) i_->height = i_->bgfxCtx->height();
 
-    if ((config.sensors & wire::kSensorAccelerometer) &&
-        !AccelSynth::realSensorAvailable()) {
-        i_->synth.emplace();
-        i_->synth->setWindow(i_->bgfxCtx->window());
-        SPDLOG_INFO("DirectRenderHost: Shift-mouse accelerometer synthesis enabled");
+    if (config.sensors & wire::kSensorAccelerometer) {
+        // Try a real sensor first (real device, Android emulator virtual sensors).
+        int count = 0;
+        SDL_SensorID* sensors = SDL_GetSensors(&count);
+        if (sensors) {
+            for (int k = 0; k < count; k++) {
+                if (SDL_GetSensorTypeForID(sensors[k]) == SDL_SENSOR_ACCEL) {
+                    i_->accelSensor = SDL_OpenSensor(sensors[k]);
+                    if (i_->accelSensor) {
+                        SPDLOG_INFO("DirectRenderHost: opened real accelerometer");
+                        break;
+                    }
+                }
+            }
+            SDL_free(sensors);
+        }
+        // Fall back to Shift-mouse synthesis.
+        if (!i_->accelSensor) {
+            i_->synth.emplace();
+            i_->synth->setWindow(i_->bgfxCtx->window());
+            SPDLOG_INFO("DirectRenderHost: Shift-mouse accelerometer synthesis enabled");
+        }
     }
 
     SPDLOG_INFO("DirectRenderHost: {}x{}", i_->width, i_->height);
 }
 
 DirectRenderHost::~DirectRenderHost() {
+    if (i_->accelSensor) {
+        SDL_CloseSensor(i_->accelSensor);
+        i_->accelSensor = nullptr;
+    }
     i_->destroyOffscreen();
 }
 
@@ -171,8 +195,12 @@ int DirectRenderHost::width() const  { return i_->width; }
 int DirectRenderHost::height() const { return i_->height; }
 DeviceClass DirectRenderHost::deviceClass() const { return DeviceClass::Desktop; }
 
-void DirectRenderHost::send(const wire::SessionConfig&) {
-    // Direct mode applies orientation/sensor hints in-process; no-op for now.
+void DirectRenderHost::send(const wire::SessionConfig& cfg) {
+    // iPadOS 26 ignores Info.plist orientation restrictions on iPad — the
+    // only working lock is the prefersInterfaceOrientationLocked swizzle in
+    // player_orientation_ios.mm. See ge/CLAUDE.md "iOS orientation lock".
+    playerForceOrientation(cfg.orientation);  // 0 = no-op
+    // Sensors are opened in the constructor from SessionHostConfig.
 }
 
 void DirectRenderHost::setEventHandler(std::function<void(const SDL_Event&)> h) {

--- a/src/render/DirectRenderHost.mm
+++ b/src/render/DirectRenderHost.mm
@@ -47,6 +47,47 @@ bgfx::VertexLayout composeLayout() {
     return l;
 }
 
+// Rotate a 3-axis accelerometer sample from the device-hardware frame
+// (SDL3's reported convention: +X = physical right edge up, +Y = physical
+// top edge up, +Z = screen up) into the game's screen frame.
+//
+// The rotation is keyed on the LIVE display orientation reported by SDL
+// (SDL_GetCurrentDisplayOrientation) — not on SessionConfig.orientation,
+// which only records what the app *requested*. The live value reflects
+// what the OS actually rotated to (post-lock-if-honoured, or the live
+// rotation when no lock was requested), so this stays correct in both
+// locked and free-orientation modes and across the brief window between
+// a lock request and the OS settling.
+//
+// Touch and mouse coordinates are NOT rotated — both iOS and Android
+// already deliver those in the rotated UI frame. Accelerometer is the
+// outlier because the sensor chip is fixed to the chassis and has no
+// notion of UI orientation. Z (out of screen) is invariant under any
+// in-plane UI rotation, so it passes through.
+//
+// Each case is a 2D rotation expressed as a swap-and-sign on (x, y):
+//
+//   Portrait        identity            ( x,  y)
+//   Landscape       device rotated CW   (-y,  x)
+//   PortraitFlipped device upside down  (-x, -y)
+//   LandscapeFlip   device rotated CCW  ( y, -x)
+void rotateAccelToScreen(SDL_DisplayOrientation orient, float d[/*≥3*/]) {
+    const float x = d[0];
+    const float y = d[1];
+    switch (orient) {
+    case SDL_ORIENTATION_LANDSCAPE:
+        d[0] = -y; d[1] =  x; break;
+    case SDL_ORIENTATION_LANDSCAPE_FLIPPED:
+        d[0] =  y; d[1] = -x; break;
+    case SDL_ORIENTATION_PORTRAIT_FLIPPED:
+        d[0] = -x; d[1] = -y; break;
+    case SDL_ORIENTATION_PORTRAIT:
+    case SDL_ORIENTATION_UNKNOWN:
+    default:
+        break;  // identity — fall back to device frame on unknown
+    }
+}
+
 bgfx::ShaderHandle loadShader(const char* path) {
     auto stream = ge::openFile(path, /*binary=*/true);
     if (!stream || !*stream) {
@@ -114,8 +155,8 @@ struct DirectRenderHost::Impl {
         bgfx::TextureHandle atts[] = { colorTex, depthTex };
         offFB = bgfx::createFrameBuffer(2, atts, /*destroyTextures=*/false);
 
-        bgfx::ShaderHandle vs = loadShader(ge::resource("build/ge/shaders/ge_compose_vs.bin").c_str());
-        bgfx::ShaderHandle fs = loadShader(ge::resource("build/ge/shaders/ge_compose_fs.bin").c_str());
+        bgfx::ShaderHandle vs = loadShader(ge::resource(ge::renderShaderDir() + "/ge_compose_vs.bin").c_str());
+        bgfx::ShaderHandle fs = loadShader(ge::resource(ge::renderShaderDir() + "/ge_compose_fs.bin").c_str());
         if (!bgfx::isValid(vs) || !bgfx::isValid(fs)) {
             SPDLOG_ERROR("DirectRenderHost: compose shaders missing — viewport tilt disabled");
             return;
@@ -201,6 +242,9 @@ void DirectRenderHost::send(const wire::SessionConfig& cfg) {
     // player_orientation_ios.mm. See ge/CLAUDE.md "iOS orientation lock".
     playerForceOrientation(cfg.orientation);  // 0 = no-op
     // Sensors are opened in the constructor from SessionHostConfig.
+    // Sensor-frame rotation is keyed on the LIVE display orientation in
+    // pumpEvents — cfg.orientation is just the lock request, not ground
+    // truth, and tells us nothing in the no-lock case.
 }
 
 void DirectRenderHost::setEventHandler(std::function<void(const SDL_Event&)> h) {
@@ -233,6 +277,17 @@ void DirectRenderHost::pumpEvents() {
             continue;
         }
         if (i_->synth && i_->synth->handle(e)) continue;
+        // Rotate real-sensor accel into screen frame using the live
+        // display orientation. AccelSynth events bypass — they arrive
+        // via setEmit() callback, already in screen frame
+        // (mouse-displacement physics).
+        if (e.type == SDL_EVENT_SENSOR_UPDATE) {
+            SDL_DisplayOrientation o = SDL_ORIENTATION_UNKNOWN;
+            if (SDL_DisplayID disp = SDL_GetDisplayForWindow(i_->bgfxCtx->window())) {
+                o = SDL_GetCurrentDisplayOrientation(disp);
+            }
+            rotateAccelToScreen(o, e.sensor.data);
+        }
         if (i_->eventHandler) i_->eventHandler(e);
     }
 }

--- a/tools/android-template/app/build.gradle.in
+++ b/tools/android-template/app/build.gradle.in
@@ -55,17 +55,20 @@ android {
     }
 }
 
-// Sync game data + compiled SPIRV shaders into APK assets before building.
-// The host-side build compiles shaders for multiple profiles:
+// Sync game data + compiled shaders into APK assets before building.
+// The host-side build compiles shaders into per-profile dirs:
 //   build/shaders/        — Metal bytecode (macOS / iOS)
-//   build/shaders-gles/   — SPIRV (Android Vulkan backend)
-// We consume the SPIRV variant but place it under assets/build/shaders/
-// so the runtime lookup via ge::resource("build/shaders/...") keeps
-// working unchanged across platforms.
+//   build/shaders-spirv/  — SPIR-V (Android Vulkan backend, used on emulator)
+//   build/shaders-gles/   — OpenGL ES 3.1 (Android GLES backend, real devices)
+// The APK ships BOTH Android variants; engine helper ge::shaderDir()
+// picks the right path at runtime based on the bgfx renderer that
+// BgfxContext.mm selected for this device.
 tasks.register('syncAssets', Sync) {
-    from("${rootDir}/../data")                  { into('data') }
-    from("${rootDir}/../build/shaders-gles")    { into('build/shaders') }
-    from("${rootDir}/../build/ge/shaders-gles") { into('build/ge/shaders') }
+    from("${rootDir}/../data")                   { into('data') }
+    from("${rootDir}/../build/shaders-spirv")    { into('build/shaders-spirv') }
+    from("${rootDir}/../build/ge/shaders-spirv") { into('build/ge/shaders-spirv') }
+    from("${rootDir}/../build/shaders-gles")     { into('build/shaders-gles') }
+    from("${rootDir}/../build/ge/shaders-gles")  { into('build/ge/shaders-gles') }
     into('src/main/assets')
 }
 preBuild.dependsOn('syncAssets')

--- a/tools/android-template/app/src/main/cpp/CMakeLists.txt.in
+++ b/tools/android-template/app/src/main/cpp/CMakeLists.txt.in
@@ -60,9 +60,17 @@ target_link_libraries(bgfx PUBLIC bx bimg)
 #     docs/papers/adreno-830-bgfx-vulkan-crash.md).
 #   * Apple-Silicon AVD emulator → Vulkan (the AVD's Apple-Metal-backed EGL
 #     translator exposes only GLES 3.0, so a 3.1 request fails).
+#
+# Single-threaded mode is non-negotiable on Android: bgfx's default
+# multi-thread mode spawns a render thread that keeps hammering the
+# SurfaceView's BufferQueue after the activity backgrounds (the queue
+# is "abandoned" but bgfx's thread doesn't know). Forcing single-thread
+# routes every bgfx call through the main thread, which our SDL3
+# DID_ENTER_BACKGROUND handler can gate cleanly via BgfxContext::paused().
 target_compile_definitions(bgfx PUBLIC
     BGFX_CONFIG_RENDERER_VULKAN=1
     BGFX_CONFIG_RENDERER_OPENGLES=31
+    BGFX_CONFIG_MULTITHREADED=0
 )
 
 # ── Box2D (vendored C code) ─────────────────────────────────────────────

--- a/tools/android-template/app/src/main/cpp/CMakeLists.txt.in
+++ b/tools/android-template/app/src/main/cpp/CMakeLists.txt.in
@@ -55,15 +55,15 @@ target_include_directories(bgfx PRIVATE
     ${BGFX_DIR}/src
 )
 target_link_libraries(bgfx PUBLIC bx bimg)
-# Vulkan-only build: explicitly select Vulkan so bgfx skips the auto-detect
-# block that would otherwise enable both GLES (=30) and Vulkan together.
-# With BGFX_CONFIG_RENDERER_VULKAN=1 defined, the entire auto-detect block
-# (lines 22-120 of config.h) is bypassed; GLES defaults to 0, so no EGL/GLES
-# symbols are compiled in and we don't need to link against EGL or GLESv3.
-# Do NOT add BGFX_CONFIG_RENDERER_OPENGLES — the Android emulator's
-# Apple-Metal-backed EGL translator only exposes GLES 3.0, so any GLES 3.1
-# context request triggers EGL_BAD_CONFIG → bgfx fatal.
-target_compile_definitions(bgfx PUBLIC BGFX_CONFIG_RENDERER_VULKAN=1)
+# Compile in BOTH backends. BgfxContext.mm picks one at runtime per device:
+#   * Real Adreno / Mali devices → OpenGL ES 3.1 (Vulkan path stalls; see
+#     docs/papers/adreno-830-bgfx-vulkan-crash.md).
+#   * Apple-Silicon AVD emulator → Vulkan (the AVD's Apple-Metal-backed EGL
+#     translator exposes only GLES 3.0, so a 3.1 request fails).
+target_compile_definitions(bgfx PUBLIC
+    BGFX_CONFIG_RENDERER_VULKAN=1
+    BGFX_CONFIG_RENDERER_OPENGLES=31
+)
 
 # ── Box2D (vendored C code) ─────────────────────────────────────────────
 set(BOX2D_DIR ${GE_ROOT}/vendor/github.com/erincatto/box2d)
@@ -85,6 +85,7 @@ set(GE_SOURCES
     ${GE_ROOT}/src/Signal.cpp
     ${GE_ROOT}/src/SessionHost.mm
     ${GE_ROOT}/src/render/DirectRenderHost.mm
+    ${GE_ROOT}/tools/player_orientation_stub.cpp
     ${GE_ROOT}/vendor/src/sqlite3.c
     ${GE_ROOT}/vendor/src/sqlpipe.cpp  # embeds sqlift — do NOT add sqlift.cpp
     ${GE_ROOT}/vendor/src/lz4.c
@@ -139,6 +140,7 @@ target_link_libraries(main PRIVATE
     bgfx box2d
     SDL3::SDL3
     # Vulkan is loaded dynamically by bgfx (libvulkan.so); no explicit link.
-    # EGL and GLESv3 are not needed since we use the Vulkan renderer.
+    # EGL + GLESv3 are needed for the GLES backend used on real devices.
+    EGL GLESv3
     android log z
 )

--- a/tools/android-template/gradle.properties
+++ b/tools/android-template/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
+org.gradle.configuration-cache=true

--- a/tools/ios-template/CMakeLists.txt.in
+++ b/tools/ios-template/CMakeLists.txt.in
@@ -71,6 +71,7 @@ set(GE_SOURCES
     ${GE_ROOT}/src/Signal.cpp
     ${GE_ROOT}/src/SessionHost.mm
     ${GE_ROOT}/src/render/DirectRenderHost.mm
+    ${GE_ROOT}/tools/player_orientation_ios.mm
     ${GE_ROOT}/vendor/src/sqlite3.c
     # sqlpipe.cpp embeds the sqlift implementation — do not add sqlift.cpp
     # here or you'll get duplicate-symbol link errors.

--- a/tools/ios-template/Info.plist.in
+++ b/tools/ios-template/Info.plist.in
@@ -17,12 +17,26 @@
     <string>$(EXECUTABLE_NAME)</string>
     <key>UILaunchScreen</key>
     <dict/>
+    <!-- This list and the prefersInterfaceOrientationLocked swizzle in
+         ge/tools/player_orientation_ios.mm WORK TOGETHER. Neither alone
+         locks orientation on iPadOS 26+; both are needed:
+           * This list bounds supportedInterfaceOrientations. UIKit
+             consults it at launch (rotating to a supported orientation
+             if the device is held in an unsupported one) and uses it
+             as the bound on prefersInterfaceOrientationLocked. iPad
+             multitasking ignores it as a hard runtime restriction
+             (apps remain resizable), but the launch orientation and
+             the swizzle's lock target both come from here.
+           * The swizzle (Apple TN3192) prevents the user from
+             swivelling out of the locked orientation during play.
+         History: e0da016 was the failed "plist alone" experiment;
+         5c2f2a5 added the swizzle that completes the picture.
+         If you change this list, you change BOTH the launch orientation
+         and what the swizzle can lock to. -->
     <key>UISupportedInterfaceOrientations</key>
     <array>
-        <string>UIInterfaceOrientationPortrait</string>
         <string>UIInterfaceOrientationLandscapeLeft</string>
         <string>UIInterfaceOrientationLandscapeRight</string>
-        <string>UIInterfaceOrientationPortraitUpsideDown</string>
     </array>
     <key>UIApplicationSupportsIndirectInputEvents</key>
     <true/>

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -982,6 +982,7 @@ LAUNCH_PID=""    # desktop only; sim/emu/device don't give us a local PID
 SIM_UDID=""      # set by ios launch helpers
 ANDROID_SERIAL=""  # set by android launch helpers
 DESKTOP_BIN=""   # overridden by debug cells to point at bin/$APP_NAME-debug
+SERVER_ARGS=""   # extra args passed to the desktop server; player cells set --brokered
 
 cold_launch_desktop() {
     local subcheck="cold-launch"
@@ -1362,7 +1363,8 @@ check_reconnect_desktop_player() {
     # Restart server.
     local serverlog="$ARTIFACTS/server-reconnect.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     # Wait for at least one session to be bridged to the new server.
@@ -1395,7 +1397,8 @@ check_reconnect_ios_sim_player() {
 
     local serverlog="$ARTIFACTS/server-reconnect.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     # Wait for at least one session to be bridged to the new server.
@@ -1427,7 +1430,8 @@ check_reconnect_android_player() {
 
     local serverlog="$ARTIFACTS/server-reconnect.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     # Wait for at least one session to be bridged to the new server.
@@ -1627,7 +1631,8 @@ check_reconnect_ios_device_player() {
     local baseline
     baseline=$(current_sessions)
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     if ! wait_for_sessions $((baseline + 1)); then
@@ -1776,7 +1781,8 @@ SERVER_PID=""
 start_server() {
     local logf="$ARTIFACTS/server.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$logf" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$logf" 2>&1 ) &
     SERVER_PID=$!
     sleep 2
 }
@@ -1808,6 +1814,7 @@ run_desktop_dist() {
 run_desktop_player() {
     build_player_desktop || { fail_check "cold-launch" "build failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
     cold_launch_player_desktop || { stop_server; return; }
     check_soak_desktop "$LAUNCH_PID" || true
@@ -1866,6 +1873,7 @@ run_ios_sim_player() {
     # Build and start desktop server.
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Pass ged address as launch arg so the player connects directly (no QR scan).
@@ -1908,6 +1916,7 @@ run_ios_device_player() {
     # Build and start desktop server.
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Physical device needs the host's LAN IP (not localhost) to reach ged.
@@ -1966,6 +1975,7 @@ run_android_emu_player() {
 
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Pass ged address as intent extra so the player connects directly (no QR scan).
@@ -2013,6 +2023,7 @@ run_android_device_player() {
 
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Physical device needs the host's LAN IP (not 10.0.2.2 which is emulator-only).
@@ -2091,6 +2102,7 @@ run_debug_player() {
             build_player_desktop_debug || { fail_check "cold-launch" "debug build failed"; return; }
             DESKTOP_BIN="$APP_DIR/bin/$APP_NAME-debug"
             ensure_ged
+            SERVER_ARGS="--brokered"
             start_server
             cold_launch_player_desktop || { stop_server; DESKTOP_BIN=""; return; }
             check_soak_desktop "$LAUNCH_PID" || true
@@ -2119,6 +2131,7 @@ run_debug_player() {
             build_desktop_debug || { fail_check "cold-launch" "debug server build failed"; return; }
             DESKTOP_BIN="$APP_DIR/bin/$APP_NAME-debug"
             ensure_ged
+            SERVER_ARGS="--brokered"
             start_server
             cold_launch_ios_sim "$PLAYER_BUNDLE_ID" "$app_path" "phone" \
                 "-ged_addr localhost:$GED_PORT" || { stop_server; DESKTOP_BIN=""; return; }
@@ -2138,6 +2151,7 @@ run_debug_player() {
             build_desktop_debug || { fail_check "cold-launch" "debug server build failed"; return; }
             DESKTOP_BIN="$APP_DIR/bin/$APP_NAME-debug"
             ensure_ged
+            SERVER_ARGS="--brokered"
             start_server
             cold_launch_android_emu "$PLAYER_ANDROID_PKG" "$apk" "" "$PLAYER_ANDROID_ACTIVITY" \
                 "--es ged_addr 10.0.2.2:$GED_PORT" || { stop_server; DESKTOP_BIN=""; return; }

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -15,13 +15,13 @@
 # Options:
 #   --app <dir>       App root dir (default: current dir).
 #   --timeout <s>     Sub-check timeout override.
-#                     Defaults: cold-launch=8s, soak=60s, debug-soak=10s.
+#                     Defaults: cold-launch=8s, soak=10s, long-soak=60s, debug-soak=10s.
 #   --capture-refs    Record reference screenshots instead of comparing.
 #   --rms <f>         Image-diff RMS threshold (default 0.08).
 #   --verbose         Echo sub-command output.
 #
 # Canonical cell names:
-#   desktop-dist  desktop-player
+#   desktop-dist  desktop-player  desktop-long-soak
 #   ios-sim-phone-dist  ios-sim-phone-player
 #   ios-sim-tablet-dist  ios-sim-tablet-player
 #   ios-device-phone-dist  ios-device-phone-player
@@ -33,6 +33,10 @@
 #   desktop-debug-dist  desktop-debug-player
 #   ios-debug-dist  ios-debug-player
 #   android-debug-dist  android-debug-player
+#
+# Environment variables for parallelism:
+#   GE_IOS_SIM_UDID        Pin a specific iOS simulator UDID for this cell.
+#   GE_ANDROID_EMU_SERIAL  Pin a specific Android emulator serial for this cell.
 #
 # Exit codes:
 #   0 — cell passed all applicable sub-checks
@@ -51,7 +55,8 @@ GE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CELL=""
 APP_DIR="$(pwd)"
 COLD_LAUNCH_TIMEOUT=8
-SOAK_TIMEOUT=60
+SOAK_TIMEOUT=10
+LONG_SOAK_TIMEOUT=60
 DEBUG_SOAK_TIMEOUT=10
 CAPTURE_REFS=0
 RMS=0.08
@@ -71,7 +76,7 @@ CELL="$1"; shift
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --app)          APP_DIR="$(cd "$2" && pwd)"; shift 2 ;;
-        --timeout)      COLD_LAUNCH_TIMEOUT="$2"; SOAK_TIMEOUT="$2"; shift 2 ;;
+        --timeout)      COLD_LAUNCH_TIMEOUT="$2"; SOAK_TIMEOUT="$2"; LONG_SOAK_TIMEOUT="$2"; shift 2 ;;
         --capture-refs) CAPTURE_REFS=1; shift ;;
         --rms)          RMS="$2"; shift 2 ;;
         --verbose)      VERBOSE=1; shift ;;
@@ -86,7 +91,7 @@ done
 # ── Validate cell name ───────────────────────────────────────────────
 
 ALL_CELLS=(
-    desktop-dist desktop-player
+    desktop-dist desktop-player desktop-long-soak
     ios-sim-phone-dist ios-sim-phone-player
     ios-sim-tablet-dist ios-sim-tablet-player
     ios-device-phone-dist ios-device-phone-player
@@ -121,9 +126,10 @@ FORM_FACTOR=""
 MODE=""
 
 case "$CELL" in
-    desktop-dist)         PLATFORM=desktop;  RUNTIME=release; FORM_FACTOR=none; MODE=dist   ;;
-    desktop-player)       PLATFORM=desktop;  RUNTIME=release; FORM_FACTOR=none; MODE=player ;;
-    desktop-debug-dist)   PLATFORM=desktop;  RUNTIME=debug;   FORM_FACTOR=none; MODE=dist   ;;
+    desktop-dist)         PLATFORM=desktop;  RUNTIME=release;   FORM_FACTOR=none; MODE=dist      ;;
+    desktop-player)       PLATFORM=desktop;  RUNTIME=release;   FORM_FACTOR=none; MODE=player    ;;
+    desktop-long-soak)    PLATFORM=desktop;  RUNTIME=long-soak; FORM_FACTOR=none; MODE=dist      ;;
+    desktop-debug-dist)   PLATFORM=desktop;  RUNTIME=debug;     FORM_FACTOR=none; MODE=dist      ;;
     desktop-debug-player) PLATFORM=desktop;  RUNTIME=debug;   FORM_FACTOR=none; MODE=player ;;
     ios-sim-phone-dist)   PLATFORM=ios;      RUNTIME=sim;     FORM_FACTOR=phone; MODE=dist   ;;
     ios-sim-phone-player) PLATFORM=ios;      RUNTIME=sim;     FORM_FACTOR=phone; MODE=player ;;
@@ -147,15 +153,17 @@ case "$CELL" in
     android-debug-player) PLATFORM=android;  RUNTIME=debug;   FORM_FACTOR=none; MODE=player ;;
 esac
 
-IS_DEBUG=0; [[ "$RUNTIME" == "debug" ]] && IS_DEBUG=1
-IS_SIM=0;   [[ "$RUNTIME" == "sim" ]]   && IS_SIM=1
-IS_EMU=0;   [[ "$RUNTIME" == "emu" ]]   && IS_EMU=1
-IS_DEVICE=0;[[ "$RUNTIME" == "device" ]] && IS_DEVICE=1
+IS_DEBUG=0;     [[ "$RUNTIME" == "debug" ]]     && IS_DEBUG=1
+IS_LONG_SOAK=0; [[ "$RUNTIME" == "long-soak" ]] && IS_LONG_SOAK=1
+IS_SIM=0;       [[ "$RUNTIME" == "sim" ]]        && IS_SIM=1
+IS_EMU=0;       [[ "$RUNTIME" == "emu" ]]        && IS_EMU=1
+IS_DEVICE=0;    [[ "$RUNTIME" == "device" ]]     && IS_DEVICE=1
 IS_MOBILE=0; [[ "$PLATFORM" == "ios" || "$PLATFORM" == "android" ]] && IS_MOBILE=1
 IS_PLAYER=0; [[ "$MODE" == "player" ]] && IS_PLAYER=1
 
 SOAK_TIME=$SOAK_TIMEOUT
-[[ $IS_DEBUG -eq 1 ]] && SOAK_TIME=$DEBUG_SOAK_TIMEOUT
+[[ $IS_DEBUG -eq 1 ]]     && SOAK_TIME=$DEBUG_SOAK_TIMEOUT
+[[ $IS_LONG_SOAK -eq 1 ]] && SOAK_TIME=$LONG_SOAK_TIMEOUT
 
 # ── Auto-detect app vars ─────────────────────────────────────────────
 
@@ -411,6 +419,13 @@ check_or_capture_ref() {
 # Writes UDID to stdout. Returns 1 if not available.
 ios_sim_get_udid() {
     local ff="${1:-}"   # phone or tablet
+
+    # If a specific UDID is pinned via environment (for parallelism), use it directly.
+    if [[ -n "${GE_IOS_SIM_UDID:-}" ]]; then
+        echo "$GE_IOS_SIM_UDID"
+        return 0
+    fi
+
     local filter=""
     case "$ff" in
         phone)  filter='test("iPhone"; "i")' ;;
@@ -631,6 +646,12 @@ host_lan_ip() {
 
 android_get_serial() {
     local ff="${1:-}"  # phone or tablet; empty = any emulator
+
+    # If a specific serial is pinned via environment (for parallelism), use it directly.
+    if [[ -n "${GE_ANDROID_EMU_SERIAL:-}" ]]; then
+        echo "$GE_ANDROID_EMU_SERIAL"
+        return 0
+    fi
 
     # Determine connected emulator serials.
     local serials
@@ -1796,6 +1817,16 @@ run_desktop_player() {
     LAUNCH_PID=""
 }
 
+run_desktop_long_soak() {
+    # Dedicated 60s soak cell: same as desktop-dist but with the long soak.
+    # SOAK_TIME is already set to LONG_SOAK_TIMEOUT for this cell.
+    build_desktop || { fail_check "cold-launch" "build failed"; return; }
+    cold_launch_desktop || return
+    check_soak_desktop "$LAUNCH_PID" || true
+    check_clean_exit_desktop "$LAUNCH_PID"
+    LAUNCH_PID=""
+}
+
 run_ios_sim_dist() {
     require_cmd xcrun "xcrun not found — Xcode not installed"
     [[ -d "$APP_DIR/ios" ]] || { fail_check "cold-launch" "no ios/ project (run make ge/ios-init)"; return; }
@@ -2130,6 +2161,7 @@ fi
 case "$CELL" in
     desktop-dist)              run_desktop_dist ;;
     desktop-player)            run_desktop_player ;;
+    desktop-long-soak)         run_desktop_long_soak ;;
     ios-sim-phone-dist)        run_ios_sim_dist ;;
     ios-sim-phone-player)      run_ios_sim_player ;;
     ios-sim-tablet-dist)       run_ios_sim_dist ;;

--- a/tools/player_orientation_ios.mm
+++ b/tools/player_orientation_ios.mm
@@ -5,6 +5,41 @@
 // This is Apple's official replacement for UIRequiresFullScreen (TN3192).
 // We swizzle UIViewController to override the property because SDL's
 // view controller doesn't know about our SessionConfig.
+//
+// HOW THE LOCK ACTUALLY WORKS — read this before "simplifying" anything.
+//
+// The swizzle below alone CANNOT force a specific orientation. All it can do
+// is freeze the current orientation against the user's swivel gesture, and
+// the orientation it freezes to is bounded by supportedInterfaceOrientations
+// (which on iPad UIKit derives from Info.plist UISupportedInterfaceOrientations).
+//
+// To get "always landscape, ignore device orientation at launch", you need
+// BOTH pieces:
+//   1. Narrow UISupportedInterfaceOrientations in Info.plist to just the
+//      orientations you want. UIKit rotates the UI to a supported orientation
+//      at launch if the device is held in an unsupported one. (iPad
+//      multitasking ignores this list as a runtime restriction — the user
+//      can still resize the window — but the launch rotation still happens
+//      and the swizzle's lock is bounded by it.)
+//   2. The swizzle below, which overrides
+//      UIViewController.prefersInterfaceOrientationLocked (Apple TN3192,
+//      iPadOS 26+) to return YES, locking the post-launch orientation
+//      against swivel.
+//
+// Things that DON'T work and should not be re-tried:
+//   * UIRequiresFullScreen                         — deprecated, ignored on iPad.
+//   * SDL_HINT_ORIENTATIONS                        — limits the supported set
+//                                                    only; no runtime force.
+//   * UIWindowScene requestGeometryUpdate          — silently no-ops on iPad.
+//   * setNeedsUpdateOfSupportedInterfaceOrientations alone — only flips
+//                                                    UIKit's view of the
+//                                                    supported set; doesn't
+//                                                    create a lock.
+// History: e0da016 reverted the "plist alone" experiment; 5c2f2a5 added
+// this swizzle. Both commits are needed context if you're touching this.
+//
+// Direct-render apps (DirectRenderHost) call playerForceOrientation from
+// DirectRenderHost::send when SessionConfig.orientation is non-zero.
 
 #include "player_orientation.h"
 


### PR DESCRIPTION
## Summary

- Cut default `SOAK_TIMEOUT` from 60s to 10s — all regular cells now use a 10s soak instead of 60s.
- Add `LONG_SOAK_TIMEOUT=60` used exclusively by the new `desktop-long-soak` cell (25th canonical cell), which runs the dedicated 60s reliability sweep.
- Add `GE_IOS_SIM_UDID` env var hook in `ios_sim_get_udid` and `GE_ANDROID_EMU_SERIAL` in `android_get_serial` — when set, they bypass auto-selection and target a specific simulator/emulator, enabling concurrent same-form-factor cells under `make -j check`.
- Module.mk: expose `GE_IOS_SIM_PHONE_UDID`, `GE_IOS_SIM_TABLET_UDID`, `GE_ANDROID_EMU_PHONE_SERIAL`, `GE_ANDROID_EMU_TABLET_SERIAL` make vars passed through cell rules so phone and tablet cells can run in parallel on distinct sims/emus when the user provides pinned identifiers.

## Acceptance criteria addressed

- [x] Per-cell soak sub-check runs for ~10s by default
- [x] A single dedicated long-soak cell (`desktop-long-soak`) runs the 60s sweep
- [x] Cells of the same platform/form-factor can run in parallel via distinct simulators/emulators (via `GE_IOS_SIM_PHONE_UDID`/`GE_IOS_SIM_TABLET_UDID` and `GE_ANDROID_EMU_PHONE_SERIAL`/`GE_ANDROID_EMU_TABLET_SERIAL`)
- [ ] Wall-clock under 8 minutes — requires primed caches and parallel execution with pinned sims/emus; structural changes are now in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)