### PR TITLE
ge: fix 🎯T25 reconnect sub-check — start server with --brokered in player cells

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -431,7 +431,7 @@ targets:
     achieved: 2026-04-19
   T25:
     name: Player-mode cells pass the reconnect sub-check on iOS sim and Android emu
-    status: identified
+    status: converging
     value: 0.0
     cost: 0.0
     observable: true
@@ -439,12 +439,7 @@ targets:
     - '`make cell.ios-sim-tablet-player` passes the reconnect sub-check end-to-end'
     - '`make cell.android-emu-phone-player` passes the reconnect sub-check end-to-end'
     - If the bug was in matrix-cell.sh, the fix explains what signal is actually reliable; if in the player, root cause is documented in the fix commit
-    context: |-
-      Both `ios-sim-tablet-player` and `android-emu-phone-player` fail the `reconnect` sub-check in matrix-cell.sh: kill the desktop server, wait 5s, verify the player reconnects by polling ged for a new session. Pre-existing — agents flagged this on both the 🎯T22 and 🎯T23 verification runs, and it's present on master prior to those PRs too.
-
-      Reconnect is an important property for the server/player architecture — games restart during development and the player should transparently pick up the new server. If this sub-check is broken but the underlying reconnect logic works, the bug is in the test. If the logic is broken, it's a real regression from the recent ged / pigeon / session-handshake work.
-
-      First diagnostic step: read `check_reconnect_ios_sim_player` / `check_reconnect_android_emu_player` in matrix-cell.sh and understand what signal it looks for. Second: manually test — start `bin/tiltbuggy`, launch the player, kill tiltbuggy, start a fresh `bin/tiltbuggy`, verify the player reconnects visually. If yes, the matrix-cell check is wrong. If no, there's a real reconnect bug.
+    context: 'Root cause found: player cells start the desktop server without --brokered, so tiltbuggy runs in direct/standalone mode and never connects to ged. server_attached_sessions() always returns 0, so wait_for_server_sessions never fires. Fix: add SERVER_ARGS global, set to --brokered in all player cell runners (run_desktop_player, run_ios_sim_player, run_android_emu_player, run_ios_device_player, run_android_device_player, run_debug_player), and thread it through start_server and all reconnect helpers. This is a pure test/matrix-cell.sh fix — the player reconnect logic itself works correctly.'
     origin: manual
     discovered: 2026-04-19
   T26:

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -961,6 +961,7 @@ LAUNCH_PID=""    # desktop only; sim/emu/device don't give us a local PID
 SIM_UDID=""      # set by ios launch helpers
 ANDROID_SERIAL=""  # set by android launch helpers
 DESKTOP_BIN=""   # overridden by debug cells to point at bin/$APP_NAME-debug
+SERVER_ARGS=""   # extra args passed to the desktop server; player cells set --brokered
 
 cold_launch_desktop() {
     local subcheck="cold-launch"
@@ -1341,7 +1342,8 @@ check_reconnect_desktop_player() {
     # Restart server.
     local serverlog="$ARTIFACTS/server-reconnect.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     # Wait for at least one session to be bridged to the new server.
@@ -1374,7 +1376,8 @@ check_reconnect_ios_sim_player() {
 
     local serverlog="$ARTIFACTS/server-reconnect.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     # Wait for at least one session to be bridged to the new server.
@@ -1406,7 +1409,8 @@ check_reconnect_android_player() {
 
     local serverlog="$ARTIFACTS/server-reconnect.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     # Wait for at least one session to be bridged to the new server.
@@ -1606,7 +1610,8 @@ check_reconnect_ios_device_player() {
     local baseline
     baseline=$(current_sessions)
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$serverlog" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$serverlog" 2>&1 ) &
     local new_srv_pid=$!
 
     if ! wait_for_sessions $((baseline + 1)); then
@@ -1755,7 +1760,8 @@ SERVER_PID=""
 start_server() {
     local logf="$ARTIFACTS/server.log"
     local srv_bin="${DESKTOP_BIN:-$APP_DIR/bin/$APP_NAME}"
-    ( cd "$APP_DIR" && exec "$srv_bin" > "$logf" 2>&1 ) &
+    # shellcheck disable=SC2086
+    ( cd "$APP_DIR" && exec "$srv_bin" $SERVER_ARGS > "$logf" 2>&1 ) &
     SERVER_PID=$!
     sleep 2
 }
@@ -1787,6 +1793,7 @@ run_desktop_dist() {
 run_desktop_player() {
     build_player_desktop || { fail_check "cold-launch" "build failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
     cold_launch_player_desktop || { stop_server; return; }
     check_soak_desktop "$LAUNCH_PID" || true
@@ -1835,6 +1842,7 @@ run_ios_sim_player() {
     # Build and start desktop server.
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Pass ged address as launch arg so the player connects directly (no QR scan).
@@ -1877,6 +1885,7 @@ run_ios_device_player() {
     # Build and start desktop server.
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Physical device needs the host's LAN IP (not localhost) to reach ged.
@@ -1935,6 +1944,7 @@ run_android_emu_player() {
 
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Pass ged address as intent extra so the player connects directly (no QR scan).
@@ -1982,6 +1992,7 @@ run_android_device_player() {
 
     ( cd "$APP_DIR" && run make ) || { fail_check "cold-launch" "build (server) failed"; return; }
     ensure_ged
+    SERVER_ARGS="--brokered"
     start_server
 
     # Physical device needs the host's LAN IP (not 10.0.2.2 which is emulator-only).
@@ -2060,6 +2071,7 @@ run_debug_player() {
             build_player_desktop_debug || { fail_check "cold-launch" "debug build failed"; return; }
             DESKTOP_BIN="$APP_DIR/bin/$APP_NAME-debug"
             ensure_ged
+            SERVER_ARGS="--brokered"
             start_server
             cold_launch_player_desktop || { stop_server; DESKTOP_BIN=""; return; }
             check_soak_desktop "$LAUNCH_PID" || true
@@ -2088,6 +2100,7 @@ run_debug_player() {
             build_desktop_debug || { fail_check "cold-launch" "debug server build failed"; return; }
             DESKTOP_BIN="$APP_DIR/bin/$APP_NAME-debug"
             ensure_ged
+            SERVER_ARGS="--brokered"
             start_server
             cold_launch_ios_sim "$PLAYER_BUNDLE_ID" "$app_path" "phone" \
                 "-ged_addr localhost:$GED_PORT" || { stop_server; DESKTOP_BIN=""; return; }
@@ -2107,6 +2120,7 @@ run_debug_player() {
             build_desktop_debug || { fail_check "cold-launch" "debug server build failed"; return; }
             DESKTOP_BIN="$APP_DIR/bin/$APP_NAME-debug"
             ensure_ged
+            SERVER_ARGS="--brokered"
             start_server
             cold_launch_android_emu "$PLAYER_ANDROID_PKG" "$apk" "" "$PLAYER_ANDROID_ACTIVITY" \
                 "--es ged_addr 10.0.2.2:$GED_PORT" || { stop_server; DESKTOP_BIN=""; return; }


### PR DESCRIPTION
## Root cause

Player cells start a desktop server to stream H.264 to the mobile player via ged. `server_attached_sessions()` counts sessions assigned to a server in ged — it only returns > 0 when the server is running in **brokered/headless** mode (connected to ged's `/ws/server` endpoint).

Previously, `start_server` and the reconnect helpers launched the server binary with no arguments, so tiltbuggy ran in **direct/standalone** mode — it opened a native window, never connected to ged, and `server_attached_sessions` returned 0 forever. The reconnect check timed out after 8s every time.

Confirmed via `server-reconnect.log`: the new server showed `DirectRenderHost.mm` and `BgfxContext: 2048x1536 windowed Metal` — clear signs of standalone mode, not brokered H.264 encode.

## Fix

- Add `SERVER_ARGS=""` global variable
- Set `SERVER_ARGS="--brokered"` in all player cell runners before `start_server`
- Thread `$SERVER_ARGS` through `start_server` and all four reconnect helpers

The bug was purely in the test harness. The player reconnect logic (ged session assignment on `AddServer`, `server_attached_sessions` polling) is correct.

## Test plan

- [ ] `make cell.ios-sim-tablet-player` — reconnect sub-check passes
- [ ] `make cell.android-emu-phone-player` — reconnect sub-check passes
- [ ] CI green