### PR TITLE
ge: 🎯T32 — push H.264 colour-space conversion onto the GPU via SDL3 YUV textures

### DIFF
--- a/include/ge/PlayerRender.h
+++ b/include/ge/PlayerRender.h
@@ -14,6 +14,8 @@
 // This keeps mobile player builds small and avoids a bgfx port there.
 #pragma once
 
+#include <ge/VideoDecoder.h>
+
 #include <SDL3/SDL.h>
 
 #include <cstddef>
@@ -47,9 +49,11 @@ public:
     // Accounts for requested orientation (portrait/landscape swap).
     void getDeviceDimensions(int& w, int& h, int& pixelRatio) const;
 
-    // Replace the video texture with a newly decoded BGRA frame.
-    // (Re)allocates the texture if dimensions change.
-    void updateVideoTexture(const uint8_t* bgra, int w, int h, size_t bytesPerRow);
+    // Replace the video texture with a newly decoded frame. The texture is
+    // (re)allocated whenever dimensions or pixel format change. SDL handles
+    // YUV→RGB conversion internally for NV12/IYUV formats (GPU-side on
+    // Metal/Vulkan, software fallback elsewhere).
+    void updateVideoTexture(const VideoFrame& frame);
 
     // Drain SDL events. Returns:
     //   quit           — SDL_EVENT_QUIT received

--- a/include/ge/PlayerWireBridge.h
+++ b/include/ge/PlayerWireBridge.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <ge/Protocol.h>
+#include <ge/VideoDecoder.h>
 
 #include <SDL3/SDL_events.h>
 
@@ -34,12 +35,36 @@ public:
         int connectTimeoutMs = 2000;
     };
 
-    // A decoded BGRA video frame ready for display.
+    // A decoded video frame ready for display. Owns its plane data so it
+    // remains valid after the decoder callback returns. Plane count and
+    // stride layout depend on `format` — see ge/VideoDecoder.h's VideoFrame
+    // for the contract; DecodedFrame is the owned counterpart.
     struct DecodedFrame {
-        std::vector<uint8_t> bgra;
+        VideoFrame::Format format = VideoFrame::Format::BGRA;
         int width = 0;
         int height = 0;
-        size_t bytesPerRow = 0;
+        std::vector<uint8_t> plane0;
+        std::vector<uint8_t> plane1;
+        std::vector<uint8_t> plane2;
+        int stride0 = 0;
+        int stride1 = 0;
+        int stride2 = 0;
+
+        // View this owned frame as a VideoFrame with raw plane pointers.
+        // Pointers are valid until the next mutation of *this.
+        VideoFrame view() const {
+            VideoFrame f;
+            f.format = format;
+            f.width = width;
+            f.height = height;
+            f.planes[0] = plane0.empty() ? nullptr : plane0.data();
+            f.planes[1] = plane1.empty() ? nullptr : plane1.data();
+            f.planes[2] = plane2.empty() ? nullptr : plane2.data();
+            f.strides[0] = stride0;
+            f.strides[1] = stride1;
+            f.strides[2] = stride2;
+            return f;
+        }
     };
 
     explicit PlayerWireBridge(Config);

--- a/include/ge/VideoDecoder.h
+++ b/include/ge/VideoDecoder.h
@@ -9,9 +9,25 @@
 
 namespace ge {
 
+// A decoded video frame, view-only. Plane pointers belong to the decoder
+// and are only valid for the duration of the FrameCallback invocation.
+//
+// Plane count depends on format:
+//   BGRA: 1 plane.  planes[0] = BGRA pixels, strides[0] = bytesPerRow.
+//   NV12: 2 planes. planes[0] = Y (w×h), planes[1] = interleaved UV (w×h/2).
+//   IYUV: 3 planes. planes[0] = Y, planes[1] = U (w/2×h/2), planes[2] = V.
+struct VideoFrame {
+    enum class Format { BGRA, NV12, IYUV };
+    Format format = Format::BGRA;
+    int width = 0;
+    int height = 0;
+    const uint8_t* planes[3] = {nullptr, nullptr, nullptr};
+    int strides[3] = {0, 0, 0};
+};
+
 class VideoDecoder {
 public:
-    using FrameCallback = std::function<void(const uint8_t* bgraPixels, int width, int height, size_t bytesPerRow)>;
+    using FrameCallback = std::function<void(const VideoFrame&)>;
 
     explicit VideoDecoder(FrameCallback onFrame);
     ~VideoDecoder();

--- a/src/bridge/PlayerWireBridge.cpp
+++ b/src/bridge/PlayerWireBridge.cpp
@@ -125,13 +125,42 @@ bool PlayerWireBridge::sendDeviceInfo(const wire::DeviceInfo& devInfo) {
     // callback captures a stable `this`.
     if (!i_->decoder) {
         i_->decoder = std::make_unique<VideoDecoder>(
-            [this](const uint8_t* bgra, int w, int h, size_t bpr) {
+            [this](const VideoFrame& f) {
                 std::lock_guard<std::mutex> lock(i_->frameMutex);
-                size_t total = bpr * h;
-                i_->pending.bgra.assign(bgra, bgra + total);
-                i_->pending.width = w;
-                i_->pending.height = h;
-                i_->pending.bytesPerRow = bpr;
+                i_->pending.format = f.format;
+                i_->pending.width = f.width;
+                i_->pending.height = f.height;
+                i_->pending.stride0 = f.strides[0];
+                i_->pending.stride1 = f.strides[1];
+                i_->pending.stride2 = f.strides[2];
+
+                auto copyPlane = [](std::vector<uint8_t>& dst,
+                                    const uint8_t* src, int stride, int rows) {
+                    if (!src || stride <= 0 || rows <= 0) {
+                        dst.clear();
+                        return;
+                    }
+                    size_t bytes = static_cast<size_t>(stride) * rows;
+                    dst.assign(src, src + bytes);
+                };
+
+                switch (f.format) {
+                case VideoFrame::Format::BGRA:
+                    copyPlane(i_->pending.plane0, f.planes[0], f.strides[0], f.height);
+                    i_->pending.plane1.clear();
+                    i_->pending.plane2.clear();
+                    break;
+                case VideoFrame::Format::NV12:
+                    copyPlane(i_->pending.plane0, f.planes[0], f.strides[0], f.height);
+                    copyPlane(i_->pending.plane1, f.planes[1], f.strides[1], f.height / 2);
+                    i_->pending.plane2.clear();
+                    break;
+                case VideoFrame::Format::IYUV:
+                    copyPlane(i_->pending.plane0, f.planes[0], f.strides[0], f.height);
+                    copyPlane(i_->pending.plane1, f.planes[1], f.strides[1], f.height / 2);
+                    copyPlane(i_->pending.plane2, f.planes[2], f.strides[2], f.height / 2);
+                    break;
+                }
                 i_->pendingReady = true;
             });
     }

--- a/src/bridge/VideoDecoder_android.cpp
+++ b/src/bridge/VideoDecoder_android.cpp
@@ -25,36 +25,6 @@ static constexpr int kColorFormatBGRA = 0x7F00A000;
 static constexpr int64_t kInputTimeoutUs = 10000;  // 10ms — wait for input buffer
 static constexpr int64_t kOutputTimeoutUs = 0;     // non-blocking output drain
 
-// Convert NV12 (YUV 4:2:0 semi-planar) to BGRA.
-// Y plane: w*h bytes.
-// UV plane: w*(h/2) bytes, interleaved U then V per pair.
-static void nv12ToBgra(const uint8_t* y, const uint8_t* uv,
-                        int width, int height,
-                        int yStride, int uvStride,
-                        uint8_t* bgra, int bgraStride) {
-    for (int row = 0; row < height; ++row) {
-        const uint8_t* yRow  = y  + row * yStride;
-        const uint8_t* uvRow = uv + (row / 2) * uvStride;
-        uint8_t*       out   = bgra + row * bgraStride;
-
-        for (int col = 0; col < width; ++col) {
-            int yVal = static_cast<int>(yRow[col]);
-            int uVal = static_cast<int>(uvRow[(col & ~1)])     - 128;
-            int vVal = static_cast<int>(uvRow[(col & ~1) + 1]) - 128;
-
-            int r = yVal + (vVal * 1436 >> 10);
-            int g = yVal - (uVal *  352 >> 10) - (vVal * 731 >> 10);
-            int b = yVal + (uVal * 1814 >> 10);
-
-            out[0] = static_cast<uint8_t>(b < 0 ? 0 : b > 255 ? 255 : b);
-            out[1] = static_cast<uint8_t>(g < 0 ? 0 : g > 255 ? 255 : g);
-            out[2] = static_cast<uint8_t>(r < 0 ? 0 : r > 255 ? 255 : r);
-            out[3] = 0xFF;
-            out += 4;
-        }
-    }
-}
-
 struct VideoDecoder::M {
     FrameCallback callback;
 
@@ -69,10 +39,6 @@ struct VideoDecoder::M {
 
     // Protect concurrent drain calls from decode() vs flush().
     std::mutex drainMutex;
-
-    // Reusable BGRA conversion buffer.
-    std::mutex        frameMutex;
-    std::vector<uint8_t> frameBuffer;
 
     ~M() {
         if (codec) {
@@ -252,40 +218,42 @@ void VideoDecoder::M::deliverFrame(uint8_t* buf, size_t bufSize,
                                     AMediaCodecBufferInfo& info) {
     if (info.size <= 0 || !buf) return;
 
-    // Detect whether the actual output color format is BGRA or NV12.
-    // On some devices the codec ignores the requested format and outputs NV12
-    // regardless. We use a simple size heuristic: BGRA = 4*w*h bytes.
+    // We always request NV12 at configure time. Some devices nonetheless
+    // return BGRA; detect by buffer size and forward in either format
+    // without conversion — the renderer (SDL_PIXELFORMAT_NV12 /
+    // SDL_PIXELFORMAT_BGRA32) handles colour-space conversion on the GPU.
     const size_t expectedBgra = static_cast<size_t>(width) * height * 4;
     const size_t expectedNv12 = static_cast<size_t>(width) * height * 3 / 2;
     const size_t frameBytes   = static_cast<size_t>(info.size);
 
+    uint8_t* src = buf + info.offset;
+
+    VideoFrame f;
+    f.width = width;
+    f.height = height;
+
     if (frameBytes >= expectedBgra) {
-        // Treat as BGRA (or RGBA — trust what the codec promised at configure).
-        std::lock_guard<std::mutex> lock(frameMutex);
-        callback(buf + info.offset, width, height,
-                 static_cast<size_t>(width) * 4);
+        f.format = VideoFrame::Format::BGRA;
+        f.planes[0] = src;
+        f.strides[0] = width * 4;
     } else if (frameBytes >= expectedNv12) {
-        // NV12: convert to BGRA.
-        const size_t bgraStride = static_cast<size_t>(width) * 4;
-        const size_t bgraBytes  = bgraStride * height;
-
-        std::lock_guard<std::mutex> lock(frameMutex);
-        frameBuffer.resize(bgraBytes);
-
-        const uint8_t* src = buf + info.offset;
-        nv12ToBgra(src,                          // Y plane
-                   src + width * height,         // UV plane
-                   width, height,
-                   width,                        // Y stride
-                   width,                        // UV stride (interleaved)
-                   frameBuffer.data(), static_cast<int>(bgraStride));
-
-        callback(frameBuffer.data(), width, height, bgraStride);
+        // NV12 layout: Y plane (width*height bytes) followed by interleaved
+        // UV plane (width*height/2 bytes). Stride==width is the universal
+        // assumption matching the existing code; codecs that use different
+        // strides would require querying AMEDIAFORMAT_KEY_STRIDE.
+        f.format = VideoFrame::Format::NV12;
+        f.planes[0] = src;
+        f.planes[1] = src + width * height;
+        f.strides[0] = width;
+        f.strides[1] = width;
     } else {
         SPDLOG_WARN("VideoDecoder: unexpected output buffer size {} "
                     "(expected BGRA={} or NV12={})",
                     frameBytes, expectedBgra, expectedNv12);
+        return;
     }
+
+    callback(f);
 }
 
 void VideoDecoder::M::drainOutput() {

--- a/src/bridge/VideoDecoder_apple.mm
+++ b/src/bridge/VideoDecoder_apple.mm
@@ -25,7 +25,6 @@ struct VideoDecoder::M {
     int frameWidth = 0;
     int frameHeight = 0;
     size_t frameBytesPerRow = 0;
-    bool frameReady = false;
 
     ~M() {
         if (session) {
@@ -114,7 +113,6 @@ void VideoDecoder::M::outputCallback(void* decompressionOutputRefCon,
         CVPixelBufferGetBaseAddress(imageBuffer));
 
     if (baseAddr) {
-        // Buffer the frame for the main thread
         std::lock_guard<std::mutex> lock(self->frameMutex);
         size_t totalBytes = bytesPerRow * height;
         self->frameBuffer.resize(totalBytes);
@@ -122,20 +120,17 @@ void VideoDecoder::M::outputCallback(void* decompressionOutputRefCon,
         self->frameWidth = width;
         self->frameHeight = height;
         self->frameBytesPerRow = bytesPerRow;
-        self->frameReady = true;
+
+        VideoFrame f;
+        f.format = VideoFrame::Format::BGRA;
+        f.width = width;
+        f.height = height;
+        f.planes[0] = self->frameBuffer.data();
+        f.strides[0] = static_cast<int>(bytesPerRow);
+        self->callback(f);
     }
 
     CVPixelBufferUnlockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
-
-    // Deliver the frame via callback on the calling thread
-    if (baseAddr) {
-        std::lock_guard<std::mutex> lock(self->frameMutex);
-        if (self->frameReady) {
-            self->callback(self->frameBuffer.data(),
-                          self->frameWidth, self->frameHeight,
-                          self->frameBytesPerRow);
-        }
-    }
 }
 
 VideoDecoder::VideoDecoder(FrameCallback onFrame)

--- a/src/bridge/VideoDecoder_ffmpeg.cpp
+++ b/src/bridge/VideoDecoder_ffmpeg.cpp
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // H.264 decoder using FFmpeg libavcodec. Used on Android where the
-// native MediaCodec API is fragile. Produces BGRA output for SDL.
+// native MediaCodec API is fragile. Delivers IYUV (planar YUV 4:2:0)
+// directly to the renderer — no software CSC.
 
 #ifdef __ANDROID__
 
@@ -11,8 +12,6 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
-#include <libavutil/imgutils.h>
-#include <libswscale/swscale.h>
 }
 
 #include <cstring>
@@ -29,19 +28,11 @@ struct VideoDecoder::M {
     AVCodecParserContext* parser = nullptr;
     AVFrame* frame = nullptr;
     AVPacket* pkt = nullptr;
-    SwsContext* sws = nullptr;
     bool opened = false;
-
-    // BGRA output buffer
-    uint8_t* bgraData[4] = {};
-    int bgraLinesize[4] = {};
-    int bgraWidth = 0, bgraHeight = 0;
 
     std::mutex decodeMutex;
 
     ~M() {
-        if (sws) sws_freeContext(sws);
-        if (bgraData[0]) av_freep(&bgraData[0]);
         av_frame_free(&frame);
         av_packet_free(&pkt);
         if (parser) av_parser_close(parser);
@@ -77,20 +68,6 @@ struct VideoDecoder::M {
         return true;
     }
 
-    void ensureBgraBuffer(int w, int h) {
-        if (bgraWidth == w && bgraHeight == h) return;
-        if (bgraData[0]) av_freep(&bgraData[0]);
-        av_image_alloc(bgraData, bgraLinesize, w, h, AV_PIX_FMT_BGRA, 1);
-        bgraWidth = w;
-        bgraHeight = h;
-
-        if (sws) sws_freeContext(sws);
-        sws = sws_getContext(w, h, ctx->pix_fmt,
-                             w, h, AV_PIX_FMT_BGRA,
-                             SWS_BILINEAR, nullptr, nullptr, nullptr);
-        SPDLOG_INFO("VideoDecoder: BGRA buffer {}x{}", w, h);
-    }
-
     void deliverDecodedFrames() {
         int ret = 0;
         while (ret >= 0) {
@@ -98,14 +75,20 @@ struct VideoDecoder::M {
             if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) break;
             if (ret < 0) break;
 
-            int w = frame->width;
-            int h = frame->height;
-            ensureBgraBuffer(w, h);
-
-            sws_scale(sws, frame->data, frame->linesize, 0, h,
-                      bgraData, bgraLinesize);
-
-            callback(bgraData[0], w, h, static_cast<size_t>(bgraLinesize[0]));
+            // libavcodec H.264 outputs AV_PIX_FMT_YUV420P (planar Y/U/V),
+            // which maps directly to SDL_PIXELFORMAT_IYUV. Pass plane
+            // pointers and strides through with no conversion.
+            VideoFrame f;
+            f.format = VideoFrame::Format::IYUV;
+            f.width = frame->width;
+            f.height = frame->height;
+            f.planes[0] = frame->data[0];
+            f.planes[1] = frame->data[1];
+            f.planes[2] = frame->data[2];
+            f.strides[0] = frame->linesize[0];
+            f.strides[1] = frame->linesize[1];
+            f.strides[2] = frame->linesize[2];
+            callback(f);
         }
     }
 };

--- a/src/render/PlayerRender.cpp
+++ b/src/render/PlayerRender.cpp
@@ -87,6 +87,7 @@ struct PlayerRender::Impl {
     SDL_Renderer* renderer = nullptr;
     SDL_Texture* videoTex = nullptr;
     int texW = 0, texH = 0;
+    SDL_PixelFormat texFormat = SDL_PIXELFORMAT_UNKNOWN;
 
     uint8_t requestedOrientation = 0;
 
@@ -219,17 +220,47 @@ void PlayerRender::getDeviceDimensions(int& w, int& h, int& pixelRatio) const {
     if (wantLandscape && h > w) std::swap(w, h);
 }
 
-void PlayerRender::updateVideoTexture(const uint8_t* bgra, int w, int h, size_t bpr) {
+void PlayerRender::updateVideoTexture(const VideoFrame& frame) {
     if (!i_->renderer) return;
-    if (!i_->videoTex || i_->texW != w || i_->texH != h) {
-        if (i_->videoTex) SDL_DestroyTexture(i_->videoTex);
-        i_->videoTex = SDL_CreateTexture(i_->renderer,
-            SDL_PIXELFORMAT_BGRA32, SDL_TEXTUREACCESS_STREAMING, w, h);
-        i_->texW = w;
-        i_->texH = h;
-        SPDLOG_INFO("PlayerRender: video texture created {}x{}", w, h);
+
+    SDL_PixelFormat sdlFormat = SDL_PIXELFORMAT_UNKNOWN;
+    switch (frame.format) {
+    case VideoFrame::Format::BGRA: sdlFormat = SDL_PIXELFORMAT_BGRA32; break;
+    case VideoFrame::Format::NV12: sdlFormat = SDL_PIXELFORMAT_NV12;   break;
+    case VideoFrame::Format::IYUV: sdlFormat = SDL_PIXELFORMAT_IYUV;   break;
     }
-    SDL_UpdateTexture(i_->videoTex, nullptr, bgra, static_cast<int>(bpr));
+    if (sdlFormat == SDL_PIXELFORMAT_UNKNOWN) return;
+
+    if (!i_->videoTex || i_->texW != frame.width ||
+        i_->texH != frame.height || i_->texFormat != sdlFormat) {
+        if (i_->videoTex) SDL_DestroyTexture(i_->videoTex);
+        i_->videoTex = SDL_CreateTexture(i_->renderer, sdlFormat,
+            SDL_TEXTUREACCESS_STREAMING, frame.width, frame.height);
+        i_->texW = frame.width;
+        i_->texH = frame.height;
+        i_->texFormat = sdlFormat;
+        SPDLOG_INFO("PlayerRender: video texture created {}x{} format={}",
+                    frame.width, frame.height, SDL_GetPixelFormatName(sdlFormat));
+    }
+
+    switch (frame.format) {
+    case VideoFrame::Format::BGRA:
+        SDL_UpdateTexture(i_->videoTex, nullptr, frame.planes[0], frame.strides[0]);
+        break;
+    case VideoFrame::Format::NV12:
+        // Y plane + interleaved UV plane.
+        SDL_UpdateNVTexture(i_->videoTex, nullptr,
+                            frame.planes[0], frame.strides[0],
+                            frame.planes[1], frame.strides[1]);
+        break;
+    case VideoFrame::Format::IYUV:
+        // Separate Y, U, V planes.
+        SDL_UpdateYUVTexture(i_->videoTex, nullptr,
+                             frame.planes[0], frame.strides[0],
+                             frame.planes[1], frame.strides[1],
+                             frame.planes[2], frame.strides[2]);
+        break;
+    }
 }
 
 PlayerRender::PumpResult PlayerRender::pumpEvents() {

--- a/tools/android/app/src/main/cpp/CMakeLists.txt
+++ b/tools/android/app/src/main/cpp/CMakeLists.txt
@@ -58,9 +58,10 @@ target_include_directories(main PRIVATE
 )
 
 # FFmpeg static libs + SDL3 + Android system libs
+# (libswscale is no longer needed: VideoDecoder_ffmpeg.cpp delivers IYUV
+# directly to the renderer, which handles YUV→RGB on the GPU via SDL.)
 target_link_libraries(main PRIVATE
     ${FFMPEG_DIR}/lib/android-arm64/libavcodec.a
-    ${FFMPEG_DIR}/lib/android-arm64/libswscale.a
     ${FFMPEG_DIR}/lib/android-arm64/libavutil.a
     SDL3::SDL3
     android

--- a/tools/player_core.cpp
+++ b/tools/player_core.cpp
@@ -112,8 +112,7 @@ int playerCore(const std::string& host, int port, const std::string& serverName)
 
         ge::PlayerWireBridge::DecodedFrame df;
         if (wire.pollFrame(df)) {
-            render.updateVideoTexture(df.bgra.data(), df.width, df.height,
-                                      df.bytesPerRow);
+            render.updateVideoTexture(df.view());
             frameCount++;
         }
 


### PR DESCRIPTION
## Summary

- Replaces the per-pixel CPU NV12→BGRA loop on Android (`src/bridge/VideoDecoder_android.cpp`) and the libswscale YUV→BGRA conversion in the FFmpeg path (`src/bridge/VideoDecoder_ffmpeg.cpp`) with direct delivery of planar/semi-planar YUV to SDL3, which uploads `SDL_PIXELFORMAT_NV12` / `SDL_PIXELFORMAT_IYUV` textures and handles YUV→RGB internally — GPU-side on Metal/Vulkan, optimised software fallback otherwise.
- ~62% less texture-upload bandwidth per 1080p frame (~3.1 MB vs ~8.3 MB; ~155 MB/s saved at 30 fps), and the hand-rolled per-pixel CSC loop disappears entirely.
- Apple is **untouched**. VideoToolbox + Apple silicon already does CSC in dedicated hardware and emits BGRA; the only Apple-side change is wrapping the existing BGRA delivery in the new `VideoFrame` struct (no behavioural change).

## Interface change

- `include/ge/VideoDecoder.h` adds `VideoFrame { format, width, height, planes[3], strides[3] }` with a `Format` enum of `BGRA` / `NV12` / `IYUV`. `FrameCallback` becomes `void(const VideoFrame&)`.
- `include/ge/PlayerWireBridge.h`'s `DecodedFrame` becomes the owned counterpart with three plane vectors + strides + a `view()` helper that reconstitutes a `VideoFrame` for the renderer.
- `include/ge/PlayerRender.h`'s `updateVideoTexture` takes a `VideoFrame`; it (re)allocates the SDL_Texture on format change in addition to dimension change.

## Per-decoder

| Decoder | Now emits | Notes |
|---|---|---|
| `VideoDecoder_apple.mm` | `VideoFrame{BGRA}` | Still requests `kCVPixelFormatType_32BGRA` from VideoToolbox; only the callback shape changed |
| `VideoDecoder_ffmpeg.cpp` | `VideoFrame{IYUV}` | Direct from `frame->data[0/1/2]`; libswscale dropped, including the link line in `tools/android/app/src/main/cpp/CMakeLists.txt` |
| `VideoDecoder_android.cpp` | `VideoFrame{NV12}` (or BGRA) | Drops `nv12ToBgra` and the BGRA conversion buffer. Still detects BGRA-vs-NV12 by output buffer size for devices that ignore the configured format, forwards either |

## Test plan

- [x] macOS player: `make ge/player` produces a clean 4.4 MB Mach-O arm64. Apple BGRA path structurally unchanged at the renderer (`SDL_PIXELFORMAT_BGRA32` + `SDL_UpdateTexture`, same as before).
- [x] Android player: CMake + NDK 29 builds a clean 56 MB `libmain.so` ELF aarch64. `libswscale` reference dropped from the link line; `libmain.so`'s `NEEDED` list shows only `libSDL3.so` + Android system libs.
- [ ] Visual end-to-end verification on Android requires a device session (to confirm SDL's NV12/IYUV path renders correctly with no green tint or chroma offset, and that BT.601-vs-BT.709 coefficients are right). Deferred to follow-on testing.
- [ ] Visual end-to-end verification on macOS to confirm no regression on the Apple BGRA path.

## What this does **not** do

- Does not switch the Android player from the current FFmpeg-based decoder back to MediaCodec. That's still 🎯T31's territory (and remains gated by the original async-callback rewrite). When MediaCodec eventually returns, `VideoDecoder_android.cpp` is already conformant to the new `VideoFrame` interface — its NV12 output flows through the same SDL path this PR establishes.
- Does not remove FFmpeg from `vendor/`. Even with libswscale gone from the link, libavcodec + libavutil still provide H.264 decode on Android. Retiring FFmpeg entirely is 🎯T31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)