### PR TITLE
ge: 🎯T30.2 — Android FontLoader so Text-using consumers link cleanly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,9 @@ set(GE_CORE_SOURCES
 if(APPLE)
     list(APPEND GE_CORE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/FontLoader_apple.mm)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    list(APPEND GE_CORE_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/FontLoader_android.cpp)
 endif()
 
 if(GE_DIRECT)

--- a/src/FontLoader_android.cpp
+++ b/src/FontLoader_android.cpp
@@ -1,0 +1,92 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Android implementation of ge::resolveFont.
+//
+// No fonts.xml parsing and no AAssetManager — system fonts on Android live
+// under /system/fonts/ with stable filenames across devices (API 24+), so a
+// hardcoded candidate list keyed on logical name is sufficient. We probe
+// candidates in order and pick the first that's readable.
+
+#include <ge/FontLoader.h>
+#include <ge/Resource.h>
+
+#include <spdlog/spdlog.h>
+
+#include <unistd.h>
+#include <string>
+#include <vector>
+
+namespace ge {
+namespace {
+
+// Candidate filesystem paths for each logical font name. First readable path
+// wins. Paths listed in decreasing order of preference: modern Roboto first,
+// legacy Droid as fallback for older devices.
+const std::vector<const char*>& candidatesFor(const std::string& name) {
+    static const std::vector<const char*> kSansSerif = {
+        "/system/fonts/Roboto-Regular.ttf",
+        "/system/fonts/DroidSans.ttf",
+    };
+    static const std::vector<const char*> kSansSerifBold = {
+        "/system/fonts/Roboto-Bold.ttf",
+        "/system/fonts/DroidSans-Bold.ttf",
+    };
+    static const std::vector<const char*> kSerif = {
+        "/system/fonts/NotoSerif-Regular.ttf",
+        "/system/fonts/DroidSerif-Regular.ttf",
+    };
+    static const std::vector<const char*> kSerifBold = {
+        "/system/fonts/NotoSerif-Bold.ttf",
+        "/system/fonts/DroidSerif-Bold.ttf",
+    };
+    static const std::vector<const char*> kMonospace = {
+        "/system/fonts/RobotoMono-Regular.ttf",
+        "/system/fonts/DroidSansMono.ttf",
+    };
+    static const std::vector<const char*> kMonospaceBold = {
+        "/system/fonts/RobotoMono-Bold.ttf",
+        "/system/fonts/DroidSansMono.ttf",  // no bold variant of DroidSansMono
+    };
+    static const std::vector<const char*> kEmpty = {};
+
+    if (name == "sans-serif")      return kSansSerif;
+    if (name == "sans-serif-bold") return kSansSerifBold;
+    if (name == "serif")           return kSerif;
+    if (name == "serif-bold")      return kSerifBold;
+    if (name == "monospace")       return kMonospace;
+    if (name == "monospace-bold")  return kMonospaceBold;
+    return kEmpty;
+}
+
+FontRef resolveSystemFont(const std::string& name) {
+    const auto& candidates = candidatesFor(name);
+    if (candidates.empty()) {
+        SPDLOG_WARN("Unknown system font name: {}", name);
+        return {};
+    }
+    for (const char* path : candidates) {
+        if (access(path, R_OK) == 0) {
+            return FontRef{path, 0};
+        }
+    }
+    SPDLOG_WARN("No readable candidate for system font '{}'", name);
+    return {};
+}
+
+} // namespace
+
+FontRef resolveFont(const std::string& uri) {
+    constexpr const char* kSystemPrefix = "system:";
+    constexpr const char* kFilePrefix = "file:";
+
+    if (uri.starts_with(kSystemPrefix)) {
+        return resolveSystemFont(uri.substr(strlen(kSystemPrefix)));
+    }
+    if (uri.starts_with(kFilePrefix)) {
+        return FontRef{uri.substr(strlen(kFilePrefix)), 0};
+    }
+    return FontRef{ge::resource(uri), 0};
+}
+
+} // namespace ge


### PR DESCRIPTION
## Summary

- Adds \`src/FontLoader_android.cpp\` — pairs with \`FontLoader_apple.mm\` to give every platform a \`ge::resolveFont()\` implementation. Consumers that include \`<ge/FontLoader.h>\` on Android no longer hit unresolved references.
- Fills the gap explicitly noted in \`sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt:76-78\`: *"FontLoader_apple.mm is Apple-only — Android would need its own FontLoader implementation."*
- No \`#ifdef\` inside a single file. \`ge/CMakeLists.txt\` picks the right implementation via an \`elseif(CMAKE_SYSTEM_NAME STREQUAL \"Android\")\` branch mirroring the existing \`if(APPLE)\` one.

## Implementation

- \`system:<name>\` — resolves against \`/system/fonts/\` via a hardcoded candidate list per logical name. Roboto first (universally present on Android 7+ / API 24+), legacy Droid as fallback for older devices. \`access()\` probes readability and picks the first viable path.
- \`file:<path>\` — pass-through.
- relative path — delegates to \`ge::resource()\`, which on Android returns the path unchanged and relies on SDL_IOFromFile to route through AAssetManager (consumer-side pattern).
- No AAssetManager plumbing and no \`fonts.xml\` parsing. The candidate list covers every Android device in the supported SDK range and matches the semantic coverage of the CoreText lookup on Apple: sans-serif / sans-serif-bold / serif / serif-bold / monospace / monospace-bold.

## Test plan

- [x] Android: CMake + NDK 29 compiles \`FontLoader_android.cpp.o\` and links into \`libge.a\`.
- [x] macOS: \`make ge/player\` succeeds; \`FontLoader_apple.o\` still picked up, \`FontLoader_android.o\` not compiled (Android branch skipped outside Android).
- [ ] End-to-end on Android device: requires a consumer that actually uses ge::resolveFont — multimaze2 is that consumer. This gets exercised naturally when 🎯T30.3 migrates tiltbuggy to \`add_subdirectory(ge)\` and/or when multimaze2 picks up the combined T30.1 + T30.2 changes.

## Relation to 🎯T30's other leaves

- 🎯T30.1 (PR #32 open) ships the SDL_ttf lib. Consumer builds can now \`#include <SDL3_ttf/SDL_ttf.h>\` and link \`SDL3_ttf::SDL3_ttf\` on Android.
- 🎯T30.2 (this PR) ships the FontLoader. Consumer builds now resolve \`ge::resolveFont()\` on Android.
- 🎯T30.3 (not yet done) switches \`sample/tiltbuggy/android\` from its hand-picked \`GE_SOURCES\` list to \`add_subdirectory(ge)\`, which is the final proof of the single-path integration principle and the moment all three pieces get exercised together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)