### PR TITLE
ge: 🎯T31 — clarify Triangle's non-commercial licence + opt-in model in the docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Engine-internal variables use the `ge/` prefix. These are read-only — the pare
 | `ge/BGFX_LIBS` | bgfx static libraries (`libbgfx.a`, `libbimg.a`, `libbx.a`) |
 | `ge/SDL_LIBS` | SDL3 static libraries (SDL3, SDL3_image, SDL3_ttf, freetype, harfbuzz, etc.) |
 | `ge/TEST_SRC`, `ge/TEST_OBJ` | Unit test sources and objects |
-| `ge/TRIANGLE_OBJ` | Triangle library object (for tools that need triangulation) |
+| `ge/TRIANGLE_OBJ` | Triangle library object — **opt-in; not linked into `libge.a`**. Commercial builds should not reference this without first reading NOTICES.md's Triangle section (restrictive licence; commercial distribution requires arrangement with the author). |
 | `ge/PLAYER` | ge player binary path (`bin/player`) |
 
 ### Shared Variables

--- a/Module.mk
+++ b/Module.mk
@@ -181,7 +181,16 @@ ge/BOX2D_CFLAGS = -I$(ge/BOX2D_DIR)/include -I$(ge/BOX2D_DIR)/src -O2 -std=c17
 ge/SQLITE_SRC = $(ge)/vendor/src/sqlite3.c
 ge/SQLITE_OBJ = $(BUILD_DIR)/ge/vendor/sqlite3.o
 
-# Triangle library (C code, used by precompute tool)
+# Triangle library (C code, used by build-time precompute tools in
+# consuming projects). OPT-IN ONLY — not linked into libge.a. Reference
+# $(ge/TRIANGLE_OBJ) in your link line explicitly to pull it in.
+#
+# LICENCE WARNING: Triangle is NOT permissively licensed. Commercial
+# distribution requires direct arrangement with Jonathan Shewchuk
+# (jrs@cs.berkeley.edu). See NOTICES.md "Triangle (J. R. Shewchuk)"
+# for the full terms and the three options if you're shipping a paid
+# product. Safe default for commercial builds: do not reference
+# $(ge/TRIANGLE_OBJ) anywhere in your Makefile.
 ge/TRIANGLE_SRC = $(ge)/vendor/src/triangle.c
 ge/TRIANGLE_OBJ = $(BUILD_DIR)/ge/vendor/triangle.o
 ge/TRIANGLE_CFLAGS = -O2 -I$(ge)/vendor/include -DTRILIBRARY -DREAL=double -DANSI_DECLARATORS -DNO_TIMER

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -14,14 +14,36 @@ terms in `vendor/src/triangle.c`. Key restrictions:
 
 - Free for private, research, and institutional use.
 - Redistribution requires retaining the copyright header unchanged.
-- Commercial distribution is **only permissible by direct arrangement
-  with the author**.
+- Modifications must preserve the original copyright, source and object
+  code must be freely available, and changes must be clearly noted.
+- **Commercial distribution is only permissible by direct arrangement
+  with Jonathan Shewchuk (jrs@cs.berkeley.edu)**, with one carve-out:
+  if you do not directly supply Triangle to your customer but instead
+  tell them where to obtain it for free (e.g. by referring them to
+  ge's public GitHub repository), no arrangement is required.
 
-If ge is distributed as part of a commercial product, confirm that
-triangulation is either removed or that a commercial arrangement has
-been made with Jonathan Shewchuk (jrs@cs.berkeley.edu). Alternatively,
-replace Triangle with the permissively-licenced earcut.hpp (also
-vendored) for polygon triangulation.
+**How this affects ge consumers**
+
+Triangle is **not linked into `libge.a`**. Nothing under `src/` calls
+`triangulate()` or `#include`s `triangle.h`. The file `vendor/src/triangle.c`
+is compiled only when a consumer explicitly references the
+opt-in `ge/TRIANGLE_OBJ` make variable in their link line (see
+`Module.mk`). Downloading ge from GitHub does not itself constitute
+commercial redistribution of Triangle, so open-source / research /
+institutional consumers are unaffected.
+
+**If you are building a commercial product**, you have three options:
+
+1. **Do nothing** and leave `ge/TRIANGLE_OBJ` out of your link line.
+   ge itself will build and link cleanly; no Triangle code will be
+   compiled into your binary. This is the safe default.
+2. **Replace with earcut.hpp** (also vendored, ISC-licensed, header-only
+   at `vendor/include/earcut.hpp`) for simple polygon triangulation.
+   earcut.hpp does not do constrained Delaunay or quality refinement,
+   so it is not a drop-in substitute for every Triangle use-case.
+3. **Contact Jonathan Shewchuk** to arrange commercial licensing if
+   your build genuinely needs Triangle's constrained Delaunay /
+   quality-mesh features and you intend to ship them in a paid product.
 
 ### FFmpeg (prebuilt, Android only)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rendering and asset engine for Dawn (WebGPU) + SDL3 applications. Provides RAII 
 - [spdlog](https://github.com/gabime/spdlog) — Logging (header-only)
 - [linalg.h](https://github.com/sgorsten/linalg) — Linear algebra (header-only)
 - [doctest](https://github.com/doctest/doctest) — Testing (header-only)
-- [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) — Constrained Delaunay triangulation
+- [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) — Constrained Delaunay triangulation *(opt-in only; not linked into `libge.a`. Non-commercial licence — see [`NOTICES.md`](NOTICES.md#triangle-j-r-shewchuk) before shipping in a paid product.)*
 
 Dependencies live in `vendor/` as git submodules or vendored sources.
 


### PR DESCRIPTION
## Summary

Triangle's non-commercial licence constraint was buried in a generic "licensing gaps and warnings" section in NOTICES.md. This PR makes the constraint structurally visible — in NOTICES.md, Module.mk, CLAUDE.md, and README.md — without changing any code.

## Facts (confirmed by inventory)

- **Triangle is not linked into `libge.a`.** Nothing under `src/` calls `triangulate()` or `#include`s `triangle.h`. `vendor/src/triangle.c` is compiled only when a consumer explicitly references `ge/TRIANGLE_OBJ` in their link line.
- **The only known consumer** across the Squz portfolio is `yourworld2/tools/precompute.cpp` — a build-time tool, not a runtime artifact.
- **GitHub distribution is covered by the licence's free-download carve-out.** Downloading ge from a public repo does not itself constitute commercial redistribution of Triangle; the licence only requires an arrangement when code is supplied directly to a customer as part of a paid product.
- **Open-source / research / institutional consumers are unaffected.** Commercial consumers have three options, enumerated in NOTICES.md: do nothing (safe default), replace with earcut.hpp, or contact Shewchuk.

## What this PR changes

- `NOTICES.md`: expands the Triangle warning into a three-option section. Explicitly states it's not in `libge.a` and that the GitHub distribution is covered by the free-download carve-out.
- `Module.mk`: adds a LICENCE WARNING comment block to the `TRIANGLE_*` variable definitions so anyone editing the build sees the constraint before wiring `$(ge/TRIANGLE_OBJ)` into a link line.
- `CLAUDE.md`: annotates the `ge/TRIANGLE_OBJ` row in the exported-variables table with the opt-in + commercial caveat.
- `README.md`: parenthetical pointer from the dependency list to the NOTICES.md section.

## Test plan

No code changes. No build impact. All modifications are text-only in documentation files + Makefile comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)