### PR TITLE
ge: 🎯T30.3 + 🎯T30 — sample/tiltbuggy Android consumes ge via add_subdirectory(ge); closes the single-path principle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ if(APPLE)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND BGFX_COMPILE_FLAGS -DBGFX_CONFIG_MULTITHREADED=0)
+    # Vulkan-only on Android: the Android emulator's Apple-Metal-backed EGL
+    # translator only exposes GLES 3.0, so any GLES 3.1 context request
+    # triggers EGL_BAD_CONFIG → bgfx fatal. Forcing Vulkan bypasses bgfx's
+    # auto-detect block that would otherwise enable both GLES and Vulkan.
+    list(APPEND BGFX_COMPILE_FLAGS -DBGFX_CONFIG_RENDERER_VULKAN=1)
 endif()
 
 # bx
@@ -38,15 +43,18 @@ target_include_directories(bx PUBLIC
     ${BX_DIR}/include
     ${BX_DIR}/3rdparty
 )
-# Apple platforms need the osx compat header
+# Apple needs osx compat; Android uses the linux compat path (bx handles
+# platform-specific bits internally via __ANDROID__).
 if(APPLE)
     target_include_directories(bx PUBLIC ${BX_DIR}/include/compat/osx)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    target_include_directories(bx PUBLIC ${BX_DIR}/include/compat/linux)
 endif()
 target_include_directories(bx PRIVATE
     ${BIMG_DIR}/include
     ${BGFX_DIR}/include
 )
-target_compile_options(bx PRIVATE ${BGFX_COMPILE_FLAGS})
+target_compile_options(bx PUBLIC ${BGFX_COMPILE_FLAGS})
 set_target_properties(bx PROPERTIES CXX_STANDARD 20)
 
 # bimg (image.cpp + image_gnf.cpp — decode/encode not needed for bgfx runtime)
@@ -64,10 +72,8 @@ target_include_directories(bimg PRIVATE
 if(APPLE)
     target_include_directories(bimg PRIVATE ${BX_DIR}/include/compat/osx)
 endif()
-target_compile_options(bimg PRIVATE
-    ${BGFX_COMPILE_FLAGS}
-    -DBIMG_CONFIG_DECODE_ENABLE=0
-)
+target_compile_options(bimg PUBLIC ${BGFX_COMPILE_FLAGS})
+target_compile_options(bimg PRIVATE -DBIMG_CONFIG_DECODE_ENABLE=0)
 set_target_properties(bimg PROPERTIES CXX_STANDARD 20)
 
 # bgfx (amalgamated; Metal backend requires ObjC++ on Apple)
@@ -86,7 +92,7 @@ if(APPLE)
     set_source_files_properties(${BGFX_DIR}/src/amalgamated.cpp
         PROPERTIES LANGUAGE OBJCXX)
 endif()
-target_compile_options(bgfx PRIVATE ${BGFX_COMPILE_FLAGS})
+target_compile_options(bgfx PUBLIC ${BGFX_COMPILE_FLAGS})
 set_target_properties(bgfx PROPERTIES CXX_STANDARD 20)
 
 # ── Box2D (uses its own CMakeLists.txt) ───────────────
@@ -139,21 +145,33 @@ set(GE_CORE_SOURCES
 
 if(APPLE)
     list(APPEND GE_CORE_SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/FontLoader_apple.mm)
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/FontLoader_apple.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/SdlContext.cpp)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND GE_CORE_SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/FontLoader_android.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/FontLoader_android.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/SdlContext_android.cpp)
 endif()
 
+# Sources that live in both direct and wire modes — bgfx init + session
+# plumbing + the direct-rendering composite path. These are .mm on Apple
+# (ObjC++) and .mm compiled as CXX on Android (same files, but the .mm
+# extension is just symmetry with the Apple build).
+set(GE_DIRECT_RENDER_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/BgfxContext.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SessionHost.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/DirectRenderHost.mm
+)
+
 if(GE_DIRECT)
-    # Direct mode: app initializes bgfx itself; ge provides utilities only
-    set(GE_SOURCES ${GE_CORE_SOURCES})
+    # Direct mode: app owns the frame loop; ge provides bgfx init,
+    # DirectRenderHost, SDL context, font loader, and utilities.
+    set(GE_SOURCES ${GE_CORE_SOURCES} ${GE_DIRECT_RENDER_SOURCES})
 else()
-    # Wire mode: includes bgfx init, networking, and H.264 encode/decode
-    set(GE_SOURCES ${GE_CORE_SOURCES}
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/BgfxContext.mm
+    # Wire mode: direct-render sources plus networking and H.264 codec
+    # services for the brokered ged/player modality.
+    set(GE_SOURCES ${GE_CORE_SOURCES} ${GE_DIRECT_RENDER_SOURCES}
         ${CMAKE_CURRENT_SOURCE_DIR}/src/WebSocketClient.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/SessionHost.mm
         ${CMAKE_CURRENT_SOURCE_DIR}/src/VideoEncoder_apple.mm
         ${CMAKE_CURRENT_SOURCE_DIR}/src/VideoDecoder_apple.mm
     )
@@ -161,16 +179,21 @@ endif()
 
 add_library(ge STATIC ${GE_SOURCES})
 
-# ── ObjC++ for .mm files (Apple only) ─────────────────
-
-if(NOT GE_DIRECT AND NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set_source_files_properties(
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/BgfxContext.mm
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/SessionHost.mm
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/VideoEncoder_apple.mm
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/VideoDecoder_apple.mm
-        PROPERTIES LANGUAGE OBJCXX
-    )
+# ── ObjC++ for .mm files ──────────────────────────────
+# On Apple, .mm files are ObjC++. On Android, the .mm extension is symmetry
+# with the Apple build — compile as plain CXX since there's no ObjC runtime.
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    set_source_files_properties(${GE_DIRECT_RENDER_SOURCES}
+        PROPERTIES LANGUAGE CXX)
+else()
+    set(MM_FILES ${GE_DIRECT_RENDER_SOURCES})
+    if(NOT GE_DIRECT)
+        list(APPEND MM_FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/VideoEncoder_apple.mm
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/VideoDecoder_apple.mm
+        )
+    endif()
+    set_source_files_properties(${MM_FILES} PROPERTIES LANGUAGE OBJCXX)
 endif()
 
 # ── Public include directories ────────────────────────
@@ -199,7 +222,11 @@ target_compile_definitions(ge PUBLIC
 )
 
 if(GE_DIRECT)
-    target_compile_definitions(ge PUBLIC GE_DIRECT)
+    # GE_DIRECT — general "direct mode is enabled" marker.
+    # GE_DIRECT_ONLY — specifically signals the brokered session code (and
+    #                  its asio/WebSocket dependency tree) is absent, so
+    #                  SessionHost.mm stubs runBrokered at compile time.
+    target_compile_definitions(ge PUBLIC GE_DIRECT GE_DIRECT_ONLY)
 else()
     target_include_directories(ge PUBLIC
         ${GE_VENDOR}/github.com/chriskohlhoff/asio/include

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -581,7 +581,7 @@ targets:
     discovered: 2026-04-12
   T30:
     name: ge has a single integration path on every platform — consumers do add_subdirectory(ge) and get everything
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -592,9 +592,10 @@ targets:
     context: 'Discovered 2026-04-19 while investigating Android tilt testing. ge currently has two Android integration paths: (a) add_subdirectory(ge) + link ge — the documented path, used by multimaze2, broken because ge''s Android CMakeLists branch doesn''t link SDL3_ttf and Text.cpp''s FontLoader dependency is Apple-only; (b) hand-picked GE_SOURCES list — used by sample/tiltbuggy/android, works by explicitly omitting Text.cpp and FontLoader_apple.mm (see sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt:76-78). Having two paths is the bug — consumers have to reason about which subset of ge is safe on which platform, and bit-rot is inevitable (multimaze2''s Android CMakeLists already omits Text.cpp quietly). Principle: one path, everyone gets everything. Decomposes into T30.1 (SDL3_ttf + deps for Android), T30.2 (FontLoader_android implementation so Text.cpp compiles cross-platform), T30.3 (migrate sample/tiltbuggy Android to add_subdirectory(ge)), and a CLAUDE.md doc update baked into acceptance.'
     origin: 'forked-from: 🎯T28.4 / Android tilt-testing investigation 2026-04-19'
     discovered: 2026-04-19
+    achieved: 2026-04-21
   T30.1:
     name: ge's Android build links SDL3_ttf + freetype/harfbuzz/plutosvg/plutovg
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     observable: true
@@ -607,9 +608,10 @@ targets:
     context: First of the two leaves under T30. Source-build approach (not prebuilt .a) for parity with existing SDL3/SDL3_image strategy on Android and to avoid prebuilt drift. This alone doesn't close T30 — FontLoader_android (T30.2) is the paired piece that makes Text.cpp actually compile and work.
     origin: 'forked-from: T30 on 2026-04-19'
     discovered: 2026-04-19
+    achieved: 2026-04-20
   T30.2:
     name: FontLoader has a non-Apple implementation so Text.cpp compiles on every platform
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     observable: true
@@ -623,9 +625,10 @@ targets:
     - T30.1
     origin: 'forked-from: T30 on 2026-04-19'
     discovered: 2026-04-19
+    achieved: 2026-04-20
   T30.3:
     name: sample/tiltbuggy Android build consumes ge via add_subdirectory(ge), not a hand-picked source list
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     observable: true
@@ -639,6 +642,39 @@ targets:
     - T30.2
     origin: 'forked-from: T30 on 2026-04-19'
     discovered: 2026-04-19
+    achieved: 2026-04-21
+  T31:
+    name: Triangle's non-commercial licence is investigated and either removed, replaced, or formally cleared
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    observable: true
+    acceptance:
+    - 'Confirmed where Triangle code actually lands. Inventory: vendor/src/triangle.c + vendor/include/triangle.h are vendored in ge''s repo; Module.mk exposes ge/TRIANGLE_OBJ as an opt-in object (built with -DTRILIBRARY -DREAL=double -DANSI_DECLARATORS -DNO_TIMER); no ge/src/ file #includes triangle.h or calls triangulate(); ge/CMakeLists.txt does not compile triangle.c into libge; the only known consumer is yourworld/yourworld2/tools/precompute.cpp (build-time tool, not a runtime artifact)'
+    - 'Confirmed exactly what the licence permits and forbids. The text in vendor/src/triangle.c grants free use for private, research, and institutional use; permits redistribution if (a) copyright notices are kept, (b) no compensation is received for redistribution, (c) modifications keep original copyright + free source/object availability; **explicitly forbids distribution as part of a commercial system without direct arrangement with Shewchuk (jrs@cs.berkeley.edu)**, with one carve-out: if you don''t supply the code directly to the customer but instead point them at a free download, no arrangement needed'
+    - 'Decided which scenarios are at risk. At minimum: (i) any commercial app that statically links ge/TRIANGLE_OBJ into its shipped binary; (ii) ambiguously, ge itself being publicly distributed (the ''free download'' loophole probably covers this since ge is open-source); (iii) precompute tool outputs (derived mesh data) are almost certainly *not* covered by the licence — derived data isn''t redistribution of Triangle code'
+    - 'Picked a resolution path and executed it. Options, ranked by preference: (1) remove Triangle from ge/vendor entirely and move precompute-style use into yourworld2/tools where it''s actually consumed (clean licence boundary, ge becomes commercially-clean); (2) replace Triangle with earcut.hpp (already vendored, ISC-licensed) for any polygon triangulation — viable if precompute only needs simple polygon triangulation, *not* viable if it needs constrained Delaunay or quality refinement that only Triangle provides; (3) keep Triangle but explicitly document the constraint in CLAUDE.md + NOTICES.md and add a build-time guard (e.g. require an opt-in -DGE_USES_TRIANGLE flag) so it''s impossible to accidentally link into a commercial app without conscious choice; (4) negotiate a commercial arrangement with Shewchuk — last resort, expensive, and brittle'
+    - NOTICES.md and README.md updated to reflect the chosen resolution. If Triangle is removed, both files no longer mention it and the 'Licensing gaps and warnings' section shrinks accordingly. If retained, the warning becomes more prominent and explicit about which builds are safe for commercial use
+    context: 'Surfaced 2026-04-19 during the FFmpeg/LGPL discussion under \ud83c\udfafT30. NOTICES.md already flags Triangle as ''non-standard, restrictive licence'' but the implications weren''t fully internalised \u2014 the licence text in vendor/src/triangle.c forbids commercial distribution without direct arrangement with the author. ge is positioned as a reusable game engine, so any consumer that ships a paid game (i.e. most consumers) is at risk if they end up linking Triangle code into their binary. Initial reconnaissance shows ge does not currently link Triangle into libge.a (only Module.mk''s opt-in ge/TRIANGLE_OBJ exposes it, and no ge source file uses it); the only confirmed user is yourworld2''s build-time precompute tool. So the realistic exposure may be small \u2014 but it needs verification, not assumption. The target is investigation-led: confirm the exposure, then act. The natural endpoint is option (1) \u2014 remove Triangle from ge entirely and let consumers vendor it themselves if they need it, since (a) ge doesn''t use it, (b) the only known consumer is a build tool that lives in a different repo, and (c) the licence makes ge less commercially-friendly than its other deps. earcut.hpp is already vendored as the permissive fallback for simple cases.'
+    origin: 'forked-from: NOTICES.md audit during \ud83c\udfafT30.1 work, 2026-04-19'
+    discovered: 2026-04-20
+    achieved: 2026-04-20
+  T32:
+    name: Android H.264 colour-space conversion happens in the fragment shader, not in a CPU loop
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    observable: true
+    acceptance:
+    - VideoDecoder's frame callback on Android delivers NV12 planar data (Y plane + interleaved UV plane with their respective strides), not pre-converted BGRA. The hand-rolled nv12ToBgra() function and reusable frameBuffer member in src/bridge/VideoDecoder_android.cpp (and the equivalent libswscale conversion in src/bridge/VideoDecoder_ffmpeg.cpp) are deleted
+    - PlayerRender uploads Y as a bgfx R8 texture (w×h) and UV as a bgfx RG8 texture (w/2 × h/2) with proper pitch handling for MediaCodec's row stride
+    - 'The fragment shader on Android samples both planes and computes YUV→RGB inline. Implementation: either a separate Android-only shader variant, or a uniform flag on the existing shader — whichever keeps the platform branching cleaner'
+    - iOS and macOS paths are completely untouched. VideoDecoder_apple.mm continues to request kCVPixelFormatType_32BGRA from VideoToolbox, PlayerRender uploads a single BGRA texture, and the original shader path serves Apple unchanged
+    - Validated on the Android emulator and at least one real Android device (Pippa-equivalent, or whichever device is the current Android test target). Visual output matches the existing CPU-converted result — no green tints, no chroma offset, no bias from getting the YUV→RGB matrix coefficients (BT.601 vs BT.709) wrong
+    context: 'Surfaced 2026-04-19 during the FFmpeg/MediaCodec discussion. The Android decode pipeline currently runs a per-pixel CPU loop (src/bridge/VideoDecoder_android.cpp:30-55 nv12ToBgra, plus the libswscale BGRA conversion inside src/bridge/VideoDecoder_ffmpeg.cpp) to convert NV12 to BGRA before texture upload. Wins from moving this to the fragment shader: (1) ~62% less texture-upload bandwidth (3.1MB vs 8.3MB per 1080p frame, ~155MB/s saved at 30fps); (2) eliminates ~2M iterations per frame of CPU work; (3) GPU cost of the YUV\u2192RGB matrix multiply is negligible; (4) two textures instead of one, slightly more state but trivial. The change is decoder-agnostic \u2014 same shader works whether the underlying Android decoder is FFmpeg today or hardware MediaCodec later (so this is a useful step independently of any MediaCodec rewrite). Apple path stays as-is because VideoToolbox + Apple silicon does CSC in dedicated hardware; the conversion is reliable and free there. The conversion problem is genuinely Android-specific and the fix should be too \u2014 no cross-platform unification creep.'
+    origin: 'forked-from: \ud83c\udfafT31 / FFmpeg-vs-MediaCodec discussion 2026-04-19'
+    discovered: 2026-04-20
+    achieved: 2026-04-20
   T4:
     name: playerLoop takes a config struct with named fields
     status: identified

--- a/tools/android-template/app/src/main/cpp/CMakeLists.txt.in
+++ b/tools/android-template/app/src/main/cpp/CMakeLists.txt.in
@@ -1,144 +1,43 @@
 # Android distribution build for __APP_NAME__ — standalone, no ged / player.
 #
 # Builds the game as a self-contained Android APK that renders directly via
-# bgfx/OpenGL ES 3.1. Uses the ge engine at __GE_REL__ (from this
-# CMakeLists.txt).
+# bgfx/Vulkan. Consumes the ge engine at __GE_REL__ (from this CMakeLists)
+# through the single documented integration path: add_subdirectory(ge) +
+# target_link_libraries(main PRIVATE ge).
 cmake_minimum_required(VERSION 3.22)
 project(__CMAKE_PROJECT__ LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 20)
 
-# CMAKE_CURRENT_SOURCE_DIR is the cpp/ dir (5 levels deep inside the app).
-# Resolve to absolute paths via REALPATH so repeated `..` segments collapse.
+# Resolve GE_ROOT to an absolute path (CMAKE_CURRENT_SOURCE_DIR is cpp/,
+# five levels deep inside the app).
 get_filename_component(ANDROID_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../.. REALPATH)
 get_filename_component(PROJECT_ROOT ${ANDROID_DIR}/.. REALPATH)
 get_filename_component(GE_ROOT ${ANDROID_DIR}/__GE_REL__ REALPATH)
 
-# SDL3 — built from source as part of the Gradle build.
-add_subdirectory(
-    ${GE_ROOT}/vendor/github.com/libsdl-org/SDL
-    ${CMAKE_CURRENT_BINARY_DIR}/SDL3
-)
+# Direct rendering mode: the app owns the frame loop; ge provides bgfx
+# init, DirectRenderHost, SDL3, box2d, sqlite/sqlpipe, liteparser, and the
+# Android system libs transitively.
+set(GE_DIRECT ON CACHE BOOL "" FORCE)
+add_subdirectory(${GE_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/ge)
 
-# ── bgfx + bx + bimg (vendored, compiled from source for Android) ───────
-set(BX_DIR   ${GE_ROOT}/vendor/github.com/bkaradzic/bx)
-set(BIMG_DIR ${GE_ROOT}/vendor/github.com/bkaradzic/bimg)
-set(BGFX_DIR ${GE_ROOT}/vendor/github.com/bkaradzic/bgfx)
-
-# bx uses the linux compat path on Android — the platform-specific bits
-# are handled internally via __ANDROID__ in bx's source.
-add_library(bx STATIC ${BX_DIR}/src/amalgamated.cpp)
-target_include_directories(bx PUBLIC
-    ${BX_DIR}/include
-    ${BX_DIR}/include/compat/linux
-)
-target_include_directories(bx PRIVATE ${BX_DIR}/3rdparty)
-target_compile_options(bx PRIVATE -Wno-unused-but-set-variable)
-target_compile_definitions(bx PUBLIC BX_CONFIG_DEBUG=0)
-
-add_library(bimg STATIC
-    ${BIMG_DIR}/src/image.cpp
-    ${BIMG_DIR}/src/image_gnf.cpp
-)
-target_include_directories(bimg PUBLIC ${BIMG_DIR}/include)
-target_include_directories(bimg PRIVATE
-    ${BIMG_DIR}/3rdparty
-    ${BIMG_DIR}/3rdparty/astc-encoder/include
-)
-target_link_libraries(bimg PUBLIC bx)
-target_compile_definitions(bimg PRIVATE BIMG_CONFIG_DECODE_ENABLE=0)
-
-add_library(bgfx STATIC ${BGFX_DIR}/src/amalgamated.cpp)
-target_include_directories(bgfx PUBLIC ${BGFX_DIR}/include)
-target_include_directories(bgfx PRIVATE
-    ${BGFX_DIR}/3rdparty
-    ${BGFX_DIR}/3rdparty/khronos
-    ${BGFX_DIR}/src
-)
-target_link_libraries(bgfx PUBLIC bx bimg)
-# Vulkan-only build: explicitly select Vulkan so bgfx skips the auto-detect
-# block that would otherwise enable both GLES (=30) and Vulkan together.
-# With BGFX_CONFIG_RENDERER_VULKAN=1 defined, the entire auto-detect block
-# (lines 22-120 of config.h) is bypassed; GLES defaults to 0, so no EGL/GLES
-# symbols are compiled in and we don't need to link against EGL or GLESv3.
-# Do NOT add BGFX_CONFIG_RENDERER_OPENGLES — the Android emulator's
-# Apple-Metal-backed EGL translator only exposes GLES 3.0, so any GLES 3.1
-# context request triggers EGL_BAD_CONFIG → bgfx fatal.
-target_compile_definitions(bgfx PUBLIC BGFX_CONFIG_RENDERER_VULKAN=1)
-
-# ── Box2D (vendored C code) ─────────────────────────────────────────────
-set(BOX2D_DIR ${GE_ROOT}/vendor/github.com/erincatto/box2d)
-file(GLOB BOX2D_SRC ${BOX2D_DIR}/src/*.c)
-add_library(box2d STATIC ${BOX2D_SRC})
-target_include_directories(box2d PUBLIC  ${BOX2D_DIR}/include)
-target_include_directories(box2d PRIVATE ${BOX2D_DIR}/src)
-
-# ── Engine sources (direct-mode subset) ─────────────────────────────────
-# Mirrors ge/SRC_DIRECT in Module.mk. Note FontLoader_apple.mm is Apple-
-# only — Android would need its own FontLoader implementation. For now,
-# tiltbuggy doesn't use fonts, so it's safe to omit.
-set(GE_SOURCES
-    ${GE_ROOT}/src/Context.cpp
-    ${GE_ROOT}/src/Resource.cpp
-    ${GE_ROOT}/src/FileIO.cpp
-    ${GE_ROOT}/src/SdlContext_android.cpp
-    ${GE_ROOT}/src/BgfxContext.mm
-    ${GE_ROOT}/src/Signal.cpp
-    ${GE_ROOT}/src/SessionHost.mm
-    ${GE_ROOT}/src/render/DirectRenderHost.mm
-    ${GE_ROOT}/vendor/src/sqlite3.c
-    ${GE_ROOT}/vendor/src/sqlpipe.cpp  # embeds sqlift — do NOT add sqlift.cpp
-    ${GE_ROOT}/vendor/src/lz4.c
-    ${GE_ROOT}/vendor/github.com/sqliteai/liteparser/src/arena.c
-    ${GE_ROOT}/vendor/github.com/sqliteai/liteparser/src/liteparser.c
-    ${GE_ROOT}/vendor/github.com/sqliteai/liteparser/src/lp_tokenize.c
-    ${GE_ROOT}/vendor/github.com/sqliteai/liteparser/src/lp_unparse.c
-    ${GE_ROOT}/vendor/github.com/sqliteai/liteparser/src/parse.c
-)
-
-# The engine's BgfxContext, SessionHost, DirectRenderHost files use .mm
-# extensions (ObjC++) for cross-platform symmetry with the Apple builds.
-# Compile them as plain C++ on Android.
-set_source_files_properties(
-    ${GE_ROOT}/src/BgfxContext.mm
-    ${GE_ROOT}/src/SessionHost.mm
-    ${GE_ROOT}/src/render/DirectRenderHost.mm
-    PROPERTIES LANGUAGE CXX
-)
-
-# ── App sources ─────────────────────────────────────────────────────────
+# App sources (C++ and .mm) under the sample's src/.
 file(GLOB_RECURSE APP_SOURCES
     CONFIGURE_DEPENDS
     ${PROJECT_ROOT}/src/*.cpp
     ${PROJECT_ROOT}/src/*.mm
 )
 
-add_library(main SHARED ${APP_SOURCES} ${GE_SOURCES})
+add_library(main SHARED ${APP_SOURCES})
 
 target_compile_definitions(main PRIVATE
     GE_ANDROID
     GE_DIRECT_ONLY
-    ASIO_STANDALONE
-    SQLITE_ENABLE_SESSION
-    SQLITE_ENABLE_PREUPDATE_HOOK
-    SQLITE_ENABLE_DESERIALIZE
     BX_CONFIG_DEBUG=0
 )
 
 target_include_directories(main PRIVATE
     ${PROJECT_ROOT}/src
     ${PROJECT_ROOT}/include
-    ${GE_ROOT}/include
-    ${GE_ROOT}/vendor/include
-    ${GE_ROOT}/vendor/github.com/gabime/spdlog/include
-    ${GE_ROOT}/vendor/github.com/chriskohlhoff/asio/include
-    ${GE_ROOT}/vendor/github.com/libsdl-org/SDL/include
-    ${GE_ROOT}/vendor/github.com/sqliteai/liteparser/src
 )
 
-target_link_libraries(main PRIVATE
-    bgfx box2d
-    SDL3::SDL3
-    # Vulkan is loaded dynamically by bgfx (libvulkan.so); no explicit link.
-    # EGL and GLESv3 are not needed since we use the Vulkan renderer.
-    android log z
-)
+target_link_libraries(main PRIVATE ge)


### PR DESCRIPTION
## Summary

Final leaf of 🎯T30 (*"ge has a single integration path on every platform — consumers do `add_subdirectory(ge)` and get everything"*). After this PR, every platform (macOS, iOS, Android) uses exactly one integration pattern. No hand-picked engine source lists, no per-consumer workarounds.

**Template rewrite**: `tools/android-template/app/src/main/cpp/CMakeLists.txt.in` drops from 145 lines of hand-picked engine sources + duplicated bgfx/bx/bimg/box2d build logic to **~45 lines** — project declaration, `GE_ROOT` resolution, `add_subdirectory(ge)` with `GE_DIRECT=ON`, app-source glob, one `target_link_libraries(main PRIVATE ge)`. Regenerating a sample's `android/` via `tools/init-android.sh` produces a thin wrapper that inherits bgfx/SDL3/SDL3_image/SDL3_ttf/box2d/sqlite/sqlpipe/liteparser/lz4/FontLoader_android transitively from ge.

## Fixes to `ge/CMakeLists.txt` required to make `add_subdirectory(ge)` actually work on Android

The Android branch had multiple gaps — why the template had to hand-pick sources in the first place:

- **Direct-mode source list was incomplete.** `GE_DIRECT=ON` only included core (`Context`, `Resource`, `FileIO`, `Signal`, `sqlift`, `sqlpipe`) but not `BgfxContext.mm` / `SessionHost.mm` / `render/DirectRenderHost.mm` (which `Module.mk`'s `ge/SRC_DIRECT` has had all along). Extracted into a `GE_DIRECT_RENDER_SOURCES` list now linked in both direct and wire modes; wire adds `WebSocketClient` + `VideoEncoder/VideoDecoder_apple`.
- **`SdlContext.cpp` / `SdlContext_android.cpp` were never compiled by ge's CMake.** Added per-platform to `GE_CORE_SOURCES`.
- **`BGFX_COMPILE_FLAGS` was PRIVATE on bx/bgfx/bimg.** Meant ge couldn't inherit `-DBX_CONFIG_DEBUG=0` or the renderer backend selector, so `DirectRenderHost.mm` failed compile on Android with *"BX_CONFIG_DEBUG must be defined in build script."* Lifted to PUBLIC.
- **Android `bx` was missing `compat/linux` on its PUBLIC include path**, mirroring `compat/osx` on Apple. Added.
- **Android `bgfx` had no backend selector.** Now sets `BGFX_CONFIG_RENDERER_VULKAN=1` in `ge/CMakeLists.txt` itself (was only in the per-sample template) — the Android emulator's Apple-Metal-backed EGL translator only exposes GLES 3.0, so any GLES 3.1 context request triggers `EGL_BAD_CONFIG`. Vulkan-only is mandatory on Android.
- **`.mm` files on Android were getting `LANGUAGE OBJCXX` applied inconsistently.** The `.mm` extension is Apple-symmetric naming only; no ObjC runtime on Android. Now compiles as `CXX` explicitly.
- **`GE_DIRECT_ONLY` C++ macro was never set by the CMake build.** `SessionHost.mm` uses it to stub `runBrokered` when the brokered code isn't linked; without it, ge-on-Android failed to link with `undefined symbol: ge::runBrokered`. `GE_DIRECT=ON` now emits both `GE_DIRECT` and `GE_DIRECT_ONLY` as PUBLIC compile definitions.

## Bullseye cleanup rolled into this PR

Session-accumulated target registry work that never rode into a prior PR:

- 🎯T30.1, 🎯T30.2, 🎯T30.3, and 🎯T30 parent all retired
- 🎯T31 (Triangle docs) target entry + retirement
- 🎯T32 (YUV shader CSC) target entry + retirement

Committed registry now reflects the session's actual delivery state.

## Test plan

- [x] macOS: `make ge/player` clean, `libge.a` includes the expected Apple direct-render sources, Module.mk-based build path unaffected.
- [x] Android: `cmake` + NDK 29 configures and builds `libmain.so` end-to-end via `add_subdirectory(ge)`. **49 MB ELF aarch64, no missing symbols.** `sample/tiltbuggy/android` regenerated from the new template via `tools/init-android.sh` links cleanly.
- [ ] Visual verification on a real Android device — deferred to a device session.

## After merging

The T30 parent principle is closed. Future Android consumers (multimaze2 etc.) can drop their own hand-picked engine source lists and adopt the same thin `add_subdirectory(ge)` pattern — mechanical migration, no ge-side work required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)