### PR TITLE
ge: rewrite 🎯T11 family for pigeon-as-it-is (v0.20.0) — target-only, no code

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 3
 targets:
   T1:
     name: Game servers can run inside the player via WebAssembly
@@ -45,102 +45,163 @@ targets:
     origin: user request
     discovered: 2026-04-15
   T11:
-    name: ged uses pigeon for all networking between server, player, and daemon
+    name: ge's player↔server transport runs on pigeon (E2E-encrypted relay) instead of plain WebSocket through ged
     status: identified
     value: 13.0
     cost: 20.0
     acceptance:
-    - No WebSocket code remains in ged or ge client code (coder/websocket removed from go.mod, Asio WS framing removed from WebSocketClient.cpp)
-    - Server↔ged and player↔ged connections use pigeon streams
-    - H.264 video frames flow over pigeon (streams or datagrams)
-    - Input events flow back from player to server over pigeon
-    - Dashboard sideband (logs, preview, tweaks) works over pigeon
-    - LAN mode works without a relay when server and player are colocated
-    - Existing ge::run() API contract unchanged — apps don't need modification
-    context: Replace ged's hand-rolled WebSocket stack (coder/websocket in Go, Asio TCP+WS framing in C++) with pigeon (github.com/marcelocantos/pigeon). Pigeon provides QUIC/WebTransport relay with E2E encryption, LAN upgrade, and native SDKs for Go, Swift, and Kotlin — eliminating the need for ged to be on the same LAN, enabling mobile players to connect over the internet, and removing the custom WebSocket framing code.
+    - The player connects to the game server via pigeon's relay (Register/Connect or LAN bypass) — not via a WebSocket through ged. Wire framing is pigeon's stream + datagram protocol; payloads are ciphertext at the relay layer. ged's role is reduced to (a) issuing PairingArtifacts via pigeon.PairingHost so newly-installed players can establish first-contact with a server, and (b) the dashboard. ged is no longer on the runtime data path between server and player.
+    - All session traffic is end-to-end encrypted via pigeon's X25519 ECDH + AES-256-GCM channel. Neither ged nor the relay can read plaintext. The QR scan that today carries a server name + port now carries a pigeon PairingArtifact (base64url) — one-time-use, TTL-bound (default 30 days), persistable on the player so reconnects skip the ceremony.
+    - H.264 video frames flow over pigeon datagram channels (with pigeon's automatic fragmentation and reassembly), not the reliable stream. Keyframes optionally promoted to streams if measured packet loss makes pure-datagram delivery insufficient. Input events flow over reliable streams.
+    - Multiple players can attach to the same server via pigeon's per-instance fan-out (one Register on the server side, multiple Connects from players, each with an independent encrypted channel). Replaces ged's current per-session WebSocket multiplexing.
+    - 'LAN bypass is enabled: when player and server are on the same Wi-Fi, pigeon''s LANServer is used and the relay round-trip is skipped. Falls back to relay automatically on LAN failure or NAT crossing. Visible in logs and ideally via a player UI indicator.'
+    - ge/include/ge/Protocol.h's hand-rolled magic-number constants and MessageHeader struct are replaced by a pigeon protocol/ YAML declaration that generates Go (server-side / ged), Swift (iOS player), Kotlin (Android player), and C (mobile bgfx-direct player) bindings. No more parallel definitions of kVideoStreamMagic / kSdlEventMagic etc. across files.
+    - All WebSocket plumbing — ge/src/bridge/WebSocketClient.cpp, ge/src/bridge/PlayerWireBridge.cpp, ge/src/bridge/SessionHost_brokered.mm's WS code path, ged's gorilla/websocket dependency — is removed once every consumer (server, player, ged dashboard) has cut over.
+    - 'End-to-end test: a fresh player install scans a QR (or imports a PairingArtifact), connects to a server (via relay or LAN), receives video, sends input, disconnects, reconnects later (within TTL) without rescanning. Reproducible via ge''s matrix-cell.sh on at least one mobile platform.'
+    context: 'Rewritten 2026-04-26. The original T11 (''ged uses pigeon for all networking between server, player, and daemon'') and its sub-targets T11.1–T11.6 imagined pigeon as a daemon-style backend that ged would register against. Pigeon-as-it-actually-exists at v0.20.0 is fundamentally different: it''s an importable library across Go/Swift/Kotlin/C/TypeScript that does relay + E2E crypto + pairing + protocol code-generation as a single integrated story.\n\nKey shifts in pigeon''s surface that motivate the rewrite:\n- pigeon.Register() / pigeon.Connect() are application-level calls. The relay (cmd/pigeon, deployable on Fly.io as carrier-pigeon.fly.dev) is just QUIC/WebTransport bridging — it doesn''t know about ged at all.\n- E2E encryption is built in: X25519 ECDH key exchange, AES-256-GCM with monotonic-counter nonces. Neither relay nor any intermediary sees plaintext. Solves a security gap ge currently doesn''t address (today it relies on WebSocket TLS to a trusted ged).\n- Pairing ceremony with 6-digit confirmation codes for MitM resistance. Codified as a state machine in pigeon''s protocol/ package.\n- PairingArtifact (v0.19.0) is a persistable, expirable envelope around a pairing record. Wire format is snake_case JSON / base64url text, portable across all SDKs. Player paired once can reconnect later within TTL without redoing the ceremony.\n- pigeon.PairingHost is the server-side artifact minter. The ''pigeon pair'' CLI subcommand exposes the same.\n- Reliable streams + unreliable datagrams in one channel. Datagrams have automatic fragmentation/reassembly with a 5-second discard window for incomplete sets. Video frames belong on datagrams; input events on streams.\n- LAN bypass: pigeon.Config.LANServer enables direct peer-to-peer when on the same network, falls back to relay otherwise. Saves the relay round-trip in the common ''phone+laptop'' scenario.\n- Multiple clients per instance ID. The relay maintains independent bridges per client. One server can fan out to N players without doing the multiplexing itself.\n- Protocol-as-YAML framework in pigeon''s protocol/ package. State machines are declared once in YAML and generated to Go/Swift/Kotlin/C/TypeScript/TLA+/PlantUML. ge''s hand-written Protocol.h with magic numbers across Apple .mm files and Go bridge code is exactly the duplication this framework eliminates.\n- C library (dist/pigeon.h + libsodium + ngtcp2 transport) means iOS/Android player binaries can speak pigeon natively without a Go runtime — important for ge''s bgfx-direct mobile players that currently have no networking at all on the direct path.\n\nged''s role under the new model:\n- Pairing-artifact issuer: ged''s web dashboard mints a PairingArtifact via pigeon.PairingHost, presents it as a QR, and the player imports. Replaces today''s name+port QR.\n- Optional management dashboard. Today ged is on the runtime data path; under the new model it''s just the pairing/discovery service — once player and server are paired, all traffic flows directly through pigeon, ged is not needed at runtime.\n- (Possibly) TURN-style signalling for LAN-bypass discovery, though pigeon''s LAN logic may handle this independently.\n\nReadiness considerations:\n- pigeon v0.20.0 just shipped; not 1.0 eligible until 2026-06-25 minimum (settling clock reset by v0.19.0''s Swift PairingRecord JSON wire format change). PairingArtifact API is ''Needs Review'' — wants real-world consumer feedback before freezing. ge would be an ideal first consumer, with the caveat that the surface may shift slightly before 1.0.\n- pigeon''s TypeScript/web pairing-artifact parity is explicitly out of scope until web stabilises — relevant if the ge dashboard wants to embed pigeon-pairable web players. Defer that until pigeon ships it.\n- The C library is Fluid — stabilisation depends on real consumer feedback. ge mobile is again an ideal first consumer.\n\nDecomposition (sub-targets T11.1–T11.6) is rewritten to match this model.'
+    tags:
+    - pigeon
+    - transport
+    - encryption
+    - pairing
+    - wire-protocol
+    - architecture
     origin: user request
     discovered: 2026-04-12
   T11.1:
-    name: pigeon is vendored as a Go dependency in ged
+    name: ge's wire protocol is declared once in pigeon-protocol YAML; magic numbers and message structs are generated for Go, Swift, Kotlin, and C
     status: identified
     value: 3.0
     cost: 2.0
     acceptance:
-    - go.mod has pigeon dependency with replace directive pointing to local checkout
-    - go build succeeds
-    context: Add github.com/marcelocantos/pigeon to ged's go.mod. ged lives at ge/ged/ with its own go.mod. Pigeon is at ../../marcelocantos/pigeon — use a replace directive for local dev.
+    - 'A protocol/ge_wire.yaml file (in ge/ or vendored) declares every message ge currently exchanges over WebSocket: DeviceInfo, SafeAreaUpdate, AspectLock, SdlEvent, VideoStream (NAL frames), StreamStart/Stop, ServerAssigned, SessionEnd, SessionConfig, PlayerLog. Each message has a name, ID, fields, and direction.'
+    - Running `pigeon protocol generate --target=go ge_wire.yaml` produces a Go file with typed structs and message-id constants that replaces ged's hand-rolled wire constants. Likewise --target=swift / --target=kotlin / --target=c produce equivalent bindings for the iOS player, Android player, and bgfx-direct mobile player respectively.
+    - ge/include/ge/Protocol.h's hand-rolled `kVideoStreamMagic` / `kSdlEventMagic` / `kSessionEndMagic` / `kStreamStartMagic` / `kStreamStopMagic` / `kServerAssignedMagic` / `kSafeAreaMagic` / `kAspectLockMagic` constants are deleted and replaced by includes / imports of the generated bindings. The wire-format catalogue in ge's CLAUDE.md is regenerated from the YAML rather than hand-maintained.
+    - 'Adding a new message becomes a one-place change: edit the YAML, regenerate, the new constant + struct appears in every binding. No more searching for parallel definitions across .mm files, Go code, and Protocol.h.'
+    - Generation is wired into ge's build (Module.mk + CMakeLists) as a normal codegen step — not a manual one-off. CI fails if generated files are out of sync with the YAML.
+    context: 'Replaces the previous T11.1 (''pigeon is vendored as a Go dependency in ged''). Vendoring is no longer the interesting question — pigeon is a published Go module (github.com/marcelocantos/pigeon). The actual cross-cutting win from pigeon for ge''s wire protocol is the YAML-driven code-generation framework.\n\nge currently has wire constants and message structs in:\n- ge/include/ge/Protocol.h (C++ #define constants)\n- ge/src/bridge/SessionHost_brokered.mm (Apple Server side)\n- ge/src/bridge/PlayerWireBridge.cpp (Apple Player side)\n- ge/src/bridge/ServerWireBridge.mm (Apple)\n- ged Go code (server side, hand-rolled magic numbers)\n\nThis is exactly the parallel-definitions trap pigeon''s protocol/ package is designed to eliminate. Pigeon''s PairingCeremony() function in Go is the canonical example of how a YAML-declared protocol gets exposed across all language bindings.\n\nRelative dependency: this can land BEFORE T11.2 (pairing) and T11.3 (datagram channels) — it''s pure infrastructure cleanup. Once the bindings exist, downstream sub-targets switch to using them rather than hand-rolled equivalents.'
+    depends_on:
+    - T11
+    tags:
+    - pigeon
+    - protocol
+    - codegen
+    - wire-protocol
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.2:
-    name: ged registers as a pigeon backend and accepts client connections
+    name: First-contact between player and server uses pigeon's PairingArtifact (QR scan delivers the artifact; player persists it for reconnect)
     status: identified
     value: 8.0
     cost: 5.0
     acceptance:
-    - ged starts a pigeon LANServer and logs its instance ID
-    - A pigeon client can connect to ged's instance ID
-    - ged distinguishes game vs player connections via initial message
-    context: ged calls pigeon.Register() on startup (LAN mode, no relay). Games and players connect via pigeon.Connect(). ged accepts connections and identifies them as game or player based on the initial handshake message. This replaces the WebSocket Accept on /ws/server and /ws/wire. The HTTP server (dashboard, REST API, MCP) stays on the existing port unchanged.
+    - ged's web dashboard mints a PairingArtifact via pigeon.PairingHost.Mint() for each newly-launched server (server-side PairingRecord stored in ged's state). The QR code displayed by the dashboard now encodes the artifact (base64url text, ~few hundred bytes), not a name+port pair.
+    - Player on first launch scans the QR, parses the PairingArtifact, calls pigeon.ConnectWithArtifact(), and is now in an E2E-encrypted session with the server.
+    - Player persists the PairingArtifact via pigeon's CredentialStore (FileCredentialStore on desktop; platform-appropriate equivalent on iOS Keychain / Android Keystore on mobile). On subsequent launches, the player loads the stored artifact and reconnects without re-scanning — unless the artifact is expired (default 30-day TTL) or the user explicitly re-pairs.
+    - Player surfaces the 6-digit confirmation code from pigeon's pairing ceremony during first-contact (and only first-contact). User compares it visually to the code shown by the dashboard and confirms or rejects. MitM attempts are caught by code mismatch.
+    - Server-side PairingRecord storage in ged survives ged restarts — paired players continue to reconnect after the daemon process bounces.
+    context: 'Replaces the previous T11.2 (''ged registers as a pigeon backend and accepts client connections''). ged isn''t a pigeon backend; pigeon backends are individual servers. ged''s role under the new model is pairing-artifact issuer, not relay endpoint.\n\nBenefits over the current ''QR carries name+port'' model:\n- Persistent across reconnects: today the player has to re-scan a QR (or rely on cached config) every time the server restarts. PairingArtifact + CredentialStore makes re-pair a one-time event.\n- MitM resistance: today a malicious actor on the same network could MitM the WebSocket. The 6-digit confirmation code rules this out.\n- Cross-platform pairing wire format: snake_case JSON / base64url text matches Go/Swift/Kotlin SDKs, so an artifact minted on the server can be read by any player.\n\nNotably, this target is technically achievable BEFORE the rest of T11 — the artifact-driven pairing can be deployed under today''s WebSocket transport as a first step (use the artifact''s pairing record to derive a key for WS-payload encryption), then the underlying transport gets swapped to pigeon in T11.3+. Allows incremental cutover instead of a big bang.'
     depends_on:
-    - T11.1
+    - T11
+    tags:
+    - pigeon
+    - pairing
+    - PairingArtifact
+    - qr
+    - e2e-crypto
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.3:
-    name: Game server sideband uses pigeon channel instead of WebSocket
+    name: 'Server↔player runtime traffic flows over pigeon channels: video on datagrams, input/control on reliable streams'
     status: identified
     value: 5.0
     cost: 5.0
     acceptance:
-    - Game server connects to ged via pigeon and opens a sideband channel
-    - JSON control messages flow over the pigeon channel
-    - No /ws/server WebSocket endpoint remains
-    context: 'Replace the game server''s /ws/server WebSocket connection with a pigeon channel. The sideband carries JSON control messages: hello, log, preview, accel, tweaks, player_attached, player_detached. Game connects to ged via pigeon.Connect(), opens a sideband channel. ged side: replace handleServerSideband WebSocket handler with pigeon channel accept. C++ side: replace WebSocketClient.cpp Asio+TCP WS framing with pigeon (needs a C/C++ wrapper or cgo bridge).'
+    - The H.264 NAL-unit stream from server to player rides on a pigeon DatagramChannel. Pigeon's automatic fragmentation handles NAL units larger than the QUIC datagram MTU; the 5-second incomplete-set discard window is acceptable because lost frames are recoverable via the next keyframe.
+    - Input events (SdlEvent, SafeAreaUpdate) from player to server ride on a pigeon reliable StreamChannel. Loss of an input event is unacceptable; reliable framing matches.
+    - Control messages (SessionConfig, StreamStart/Stop, ServerAssigned, SessionEnd, AspectLock) ride on a separate reliable StreamChannel. Control isolation prevents head-of-line blocking from queued video frames or input bursts.
+    - Each channel uses an independently-keyed pigeon Channel (HKDF-derived from the pairing record's shared secret with channel-specific info strings). Different channels can't decrypt each other's messages even if a shared key were leaked.
+    - Measured throughput meets or exceeds today's WebSocket-based path on a controlled local network. End-to-end frame latency is comparable; tail latency improves under packet loss because video doesn't wait for retransmits.
+    context: 'Replaces the previous T11.3 + T11.4 (''Game server sideband uses pigeon channel instead of WebSocket'' + ''Per-session wire uses pigeon channel instead of WebSocket''). The old framing assumed two parallel WebSocket-equivalent channels; pigeon''s reliable+unreliable model is a better fit and lets us split video off the reliable path entirely.\n\nMaps directly onto pigeon''s channel API: OpenChannel() for reliable, DatagramChannel() for unreliable. Each channel gets its own keys via PairingRecord.DeriveChannel(sendInfo, recvInfo).\n\nThe video-on-datagrams decision is the headline win: today''s WebSocket path waits for retransmits even on lost video frames, which is wasted because we''re going to send another frame imminently anyway. Datagrams let dropped video frames just fall through, while keyframes act as natural resync points.\n\nLow-priority follow-up worth noting: if measurement shows datagrams alone are insufficient under high loss (say, >5% sustained), the design can fall back to streaming keyframes specifically, rather than abandoning the datagram path. Don''t optimise for that until we measure it.'
     depends_on:
+    - T11.1
     - T11.2
+    tags:
+    - pigeon
+    - transport
+    - datagram
+    - video
+    - channel
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.4:
-    name: Per-session wire uses pigeon channel instead of WebSocket
+    name: LAN-co-located peers bypass the relay via pigeon's LAN server; falls back automatically when the network changes
     status: identified
     value: 8.0
     cost: 5.0
     acceptance:
-    - H.264 frames flow over pigeon channel from game to ged
-    - Input events flow over pigeon channel from ged to game
-    - No /ws/server/wire/{sessionID} endpoint remains
-    context: Replace /ws/server/wire/{sessionID} with a pigeon channel per session. When ged tells a game server "player attached", the game opens a new pigeon channel for that session's wire traffic (H.264 frames server→ged, input events ged→server). ged bridges this to the player's pigeon channel.
+    - When player and server detect they're on the same Wi-Fi (or wired LAN), pigeon's LAN bypass kicks in via pigeon.Config.LANServer + LAN-IP discovery. Traffic goes peer-to-peer over QUIC, the relay sees only the initial introduction handshake.
+    - 'Player surfaces the connection mode in its UI (or at least logs it): ''connected via LAN'' vs ''connected via relay''. Useful for debugging and for users to understand performance characteristics.'
+    - When the LAN connection drops (peer leaves the network, Wi-Fi switches, etc.), pigeon's automatic FallbackToRelay() restores connectivity over the relay without dropping the session. Visible in logs; not user-visible if seamless.
+    - Latency on LAN is measurably lower than via the relay (relay adds the round-trip to carrier-pigeon.fly.dev). Confirm with a basic measurement on at least one platform.
+    - The transition relay→LAN→relay survives an active video stream without visible glitches — pigeon handles the underlying reconnect transparently to ge's application layer.
+    context: 'Net-new sub-target. The original T11 family didn''t have LAN-bypass; pigeon''s LAN-server feature only landed later. Highly relevant to ge''s most-common use case: phone-as-player + laptop-as-server on the same Wi-Fi at home or in a meeting room.\n\nThe relay round-trip to carrier-pigeon.fly.dev (presumably us-west or similar) adds 50–200 ms depending on the user''s location. Eliminating it for the LAN-co-located case is a meaningful UX improvement, especially for input latency in interactive games.\n\nTechnically pigeon does most of the work; ge''s job is mostly to enable LAN mode in pigeon.Config and to surface the resulting state in the player UI / logs.'
     depends_on:
     - T11.3
+    tags:
+    - pigeon
+    - lan
+    - latency
+    - transport
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.5:
-    name: Player connects to ged via pigeon instead of WebSocket
+    name: Mobile players (bgfx-direct iOS + Android distribution builds) speak pigeon natively via the C library, with no Go runtime
     status: identified
     value: 8.0
     cost: 5.0
     acceptance:
-    - Desktop player connects to ged via pigeon
-    - H.264 frames arrive at player over pigeon
-    - Input events flow from player to ged over pigeon
-    - No /ws/wire WebSocket endpoint remains
-    context: Replace /ws/wire player WebSocket with pigeon. Player connects via pigeon's C API (pigeon_connect), sends DeviceInfo, receives H.264 stream, sends input events back. Desktop player (tools/player.cpp) links libpigeon. ged bridges the player's pigeon channel to the game's wire channel. Same C API available for game server side (SessionHost.mm), eliminating WebSocketClient.cpp entirely.
+    - The bgfx-direct iOS and Android distribution players link pigeon's C library (dist/pigeon.h + dist/pigeon.c) plus libsodium and ngtcp2 (vendored as submodules under ge/vendor/github.com/<org>/, per CLAUDE.md). No Go runtime is shipped to the device.
+    - 'The mobile player can connect to a server via a stored PairingArtifact and run a session end-to-end: receive video, send input, decode, render. Functional parity with the desktop player on the same server.'
+    - Pigeon's C library generates the same wire-protocol bindings (T11.1) and the same pairing-ceremony state machine (T11.2) that the Swift/Kotlin/Go SDKs use, via pigeon's protocol/ codegen. No hand-translated state machines on the C side.
+    - ge/CMakeLists.txt's Android branch and the iOS xcframework story include pigeon's C library + libsodium + ngtcp2 as transitive deps of `ge`. Consumer apps still consume ge via add_subdirectory(ge) (T30 principle) — pigeon is one more thing they get for free.
+    - 'Apk / ipa size impact is acceptable: libsodium (~200KB), ngtcp2 (~500KB), pigeon (~100KB), generated state machines (~50KB) — about 1MB additional vs the current direct-mode build. Confirm with a measurement; reject the design if it''s more than ~3MB.'
+    context: 'Net-new sub-target. The original T11 family assumed the player would always have access to a Go runtime (via gomobile or similar). The pigeon C library makes it possible to ship a fully-native mobile player with no Go.\n\nWhy this matters for ge:\n- Today''s bgfx-direct mobile players (sample/tiltbuggy/android, sample/tiltbuggy/ios) have NO networking. They render locally only. There''s currently no path to add multiplayer / streaming to a direct-mode mobile build without either (a) shipping a Go runtime via gomobile (~10MB+) or (b) writing a custom networking layer per platform.\n- pigeon''s C library is the missing piece that lets ge''s direct-mode mobile builds participate in a pigeon session as a client. Server-side pigeon would still be Go (where the H.264 encoder lives anyway), but the player is C — small footprint, no GC pauses, no cross-language FFI.\n- The C library is currently ''Fluid'' per pigeon''s STABILITY.md — stabilisation depends on real consumer feedback. ge mobile would be an ideal first consumer and would help drive pigeon''s C surface to stable.\n\nTransport stack on the C side: ngtcp2 for QUIC, libsodium for crypto primitives, pigeon''s C glue on top. Both deps are vendored per CLAUDE.md (substantial libraries get git submodules under vendor/github.com/<org>/<repo>).'
     depends_on:
-    - T11.4
+    - T11.1
+    - T11.2
+    - T11.3
+    tags:
+    - pigeon
+    - c-library
+    - ios
+    - android
+    - direct-mode
+    - mobile
     origin: decomposed from T11
     discovered: 2026-04-12
   T11.6:
-    name: WebSocket code removed from ged and ge client
+    name: All WebSocket plumbing is removed from ge and ged once every consumer has cut over to pigeon
     status: identified
     value: 3.0
     cost: 3.0
     acceptance:
-    - coder/websocket removed from go.mod
-    - WebSocketClient.cpp deleted or gutted
-    - No /ws/server or /ws/wire routes in ged
-    - Dashboard /ws/logs, /ws/preview, /ws/stream still work
-    context: 'Final cleanup: remove coder/websocket from go.mod, remove WebSocketClient.cpp and Asio WS framing, remove all /ws/* route registrations (except dashboard WS endpoints which stay as-is). Dashboard WebSocket endpoints (/ws/logs, /ws/preview, /ws/stream) remain — they serve the browser and don''t need pigeon.'
+    - ge/src/bridge/WebSocketClient.cpp and the matching WebSocketClient.h are deleted. No remaining call sites in ge.
+    - PlayerWireBridge.cpp's WebSocket-specific code paths are deleted (the class itself may still exist as a thin wrapper around pigeon, or be replaced entirely — author's discretion).
+    - SessionHost_brokered.mm's WebSocket code path is replaced by pigeon channel calls. The class either retains its name as a pigeon wrapper or is renamed; either is fine.
+    - ged's gorilla/websocket dependency is removed from go.mod. The dashboard's WS endpoints (/ws/wire) are deleted; the dashboard still exists as the pairing-artifact issuer + management UI, just without WebSocket plumbing.
+    - The 'Wire format' / 'Steady-State Messages' section in ge/CLAUDE.md is rewritten to document the pigeon-channel layout instead of WebSocket framing. The per-message magic-number table is replaced by a pointer to the protocol YAML.
+    - ge/vendor/include/ws.h (and any WebSocket-specific transitive deps) are removed from vendor/ if not used elsewhere.
+    context: 'Carryover from the original T11.6 — same intent, slightly broader scope. The cleanup target. Lands AFTER all the cut-over targets (T11.2 through T11.5) so that no consumer is left needing the WebSocket path.\n\nIntentionally last in the chain so the migration can be incremental: each prior sub-target can land independently with WebSocket fallback still available, and only when every consumer is on pigeon does the WebSocket code go.\n\nAlso drives the CLAUDE.md documentation refresh — today''s wire-protocol section is one of the larger blocks and is heavily WebSocket-shaped. Once removed, the new pigeon-shaped doc should be considerably shorter (most of the framing detail moves into pigeon''s STABILITY.md by reference).'
     depends_on:
+    - T11.3
+    - T11.4
     - T11.5
+    tags:
+    - pigeon
+    - websocket-removal
+    - cleanup
+    - documentation
     origin: decomposed from T11
     discovered: 2026-04-12
   T12:
@@ -291,7 +352,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 2.0
     acceptance:
     - 'All 6 automated matrix-test cells pass on current hardware: desktop-dist, desktop-player, ios-sim-dist, ios-sim-player, android-emu-dist, android-emu-player'
@@ -336,7 +397,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 1.0
     acceptance:
     - rotation-stability-test.sh --platform ios-sim --app-id com.squz.tiltbuggy --cycles 10 reports PASS end-to-end against the iPad Air M4 simulator
@@ -351,7 +412,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - 'iPhone: dist + player smoke pass (cold launch, 60s soak, no crashes)'
@@ -369,7 +430,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - make ge/<platform>-debug (or equivalent) produces a debug binary / .app / APK distinct from the release build — assertions enabled, debug symbols retained
@@ -385,7 +446,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - Android player reads a `ged_addr` intent extra (e.g. `adb shell am start -n com.squz.player/.GeActivity --es ged_addr host:port`) and connects directly, skipping QR onboarding
@@ -412,7 +473,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - '`make cell.android-emu-phone-dist` and `make cell.android-debug-dist` both pass end-to-end on the current canonical phone AVD'
     - Failure mode (GL-context error) either fixed at the bgfx config layer or worked around with a documented AVD requirement in Module.mk
@@ -436,7 +497,7 @@ targets:
     status: converging
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - '`make cell.ios-sim-tablet-player` passes the reconnect sub-check end-to-end'
     - '`make cell.android-emu-phone-player` passes the reconnect sub-check end-to-end'
@@ -449,7 +510,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 3.0
     acceptance:
     - '`make cell.android-emu-phone-player` passes the startup-flash sub-check end-to-end with no false positive and no genuine flash'
@@ -471,7 +532,7 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - Per-cell soak sub-check runs for ~10s by default
     - A single dedicated long-soak cell runs the 60s sweep
@@ -498,7 +559,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - DirectRenderHost::pumpEvents routes each SDL event through synth->handle() (when synth is active) before forwarding to the user event handler; consumed events are NOT forwarded
     - DirectRenderHost drives synth->update() once per frame (beginFrame or endFrame) so the ease-back after Shift-release animates
@@ -513,7 +574,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - In a distribution build using DirectRenderHost, Shift-dragging produces a visible viewport tilt matching the player binary's visual behaviour on the same app
     - The tilt compose shader in DirectRenderHost is fed the current AccelSynth tilt each frame (same convention as PlayerRender.cpp ~line 346)
@@ -529,7 +590,7 @@ targets:
     status: converging
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - On an iOS simulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors and AccelSynth activates
     - Shift+mouse-drag inside the simulator window tilts the viewport and drives sensor-driven gameplay
@@ -547,7 +608,7 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - On an Android emulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors (or emulator's virtual sensors pass a simulator-detection check) and AccelSynth activates
     - Shift+mouse-drag inside the emulator window tilts the viewport and drives sensor-driven gameplay
@@ -581,7 +642,7 @@ targets:
     discovered: 2026-04-12
   T30:
     name: ge has a single integration path on every platform — consumers do add_subdirectory(ge) and get everything
-    status: achieved
+    status: identified
     value: 0.0
     cost: 0.0
     acceptance:
@@ -592,13 +653,12 @@ targets:
     context: 'Discovered 2026-04-19 while investigating Android tilt testing. ge currently has two Android integration paths: (a) add_subdirectory(ge) + link ge — the documented path, used by multimaze2, broken because ge''s Android CMakeLists branch doesn''t link SDL3_ttf and Text.cpp''s FontLoader dependency is Apple-only; (b) hand-picked GE_SOURCES list — used by sample/tiltbuggy/android, works by explicitly omitting Text.cpp and FontLoader_apple.mm (see sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt:76-78). Having two paths is the bug — consumers have to reason about which subset of ge is safe on which platform, and bit-rot is inevitable (multimaze2''s Android CMakeLists already omits Text.cpp quietly). Principle: one path, everyone gets everything. Decomposes into T30.1 (SDL3_ttf + deps for Android), T30.2 (FontLoader_android implementation so Text.cpp compiles cross-platform), T30.3 (migrate sample/tiltbuggy Android to add_subdirectory(ge)), and a CLAUDE.md doc update baked into acceptance.'
     origin: 'forked-from: 🎯T28.4 / Android tilt-testing investigation 2026-04-19'
     discovered: 2026-04-19
-    achieved: 2026-04-21
   T30.1:
     name: ge's Android build links SDL3_ttf + freetype/harfbuzz/plutosvg/plutovg
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - SDL_ttf is vendored under ge/vendor/github.com/libsdl-org/SDL_ttf — added as a git submodule (matching the existing SDL submodule at the same parent path) pinned to release-3.2.2 (requires SDL ≥ 3.2.6; ge's SDL is 3.4.0 so compatible)
     - ge/CMakeLists.txt's Android branch (currently lines 217-234) does add_subdirectory for SDL_ttf and links SDL3_ttf::SDL3_ttf into the ge target via PUBLIC
@@ -614,7 +674,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - A FontLoader implementation exists that works on Android (and is portable to desktop Linux/Windows if/when those are added) — likely FontLoader_sdl.cpp using SDL_IOStream + SDL_ttf directly, or FontLoader_android.cpp using AAssetManager. Name and approach at author's discretion.
     - 'ge/CMakeLists.txt selects the right FontLoader source per platform (FontLoader_apple.mm on Apple, the new one everywhere else) — no #ifdef sprawl inside a single file'
@@ -628,10 +688,10 @@ targets:
     achieved: 2026-04-20
   T30.3:
     name: sample/tiltbuggy Android build consumes ge via add_subdirectory(ge), not a hand-picked source list
-    status: achieved
+    status: identified
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt calls add_subdirectory(${GE_ROOT}) and target_link_libraries(main PRIVATE ge)
     - The inline GE_SOURCES block (currently lines 79-96) and its accompanying Apple-only comment (lines 76-78) are deleted
@@ -642,13 +702,12 @@ targets:
     - T30.2
     origin: 'forked-from: T30 on 2026-04-19'
     discovered: 2026-04-19
-    achieved: 2026-04-21
   T31:
     name: Triangle's non-commercial licence is investigated and either removed, replaced, or formally cleared
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - 'Confirmed where Triangle code actually lands. Inventory: vendor/src/triangle.c + vendor/include/triangle.h are vendored in ge''s repo; Module.mk exposes ge/TRIANGLE_OBJ as an opt-in object (built with -DTRILIBRARY -DREAL=double -DANSI_DECLARATORS -DNO_TIMER); no ge/src/ file #includes triangle.h or calls triangulate(); ge/CMakeLists.txt does not compile triangle.c into libge; the only known consumer is yourworld/yourworld2/tools/precompute.cpp (build-time tool, not a runtime artifact)'
     - 'Confirmed exactly what the licence permits and forbids. The text in vendor/src/triangle.c grants free use for private, research, and institutional use; permits redistribution if (a) copyright notices are kept, (b) no compensation is received for redistribution, (c) modifications keep original copyright + free source/object availability; **explicitly forbids distribution as part of a commercial system without direct arrangement with Shewchuk (jrs@cs.berkeley.edu)**, with one carve-out: if you don''t supply the code directly to the customer but instead point them at a free download, no arrangement needed'
@@ -664,7 +723,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - VideoDecoder's frame callback on Android delivers NV12 planar data (Y plane + interleaved UV plane with their respective strides), not pre-converted BGRA. The hand-rolled nv12ToBgra() function and reusable frameBuffer member in src/bridge/VideoDecoder_android.cpp (and the equivalent libswscale conversion in src/bridge/VideoDecoder_ffmpeg.cpp) are deleted
     - PlayerRender uploads Y as a bgfx R8 texture (w×h) and UV as a bgfx RG8 texture (w/2 × h/2) with proper pitch handling for MediaCodec's row stride


### PR DESCRIPTION
## Summary

Target-only update. Rewrites the 🎯T11 parent and T11.1–T11.6 sub-targets to reflect pigeon's actual shape at v0.20.0. The previous targets assumed pigeon was a daemon-style backend that ged would register against; pigeon-as-it-actually-exists is an importable library across Go / Swift / Kotlin / C / TypeScript that bundles relay + E2E crypto + pairing + protocol code-generation as a single integrated story.

Per the global directive on target-only edits: **this PR is for visibility only — do not merge.** The committed registry is the canonical artefact, but the sub-targets land via their own implementation work over time. Closes naturally when superseded or when the implementation PRs start landing.

## Per-target shape after rewrite

| Target | Shape |
|---|---|
| 🎯T11 (parent) | Player↔server runs on pigeon E2E-encrypted relay; ged reduced to pairing-artifact issuer + dashboard, off the runtime data path |
| 🎯T11.1 | Wire protocol declared in pigeon-protocol YAML; bindings generated for Go / Swift / Kotlin / C; \`Protocol.h\` magic numbers gone |
| 🎯T11.2 | QR delivers a \`PairingArtifact\`; player persists via \`CredentialStore\`; 6-digit confirmation code on first contact |
| 🎯T11.3 | Video on \`DatagramChannel\`, input/control on reliable \`StreamChannel\`s; per-channel keys via HKDF |
| 🎯T11.4 (net-new) | LAN bypass via \`pigeon.LANServer\` with automatic fallback to relay |
| 🎯T11.5 (net-new) | Mobile bgfx-direct players link pigeon's C library + libsodium + ngtcp2 — no Go runtime on device |
| 🎯T11.6 | Delete \`WebSocketClient.cpp\`, ged's \`gorilla/websocket\`, related vendor headers; rewrite Wire-format docs |

Dependency chain: T11.1 + T11.2 are independent leaves; T11.3 builds on both; T11.4 + T11.5 build on T11.3; T11.6 is the cleanup tail after T11.3, T11.4, T11.5 are all done.

## Why now

[pigeon v0.20.0](https://github.com/marcelocantos/pigeon) just shipped. Its PairingArtifact API is "Needs Review" — wants real-world consumer feedback before freezing. ge would be an ideal first consumer; this rewrite captures the target shape so the integration work has a coherent set of acceptance criteria to converge against.

## Test plan

No code changes; nothing to test. Validation is reading the new target text and confirming the acceptance criteria match the pigeon surface as documented in pigeon's STABILITY.md v0.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)