### PR TITLE
ge: 🎯T33.1 — smoke-test.sh runs on spyder CLI; per-platform branches collapsed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,59 +444,78 @@ Protocol changes require updating both `SessionHost.mm` (server side) and `playe
 
 **Before asking the user whether something is rendering on a mobile device, exhaust all programmatic checks first.** The user cannot easily tell you what's on screen during an automated workflow — treat "ask user to look at device" as a last resort, not a first step.
 
-After building and deploying to a device/simulator, run the smoke test script:
+The smoke test script uses the **spyder CLI** for all device-side operations. Spyder must be installed and `spyder serve` must be running (or auto-started) before running the script. After building and deploying to a device/simulator, run:
 
 ```bash
-# iOS Simulator — specify phone or tablet form factor
-ge/tools/smoke-test.sh --platform ios-sim --device tablet
-ge/tools/smoke-test.sh --platform ios-sim --device phone
+# Named device (inventory alias)
+ge/tools/smoke-test.sh --device Pippa
 
-# iOS Device — specific device by name or UDID
-ge/tools/smoke-test.sh --platform ios-device --device Pippa
+# Selector predicate — any booted iPad sim running iOS 18+
+ge/tools/smoke-test.sh --device platform=ios-sim,model=ipad,os>=18
 
-# Android emulator
-ge/tools/smoke-test.sh --platform android-emu --package com.squz.player
+# Selector predicate — Android emulator
+ge/tools/smoke-test.sh --device platform=android-emu
 
-# Android device — specific device by serial
-ge/tools/smoke-test.sh --platform android-device --device R5CT900XYZ
-
-# Desktop player
+# Desktop player (no device checks)
 ge/tools/smoke-test.sh --platform desktop
+
+# Sole connected device (errors if multiple)
+ge/tools/smoke-test.sh
 ```
 
-The `--device` flag meaning varies by platform:
-- **ios-sim**: `phone` or `tablet` — picks the latest booted simulator of that form factor. Omit to use any sole booted sim (errors if multiple are booted).
-- **ios-device**: device name or UDID (substring match, case-insensitive). Omit for the sole connected device. Lists all registered physical devices with `[connected]`/`[disconnected]` state when the target isn't found.
-- **android**: serial or model substring. Omit for the sole connected device.
+The `--device` flag accepts any spyder selector:
+- **Inventory alias**: a name registered in `~/.spyder/inventory.json` (e.g. `Pippa`).
+- **Selector predicate**: comma-separated `key=value` pairs understood by `spyder reserve --on`
+  (e.g. `platform=ios-sim,model=ipad`, `platform=android,os>=12`).
+- **Raw UUID / serial**: passed directly to spyder subcommands.
 
-Use `--install <path>` to ensure the device runs the latest build. This performs an atomic terminate → install → launch cycle and verifies the new process starts:
+Use `--install <path>` to ensure the device runs the latest build. This performs an atomic
+terminate → install → launch → verify-pid via `spyder deploy`:
 
 ```bash
-# Deploy latest build to simulator before testing
-ge/tools/smoke-test.sh --platform ios-sim --device tablet \
+# Deploy latest iOS build before testing
+ge/tools/smoke-test.sh --device Pippa \
+    --install ios/build/xcode/Debug-iphoneos/YourWorld.app
+
+# Deploy iOS Simulator build
+ge/tools/smoke-test.sh --device platform=ios-sim,model=ipad \
     --install ios/build/xcode/Debug-iphonesimulator/YourWorld.app
 
-# Deploy APK to Android
-ge/tools/smoke-test.sh --platform android-emu \
+# Deploy Android APK
+ge/tools/smoke-test.sh --device platform=android-emu \
     --install ge/tools/android/app/build/outputs/apk/debug/app-debug.apk
 ```
 
-Without `--install`, the script checks passively (is the app installed? is it running? is the running process newer than the binary?). **Always prefer `--install`** after a rebuild to avoid debugging stale binaries.
+Without `--install`, the script checks passively (is the app installed? is it in the foreground?). **Always prefer `--install`** after a rebuild to avoid debugging stale binaries.
 
 The script checks, in order:
 
 1. **ged reachable** — port listening, `/api/info` responds, game server connected, active session count
 2. **Game server running** — process alive (if `--server-pid` given)
-3. **Device/simulator reachable** — `simctl`, `devicectl`, or `adb` confirms device present
-4. **App deployed and running** — with `--install`: terminate → install → launch → verify PID. Without: check installation, process state, and binary freshness.
+3. **Device reachable** — `spyder devices` / `spyder resolve` confirms device found and connected; branches on spyder exit codes (11 = not found, 12 = not connected, 40 = trust not granted, 41 = developer mode off, 42 = locked)
+4. **App deployed and running** — with `--install`: `spyder deploy` (atomic terminate→install→launch→PID-verify); without: `spyder list-apps` + `spyder device-state` for foreground app
 5. **Player connected** — polls ged `/api/info` for active sessions (up to `--timeout` seconds)
-6. **Player logs** — checks logcat (Android) or crash reports (iOS) for recent errors
+6. **Player logs** — `spyder log <device>` filtered to error/fatal/crash; falls back to `~/Library/Logs/DiagnosticReports` crash scan
 
-Each check prints PASS/FAIL/WARN. The script exits non-zero if any check fails. **Do not ask the user about visual output until this script passes.** If it fails, diagnose and fix the failure — don't escalate to the user.
+Each check prints PASS/FAIL/WARN. The script exits non-zero if any check fails. **Do not ask the user about visual output until this script passes.** If it fails, read the spyder exit code in the FAIL message and branch accordingly:
+
+| Exit code | Meaning | Action |
+|-----------|---------|--------|
+| 10 | spyder daemon unreachable | Run `spyder serve` |
+| 11 | device not in inventory | Check alias spelling; run `spyder devices` |
+| 12 | device not connected | Plug in / boot the device |
+| 20 | app not installed | Re-run with `--install` |
+| 21 | install failed | Check signing / provisioning profile |
+| 22 | launch failed | Check bundle ID; look at crash logs |
+| 24 | PID verify failed | App crashed at startup — check logs |
+| 30 | timeout | Increase `--timeout` or check device health |
+| 40 | trust not granted | Accept the "Trust this Computer" dialog |
+| 41 | Developer Mode off | Enable in iOS Settings → Privacy & Security |
+| 42 | device locked | Unlock the device |
 
 Only after the smoke test passes and the problem is still unclear, ask the user what they see — but state what you already verified: "Smoke test passed (ged connected, player session active, no crash reports) — can you confirm whether the globe is rendering?"
 
-**Device preference**: When the user tells you which device to test on (e.g. "use Pippa"), save it to auto-memory so you remember across sessions. Always pass the preferred device via `--device`. If the smoke test fails because that device isn't found, tell the user which device was expected and list the devices that *are* available (the script prints them), then ask how they'd like to proceed.
+**Device preference**: When the user tells you which device to test on (e.g. "use Pippa"), save it to auto-memory so you remember across sessions. Always pass the preferred device via `--device`. If the smoke test fails because that device isn't found, tell the user which device was expected and list the devices that *are* available (the script prints them via `spyder devices`), then ask how they'd like to proceed.
 
 ### Visual regression
 

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -4,65 +4,73 @@
 #
 # Verifies that the full stack is healthy before asking a human to check
 # visual output. Designed to be called by Claude Code after building and
-# deploying to a device/simulator.
+# deploying to a device/simulator. Uses the spyder CLI for all device-side
+# operations (discovery, install, launch, log retrieval).
 #
 # Usage:
-#   ge/tools/smoke-test.sh --platform <platform> [options]
-#
-# Platforms:
-#   ios-sim        iOS Simulator
-#   ios-device     Physical iOS device
-#   android-emu    Android emulator
-#   android-device Physical Android device
-#   desktop        Desktop player (macOS)
+#   ge/tools/smoke-test.sh [options]
 #
 # Options:
-#   --device <id>       Target device. Meaning varies by platform:
-#                         ios-sim:  "phone" or "tablet" (picks latest booted sim
-#                                   of that form factor). Omit to use any sole
-#                                   booted sim.
-#                         ios-device: device name or UDID (substring match,
-#                                   case-insensitive). Omit for sole connected device.
-#                         android:  serial or model substring. Omit for sole device.
-#   --install <path>    Build artifact to deploy before testing. This ensures the
-#                       device runs the latest build (terminate → install → launch).
-#                         ios-sim:     path to .app bundle
-#                         ios-device:  path to .app bundle (uses devicectl)
-#                         android:     path to .apk file
-#                       Without --install, the script only checks passively.
-#   --bundle-id <id>    iOS bundle identifier (default: com.squz.yourworld2)
-#   --package <pkg>     Android package name (default: com.squz.player)
+#   --device <selector>  Target device. Accepts any spyder selector:
+#                          - An inventory alias:  Pippa
+#                          - A selector predicate: platform=ios-sim,model=ipad
+#                          - A raw UDID/serial
+#                        Omit to use the sole connected device (errors if
+#                        multiple are present).
+#   --install <path>    Build artifact to deploy before testing. Performs an
+#                       atomic terminate → install → launch → verify-pid via
+#                       `spyder deploy`. Without --install, the script checks
+#                       passively (is the app installed? is it running?).
+#                         iOS:     path to .app bundle
+#                         Android: path to .apk file
+#   --bundle-id <id>    App bundle identifier / package name
+#                       (default: com.squz.yourworld2)
 #   --ged-port <port>   ged daemon port (default: 42069)
 #   --timeout <secs>    Max seconds to wait for player connection (default: 15)
 #   --server-pid <pid>  Game server PID to verify is running
+#   --platform <p>      Retained for backwards compatibility; ignored. Device
+#                       discovery is now handled by spyder regardless of
+#                       platform type.
 #
 # Exit codes:
 #   0  All checks passed
 #   1  One or more checks failed (details in output)
+#
+# Spyder exit codes used for branching:
+#   10  daemon-unreachable
+#   11  device-not-found
+#   12  device-not-connected
+#   20  app-not-installed
+#   21  install-failed
+#   22  launch-failed
+#   24  pid-verification-failed
+#   30  timeout
+#   40  trust-not-granted
+#   41  developer-mode-disabled
+#   42  device-locked
 
 set -euo pipefail
 
 # Defaults
-PLATFORM=""
+DEVICE=""
+INSTALL=""
 BUNDLE_ID="com.squz.yourworld2"
-PACKAGE="com.squz.player"
 GED_PORT=42069
 TIMEOUT=15
 SERVER_PID=""
-DEVICE=""
-INSTALL=""
+PLATFORM=""  # accepted but ignored; kept for backwards compat
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --platform)    PLATFORM="$2"; shift 2 ;;
+        --device)      DEVICE="$2"; shift 2 ;;
+        --install)     INSTALL="$2"; shift 2 ;;
         --bundle-id)   BUNDLE_ID="$2"; shift 2 ;;
-        --package)     PACKAGE="$2"; shift 2 ;;
+        --package)     BUNDLE_ID="$2"; shift 2 ;;  # Android alias
         --ged-port)    GED_PORT="$2"; shift 2 ;;
         --timeout)     TIMEOUT="$2"; shift 2 ;;
         --server-pid)  SERVER_PID="$2"; shift 2 ;;
-        --device)      DEVICE="$2"; shift 2 ;;
-        --install)     INSTALL="$2"; shift 2 ;;
+        --platform)    PLATFORM="$2"; shift 2 ;;  # accepted, ignored
         -h|--help)
             sed -n '2,/^$/{ s/^# \{0,1\}//; p; }' "$0"
             exit 0
@@ -70,12 +78,6 @@ while [[ $# -gt 0 ]]; do
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
-
-if [[ -z "$PLATFORM" ]]; then
-    echo "Error: --platform is required"
-    echo "Run with --help for usage"
-    exit 1
-fi
 
 # ── Output helpers ──────────────────────────────────────────────────
 
@@ -87,6 +89,14 @@ pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
 warn() { echo "  WARN  $1"; WARN=$((WARN + 1)); }
 info() { echo "  ....  $1"; }
+
+# ── Spyder availability check ───────────────────────────────────────
+
+if ! command -v spyder &>/dev/null; then
+    echo "Error: spyder CLI not found in PATH"
+    echo "Install spyder from https://github.com/marcelocantos/spyder"
+    exit 1
+fi
 
 # ── Check: ged reachable ────────────────────────────────────────────
 
@@ -142,539 +152,192 @@ check_server() {
     fi
 }
 
-# ── iOS Simulator ───────────────────────────────────────────────────
+# ── Check: device reachable via spyder ─────────────────────────────
+#
+# Uses `spyder devices --json` to list all known devices, then resolves
+# DEVICE (if given) via `spyder resolve`. Branches on spyder exit codes:
+#   11  device-not-found
+#   12  device-not-connected
+#   10  daemon-unreachable
 
-# Resolve --device for ios-sim. Sets SIM_UDID.
-#   "phone"  → latest booted iPhone sim
-#   "tablet" → latest booted iPad sim
-#   (empty)  → any sole booted sim (error if multiple)
-# Returns: 0=found, 1=not found, 2=ambiguous (multiple)
-resolve_sim_device() {
-    SIM_UDID=""
+RESOLVED_DEVICE=""  # canonical alias or selector to pass to subsequent spyder calls
 
-    # Validate --device value early
-    if [[ -n "$DEVICE" ]]; then
-        case "${DEVICE,,}" in
-            phone|tablet) ;;
+check_device() {
+    echo "── Device ──"
+
+    if [[ -z "$DEVICE" ]]; then
+        # No selector — require exactly one connected device
+        local devices_json rc=0
+        devices_json=$(spyder devices --json 2>/dev/null) || rc=$?
+        case $rc in
+            0) ;;
+            10)
+                fail "spyder daemon unreachable — is spyder serve running?"
+                return
+                ;;
             *)
-                fail "--device for ios-sim must be 'phone' or 'tablet', got '$DEVICE'"
-                return 1
+                fail "spyder devices failed (exit $rc)"
+                return
                 ;;
         esac
+
+        local count
+        count=$(echo "$devices_json" | jq 'if type == "array" then length else (.devices // [] | length) end' 2>/dev/null || echo 0)
+
+        if [[ "$count" -eq 0 ]]; then
+            fail "No devices known to spyder"
+            return
+        elif [[ "$count" -gt 1 ]]; then
+            fail "Multiple devices known — specify --device <selector>:"
+            echo "$devices_json" | jq -r '
+                (if type == "array" then . else .devices end) // [] |
+                .[] | "  ....  \(.name) — \(.model // "unknown") (\(.uuid)) [\(.platform)]"
+            ' 2>/dev/null || true
+            return
+        fi
+
+        # Exactly one device
+        local device_name device_uuid
+        device_name=$(echo "$devices_json" | jq -r '(if type == "array" then . else .devices end)[0].name' 2>/dev/null)
+        device_uuid=$(echo "$devices_json" | jq -r '(if type == "array" then . else .devices end)[0].uuid' 2>/dev/null)
+        info "$device_name ($device_uuid)"
+        RESOLVED_DEVICE="$device_name"
+        pass "Device found: $device_name"
+        return
     fi
 
-    local all_booted
-    all_booted=$(xcrun simctl list devices booted -j 2>/dev/null) || return 1
-
-    local booted_json
-    booted_json=$(echo "$all_booted" | jq -c '[
-        [to_entries[] | .key as $runtime | .value[] | select(.state == "Booted") | . + {runtime: $runtime}]
-        | sort_by(.runtime) | reverse | .[]
-    ] ' <<< "$(echo "$all_booted" | jq '.devices')")
-
-    local count
-    count=$(echo "$booted_json" | jq 'length')
-    if [[ "$count" -eq 0 ]]; then
-        return 1
-    fi
-
-    case "${DEVICE,,}" in
-        phone)
-            # Latest booted iPhone simulator
-            local match
-            match=$(echo "$booted_json" | jq -r '[.[] | select(.name | test("iPhone"; "i"))][0] // empty')
-            if [[ -n "$match" && "$match" != "null" ]]; then
-                SIM_UDID=$(echo "$match" | jq -r '.udid')
-                local name
-                name=$(echo "$match" | jq -r '.name')
-                info "$name ($SIM_UDID)"
-                return 0
-            fi
-            # No booted iPhone — list what's booted
-            info "No booted iPhone simulator found. Booted simulators:"
-            echo "$booted_json" | jq -r '.[] | "  ....  \(.name) (\(.udid))"'
-            return 1
+    # Selector given — try to resolve it
+    local resolve_out rc=0
+    resolve_out=$(spyder resolve "$DEVICE" 2>&1) || rc=$?
+    case $rc in
+        0)
+            local alias
+            alias=$(echo "$resolve_out" | jq -r '.alias // empty' 2>/dev/null || echo "$DEVICE")
+            RESOLVED_DEVICE="${alias:-$DEVICE}"
+            info "Resolved '$DEVICE' → $RESOLVED_DEVICE"
+            pass "Device '$DEVICE' found"
             ;;
-        tablet)
-            # Latest booted iPad simulator
-            local match
-            match=$(echo "$booted_json" | jq -r '[.[] | select(.name | test("iPad"; "i"))][0] // empty')
-            if [[ -n "$match" && "$match" != "null" ]]; then
-                SIM_UDID=$(echo "$match" | jq -r '.udid')
-                local name
-                name=$(echo "$match" | jq -r '.name')
-                info "$name ($SIM_UDID)"
-                return 0
-            fi
-            # No booted iPad — list what's booted
-            info "No booted iPad simulator found. Booted simulators:"
-            echo "$booted_json" | jq -r '.[] | "  ....  \(.name) (\(.udid))"'
-            return 1
+        10)
+            fail "spyder daemon unreachable — is spyder serve running?"
             ;;
-        "")
-            # No preference — require exactly one booted sim
-            if [[ "$count" -gt 1 ]]; then
-                echo "$booted_json" | jq -r '.[] | "  ....  \(.name) (\(.udid))"'
-                return 2
+        11)
+            fail "Device '$DEVICE' not found in spyder inventory"
+            # List available devices to help the user
+            local devices_json
+            devices_json=$(spyder devices --json 2>/dev/null) || true
+            if [[ -n "$devices_json" ]]; then
+                echo "$devices_json" | jq -r '
+                    (if type == "array" then . else .devices end) // [] |
+                    .[] | "  ....  \(.name) — \(.model // "unknown") (\(.uuid)) [\(.platform)]"
+                ' 2>/dev/null || true
             fi
-            SIM_UDID="booted"
-            echo "$booted_json" | jq -r '.[] | "  ....  \(.name) (\(.udid))"'
-            return 0
+            ;;
+        12)
+            fail "Device '$DEVICE' is known but not connected"
+            ;;
+        *)
+            # resolve may exit 1 for selector predicates; fall back to using
+            # DEVICE as-is and let subsequent spyder calls report the error
+            info "spyder resolve '$DEVICE' exited $rc — using selector as-is"
+            RESOLVED_DEVICE="$DEVICE"
+            pass "Device selector set: $DEVICE"
             ;;
     esac
 }
 
-check_device_ios_sim() {
-    echo "── iOS Simulator ──"
+# ── Check: app deployed and running ────────────────────────────────
+#
+# With --install:  `spyder deploy <device> <path>` (atomic terminate→install→
+#                  launch→verify-pid). Branches on exit codes 20–24, 30, 40–42.
+# Without --install: `spyder list-apps` to confirm installation, then
+#                    `spyder device-state` for foreground app check.
 
-    local fail_before=$FAIL
-    local rc=0
-    resolve_sim_device || rc=$?
-    if [[ $rc -eq 0 ]]; then
-        if [[ -n "$DEVICE" ]]; then
-            pass "Booted ${DEVICE} simulator found ($SIM_UDID)"
-        else
-            pass "Simulator booted"
-        fi
-    elif [[ $rc -eq 2 ]]; then
-        fail "Multiple simulators booted — specify --device phone or --device tablet:"
-    elif [[ $FAIL -eq $fail_before ]]; then
-        # resolve_sim_device didn't call fail() itself
-        if [[ -n "$DEVICE" ]]; then
-            fail "No booted ${DEVICE} simulator found"
-        else
-            fail "No iOS Simulator is booted"
-        fi
-    fi
-}
+check_app() {
+    echo "── App ($BUNDLE_ID) ──"
 
-# ── iOS Physical Device ─────────────────────────────────────────────
-
-# List all registered physical iOS devices via devicectl.
-# Output: JSON array of {name, udid, model, state} objects.
-list_physical_devices() {
-    local tmpfile
-    tmpfile=$(mktemp)
-    trap "rm -f '$tmpfile'" RETURN
-
-    xcrun devicectl list devices -j "$tmpfile" >/dev/null 2>&1 || return 1
-
-    jq -r '[.result.devices[] | {
-        name:  .deviceProperties.name,
-        udid:  .identifier,
-        model: .hardwareProperties.marketingName,
-        state: .connectionProperties.tunnelState
-    }]' "$tmpfile"
-}
-
-# Print a device list (JSON array) with connection state annotations.
-print_device_list() {
-    local devices_json="$1"
-    echo "$devices_json" | jq -r '.[] |
-        if .state == "connected" then
-            "  ....  \(.name) — \(.model) (\(.udid)) [connected]"
-        else
-            "  ....  \(.name) — \(.model) (\(.udid)) [disconnected]"
-        end
-    '
-}
-
-# Resolve --device for ios-device. Sets IOS_DEVICE_UDID.
-# Returns: 0=found+connected, 1=not found or not connected, 2=ambiguous
-resolve_ios_device() {
-    IOS_DEVICE_UDID=""
-
-    local devices_json
-    devices_json=$(list_physical_devices) || {
-        info "(devicectl unavailable — is Xcode installed?)"
-        return 1
-    }
-
-    local total
-    total=$(echo "$devices_json" | jq 'length')
-    if [[ "$total" -eq 0 ]]; then
-        info "(no physical iOS devices registered)"
-        return 1
-    fi
-
-    local connected_json
-    connected_json=$(echo "$devices_json" | jq '[.[] | select(.state == "connected")]')
-    local connected_count
-    connected_count=$(echo "$connected_json" | jq 'length')
-
-    if [[ -z "$DEVICE" ]]; then
-        # No preference — list all devices, require exactly one connected
-        print_device_list "$devices_json"
-        if [[ "$connected_count" -eq 0 ]]; then
-            return 1
-        elif [[ "$connected_count" -gt 1 ]]; then
-            return 2
-        fi
-        IOS_DEVICE_UDID=$(echo "$connected_json" | jq -r '.[0].udid')
-        return 0
-    fi
-
-    # Match by name or UDID substring (case-insensitive) among ALL registered devices
-    local match
-    match=$(echo "$devices_json" | jq -r --arg d "$DEVICE" '
-        [.[] | select(
-            (.name | test($d; "i")) or
-            (.udid | test($d; "i"))
-        )][0] // empty
-    ')
-
-    if [[ -z "$match" || "$match" == "null" ]]; then
-        # Not found — list all registered devices
-        print_device_list "$devices_json"
-        return 1
-    fi
-
-    local name state udid model
-    name=$(echo "$match" | jq -r '.name')
-    state=$(echo "$match" | jq -r '.state')
-    udid=$(echo "$match" | jq -r '.udid')
-    model=$(echo "$match" | jq -r '.model')
-
-    if [[ "$state" == "connected" ]]; then
-        info "$name — $model ($udid) [connected]"
-        IOS_DEVICE_UDID="$udid"
-        return 0
-    else
-        # Found but not connected — show the target and full list
-        info "$name — $model ($udid) [disconnected]"
-        info ""
-        info "All registered devices:"
-        print_device_list "$devices_json"
-        return 1
-    fi
-}
-
-check_device_ios_device() {
-    echo "── iOS Device ──"
-
-    local rc=0
-    resolve_ios_device || rc=$?
-    if [[ $rc -eq 0 ]]; then
-        if [[ -n "$DEVICE" ]]; then
-            pass "iOS device '$DEVICE' connected"
-        else
-            pass "iOS device connected"
-        fi
-    elif [[ $rc -eq 2 ]]; then
-        fail "Multiple iOS devices connected — specify one with --device <name>:"
-    elif [[ -n "$DEVICE" ]]; then
-        fail "iOS device '$DEVICE' not connected"
-    else
-        fail "No iOS device connected"
-    fi
-}
-
-# Deploy and verify on iOS physical device: terminate → install → launch → verify.
-check_app_ios_device() {
-    echo "── App ($BUNDLE_ID) on device ──"
-
-    local device_id="${IOS_DEVICE_UDID:-}"
-    if [[ -z "$device_id" ]]; then
+    if [[ -z "$RESOLVED_DEVICE" ]]; then
         fail "No device resolved — cannot check app"
         return
     fi
 
     if [[ -n "$INSTALL" ]]; then
-        if [[ ! -d "$INSTALL" ]]; then
+        if [[ ! -e "$INSTALL" ]]; then
             fail "Build artifact not found: $INSTALL"
             return
         fi
 
-        # Terminate old instance (need PID first)
-        info "Looking for running instance..."
-        local tmpfile
-        tmpfile=$(mktemp)
-        if xcrun devicectl device info processes -d "$device_id" -j "$tmpfile" --quiet 2>/dev/null; then
-            local old_pid
-            old_pid=$(jq -r --arg b "$BUNDLE_ID" '
-                [.result.runningProcesses[] | select(.bundleIdentifier == $b)][0].processIdentifier // empty
-            ' "$tmpfile" 2>/dev/null || true)
-            rm -f "$tmpfile"
-            if [[ -n "$old_pid" ]]; then
-                info "Terminating pid $old_pid..."
-                xcrun devicectl device process terminate -d "$device_id" --pid "$old_pid" --quiet 2>/dev/null || true
-                sleep 0.5
+        info "Deploying $INSTALL to $RESOLVED_DEVICE..."
+        local deploy_out rc=0
+        deploy_out=$(spyder deploy "$RESOLVED_DEVICE" "$INSTALL" --bundle-id "$BUNDLE_ID" 2>&1) || rc=$?
+        case $rc in
+            0)
+                local pid
+                pid=$(echo "$deploy_out" | jq -r '.pid // empty' 2>/dev/null || true)
+                if [[ -n "$pid" ]]; then
+                    pass "App deployed and launched (pid $pid)"
+                else
+                    pass "App deployed and launched"
+                fi
+                ;;
+            10) fail "spyder daemon unreachable during deploy" ;;
+            11) fail "Device '$RESOLVED_DEVICE' not found during deploy" ;;
+            12) fail "Device '$RESOLVED_DEVICE' not connected during deploy" ;;
+            20) fail "App not installed after deploy (bundle id mismatch?)" ;;
+            21) fail "Install failed — check signing/profile (spyder exit 21)" ;;
+            22) fail "Launch failed after install (spyder exit 22)" ;;
+            24) fail "PID verification failed — app may have crashed at startup (spyder exit 24)" ;;
+            30) fail "Deploy timed out (spyder exit 30)" ;;
+            40) fail "Trust not granted — accept the pairing dialog on the device (spyder exit 40)" ;;
+            41) fail "Developer Mode is disabled on the device (spyder exit 41)" ;;
+            42) fail "Device is locked — unlock it and retry (spyder exit 42)" ;;
+            *)  fail "Deploy failed (spyder exit $rc): $deploy_out" ;;
+        esac
+        return
+    fi
+
+    # Passive check: confirm the app is installed
+    local apps_out rc=0
+    apps_out=$(spyder list-apps "$RESOLVED_DEVICE" --json 2>&1) || rc=$?
+    case $rc in
+        0)
+            local installed
+            installed=$(echo "$apps_out" | jq --arg b "$BUNDLE_ID" \
+                'map(select(.bundle_id == $b)) | length' 2>/dev/null || echo 0)
+            if [[ "$installed" -gt 0 ]]; then
+                pass "App is installed"
             else
-                info "No running instance found"
-            fi
-        else
-            rm -f "$tmpfile"
-        fi
-
-        info "Installing $INSTALL..."
-        if ! xcrun devicectl device install app -d "$device_id" "$INSTALL" --quiet 2>&1; then
-            fail "devicectl install failed"
-            return
-        fi
-        pass "App installed from $INSTALL"
-
-        info "Launching $BUNDLE_ID..."
-        local launch_tmp
-        launch_tmp=$(mktemp)
-        if ! xcrun devicectl device process launch -d "$device_id" "$BUNDLE_ID" -j "$launch_tmp" --quiet 2>&1; then
-            rm -f "$launch_tmp"
-            fail "devicectl launch failed"
-            return
-        fi
-        local new_pid
-        new_pid=$(jq -r '.result.process.processIdentifier // empty' "$launch_tmp" 2>/dev/null || true)
-        rm -f "$launch_tmp"
-        if [[ -n "$new_pid" ]]; then
-            pass "App launched (pid $new_pid)"
-        else
-            pass "App launched"
-        fi
-        return
-    fi
-
-    # Passive check: is the app running?
-    local tmpfile
-    tmpfile=$(mktemp)
-    if xcrun devicectl device info processes -d "$device_id" -j "$tmpfile" --quiet 2>/dev/null; then
-        local pid
-        pid=$(jq -r --arg b "$BUNDLE_ID" '
-            [.result.runningProcesses[] | select(.bundleIdentifier == $b)][0].processIdentifier // empty
-        ' "$tmpfile" 2>/dev/null || true)
-        rm -f "$tmpfile"
-        if [[ -n "$pid" ]]; then
-            pass "App is running (pid $pid)"
-        else
-            fail "App is not running on device"
-        fi
-    else
-        rm -f "$tmpfile"
-        warn "Could not query device processes"
-    fi
-}
-
-# ── Android ─────────────────────────────────────────────────────────
-
-# Resolve DEVICE to an Android serial. Sets ADB_SERIAL.
-resolve_android_device() {
-    ADB_SERIAL=""
-
-    if [[ -z "$DEVICE" ]]; then
-        local count
-        count=$(adb devices 2>/dev/null | grep -c "device$" || true)
-        if [[ "$count" -eq 0 ]]; then
-            return 1
-        fi
-        adb devices -l 2>/dev/null | grep "device " | while read -r line; do
-            info "$line"
-        done
-        if [[ "$count" -gt 1 ]]; then
-            return 2  # multiple devices
-        fi
-        ADB_SERIAL=$(adb devices 2>/dev/null | grep "device$" | awk '{print $1}')
-        return 0
-    fi
-
-    # Match by serial or model substring
-    local match_line
-    match_line=$(adb devices -l 2>/dev/null | grep "device " | grep -i "$DEVICE" | head -1) || true
-    if [[ -n "$match_line" ]]; then
-        ADB_SERIAL=$(echo "$match_line" | awk '{print $1}')
-        info "$match_line"
-        return 0
-    fi
-
-    # Not found — list what is available
-    local available
-    available=$(adb devices -l 2>/dev/null | grep "device " || true)
-    if [[ -n "$available" ]]; then
-        echo "$available" | while read -r line; do
-            info "$line"
-        done
-    else
-        info "(no Android devices connected)"
-    fi
-    return 1
-}
-
-check_device_android() {
-    echo "── Android ($PLATFORM) ──"
-
-    if ! command -v adb &>/dev/null; then
-        fail "adb not found in PATH"
-        return
-    fi
-
-    local rc=0
-    resolve_android_device || rc=$?
-    if [[ $rc -eq 0 ]]; then
-        if [[ -n "$DEVICE" ]]; then
-            pass "Android device '$DEVICE' connected"
-        else
-            pass "Android device connected"
-        fi
-    elif [[ $rc -eq 2 ]]; then
-        fail "Multiple Android devices connected — specify one with --device <serial>:"
-    elif [[ -n "$DEVICE" ]]; then
-        fail "Android device '$DEVICE' not found — available devices:"
-    else
-        fail "No Android device/emulator connected"
-    fi
-}
-
-# ── Check: app installed and running ────────────────────────────────
-
-# Deploy and verify on iOS Simulator: terminate → install → launch → verify PID.
-# Without --install, passively checks installation and freshness.
-check_app_ios_sim() {
-    echo "── App ($BUNDLE_ID) on Simulator ──"
-
-    local target="${SIM_UDID:-booted}"
-
-    if [[ -n "$INSTALL" ]]; then
-        # Active deploy: terminate → install → launch
-        if [[ ! -d "$INSTALL" ]]; then
-            fail "Build artifact not found: $INSTALL"
-            return
-        fi
-
-        info "Terminating old instance..."
-        xcrun simctl terminate "$target" "$BUNDLE_ID" 2>/dev/null || true
-        sleep 0.5
-
-        info "Installing $INSTALL..."
-        if ! xcrun simctl install "$target" "$INSTALL" 2>&1; then
-            fail "simctl install failed"
-            return
-        fi
-        pass "App installed from $INSTALL"
-
-        info "Launching..."
-        local launch_output
-        if ! launch_output=$(xcrun simctl launch "$target" "$BUNDLE_ID" 2>&1); then
-            fail "simctl launch failed: $launch_output"
-            return
-        fi
-        # launch output is like "com.foo.bar: 12345"
-        local launched_pid
-        launched_pid=$(echo "$launch_output" | grep -oE '[0-9]+$' || true)
-        if [[ -n "$launched_pid" ]]; then
-            pass "App launched (pid $launched_pid)"
-        else
-            pass "App launched"
-        fi
-        return
-    fi
-
-    # Passive check: is the app installed and is it the latest build?
-    local container
-    container=$(xcrun simctl get_app_container "$target" "$BUNDLE_ID" 2>/dev/null) || {
-        fail "App not installed on simulator ($target)"
-        return
-    }
-    pass "App is installed"
-
-    # Check if the app process is running
-    if xcrun simctl spawn "$target" launchctl list 2>/dev/null | grep -qi "$BUNDLE_ID"; then
-        pass "App appears to be running"
-    else
-        warn "Could not confirm app is running (may need manual launch)"
-        return
-    fi
-
-    # Freshness check: compare installed binary mtime against build product
-    # Find the executable name from the .app bundle's Info.plist
-    local exec_name
-    exec_name=$(defaults read "$container/Info" CFBundleExecutable 2>/dev/null || true)
-    if [[ -z "$exec_name" ]]; then
-        info "Could not determine executable name — skipping freshness check"
-        return
-    fi
-
-    local installed_bin="$container/$exec_name"
-    if [[ ! -f "$installed_bin" ]]; then
-        info "Installed binary not found at $installed_bin — skipping freshness check"
-        return
-    fi
-
-    # Check process start time vs binary mtime
-    local bin_mtime
-    bin_mtime=$(stat -f %m "$installed_bin" 2>/dev/null || true)
-    local proc_pid
-    proc_pid=$(xcrun simctl spawn "$target" launchctl list 2>/dev/null \
-        | grep -i "$BUNDLE_ID" | awk '{print $1}' || true)
-
-    if [[ -n "$proc_pid" && "$proc_pid" != "-" && -n "$bin_mtime" ]]; then
-        # Get process start time (elapsed seconds via ps)
-        local proc_start
-        proc_start=$(xcrun simctl spawn "$target" ps -p "$proc_pid" -o lstart= 2>/dev/null || true)
-        if [[ -n "$proc_start" ]]; then
-            local proc_epoch
-            proc_epoch=$(date -j -f "%a %b %d %T %Y" "$proc_start" +%s 2>/dev/null || true)
-            if [[ -n "$proc_epoch" && "$proc_epoch" -lt "$bin_mtime" ]]; then
-                fail "Running process (pid $proc_pid) started before the installed binary was updated — restart needed"
+                fail "App ($BUNDLE_ID) not installed on device"
                 return
             fi
-        fi
-    fi
-}
+            ;;
+        10) fail "spyder daemon unreachable when checking app list"; return ;;
+        11) fail "Device not found when checking app list"; return ;;
+        12) fail "Device not connected when checking app list"; return ;;
+        40) fail "Trust not granted — accept pairing dialog (spyder exit 40)"; return ;;
+        41) fail "Developer Mode disabled (spyder exit 41)"; return ;;
+        42) fail "Device locked (spyder exit 42)"; return ;;
+        *)
+            warn "Could not list apps (spyder exit $rc) — skipping install check"
+            ;;
+    esac
 
-check_app_android() {
-    echo "── App ($PACKAGE) on Android ──"
-
-    local adb_cmd="adb"
-    [[ -n "${ADB_SERIAL:-}" ]] && adb_cmd="adb -s $ADB_SERIAL"
-
-    if [[ -n "$INSTALL" ]]; then
-        # Active deploy: force-stop → install → launch
-        if [[ ! -f "$INSTALL" ]]; then
-            fail "Build artifact not found: $INSTALL"
-            return
-        fi
-
-        info "Stopping old instance..."
-        $adb_cmd shell am force-stop "$PACKAGE" 2>/dev/null || true
-
-        info "Installing $INSTALL..."
-        if ! $adb_cmd install -r "$INSTALL" 2>&1; then
-            fail "adb install failed"
-            return
-        fi
-        pass "App installed from $INSTALL"
-
-        # Derive activity name: last segment of package, capitalised, + "Activity"
-        # Default to GeActivity for ge player
-        local activity="${PACKAGE}/.GeActivity"
-        info "Launching $activity..."
-        if ! $adb_cmd shell am start -n "$activity" 2>&1; then
-            fail "adb am start failed"
-            return
-        fi
-
-        sleep 1
-        local pid
-        pid=$($adb_cmd shell pidof "$PACKAGE" 2>/dev/null || true)
-        if [[ -n "$pid" ]]; then
-            pass "App launched (pid $pid)"
+    # Passive check: foreground app via device-state
+    local state_out state_rc=0
+    state_out=$(spyder device-state "$RESOLVED_DEVICE" --json 2>&1) || state_rc=$?
+    if [[ $state_rc -eq 0 ]]; then
+        local fg_app
+        fg_app=$(echo "$state_out" | jq -r '.foreground_app // empty' 2>/dev/null || true)
+        if [[ -n "$fg_app" ]]; then
+            if [[ "$fg_app" == *"$BUNDLE_ID"* ]]; then
+                pass "App is in the foreground ($fg_app)"
+            else
+                warn "Foreground app is '$fg_app', expected '$BUNDLE_ID'"
+            fi
         else
-            fail "App did not start after install"
+            info "Foreground app detection not available on this device — skipping running check"
         fi
-        return
-    fi
-
-    # Passive check
-    if $adb_cmd shell pm list packages 2>/dev/null | grep -q "$PACKAGE"; then
-        pass "App is installed"
     else
-        fail "App ($PACKAGE) not installed"
-        return
-    fi
-
-    local pid
-    pid=$($adb_cmd shell pidof "$PACKAGE" 2>/dev/null || true)
-    if [[ -n "$pid" ]]; then
-        pass "App is running (pid $pid)"
-    else
-        fail "App is not running"
+        info "device-state unavailable (spyder exit $state_rc) — skipping running check"
     fi
 }
 
@@ -710,94 +373,77 @@ check_player_connection() {
 }
 
 # ── Check: player-side logs for errors ──────────────────────────────
+#
+# Uses `spyder log <device>` for mobile devices; scans DiagnosticReports
+# for crash files on iOS (crash reports are written locally by Xcode/iOS).
+# Desktop logs go to stderr — nothing to check programmatically.
 
 check_player_logs() {
     echo "── Player logs (recent errors) ──"
 
-    case "$PLATFORM" in
-        android-emu|android-device)
-            local adb_cmd="adb"
-            [[ -n "${ADB_SERIAL:-}" ]] && adb_cmd="adb -s $ADB_SERIAL"
-            local errors
-            errors=$($adb_cmd logcat -s "GePlayer" -d -v brief 2>/dev/null | grep -i "error\|fatal\|crash" | tail -5)
-            if [[ -n "$errors" ]]; then
-                fail "Errors in player logcat:"
-                echo "$errors" | while read -r line; do
-                    info "  $line"
-                done
-            else
-                pass "No recent errors in player logcat"
-            fi
-            ;;
-        ios-sim)
-            # Check for crash reports
-            local crash_dir="$HOME/Library/Logs/DiagnosticReports"
-            local app_name
-            app_name=$(echo "$BUNDLE_ID" | awk -F. '{print $NF}')
-            local recent_crashes
-            recent_crashes=$(find "$crash_dir" -name "${app_name}*" -mmin -5 2>/dev/null | head -3)
-            if [[ -n "$recent_crashes" ]]; then
-                fail "Recent crash report(s) found:"
-                echo "$recent_crashes" | while read -r f; do
-                    info "  $f"
-                done
-            else
-                pass "No recent crash reports"
-            fi
-            ;;
-        ios-device)
-            # Check for crash reports (same dir, device crashes sync here)
-            local crash_dir="$HOME/Library/Logs/DiagnosticReports"
-            local app_name
-            app_name=$(echo "$BUNDLE_ID" | awk -F. '{print $NF}')
-            local recent_crashes
-            recent_crashes=$(find "$crash_dir" -name "${app_name}*" -mmin -5 2>/dev/null | head -3)
-            if [[ -n "$recent_crashes" ]]; then
-                fail "Recent crash report(s) found:"
-                echo "$recent_crashes" | while read -r f; do
-                    info "  $f"
-                done
-            else
-                pass "No recent crash reports"
-            fi
-            ;;
-        desktop)
+    if [[ -z "$RESOLVED_DEVICE" ]] || [[ "$PLATFORM" == "desktop" ]]; then
+        if [[ "$PLATFORM" == "desktop" ]]; then
             info "Desktop player logs go to stderr — check the terminal"
+        else
+            info "No device resolved — skipping log check"
+        fi
+        return
+    fi
+
+    # Use spyder log to retrieve recent device logs filtered to error level
+    local log_out rc=0
+    log_out=$(spyder log "$RESOLVED_DEVICE" --process "$BUNDLE_ID" --json 2>/dev/null) || rc=$?
+    case $rc in
+        0)
+            local errors
+            errors=$(echo "$log_out" | jq -r \
+                '[.[] | select(.level? and (.level | test("error|fatal|crash"; "i")))] | .[-5:] | .[].message' \
+                2>/dev/null || true)
+            if [[ -n "$errors" ]]; then
+                fail "Errors in device logs:"
+                while IFS= read -r line; do
+                    info "  $line"
+                done <<< "$errors"
+            else
+                pass "No recent errors in device logs"
+            fi
             ;;
+        10) info "spyder daemon unreachable — skipping log check" ;;
+        11) info "Device not found — skipping log check" ;;
+        12) info "Device not connected — skipping log check" ;;
         *)
-            info "Log checking not implemented for $PLATFORM"
+            # Fall back to crash report scan (iOS crash reports sync locally)
+            local crash_dir="$HOME/Library/Logs/DiagnosticReports"
+            local app_name
+            app_name=$(echo "$BUNDLE_ID" | awk -F. '{print $NF}')
+            local recent_crashes
+            recent_crashes=$(find "$crash_dir" -name "${app_name}*" -mmin -5 2>/dev/null | head -3)
+            if [[ -n "$recent_crashes" ]]; then
+                fail "Recent crash report(s) found:"
+                while IFS= read -r f; do
+                    info "  $f"
+                done <<< "$recent_crashes"
+            else
+                pass "No recent crash reports"
+            fi
             ;;
     esac
 }
 
 # ── Run checks ──────────────────────────────────────────────────────
 
-echo "ge smoke test — platform: $PLATFORM${DEVICE:+, device: $DEVICE}"
+echo "ge smoke test${DEVICE:+ — device: $DEVICE}"
 echo
 
 check_ged
 check_server
 
-case "$PLATFORM" in
-    ios-sim)
-        check_device_ios_sim
-        check_app_ios_sim
-        ;;
-    ios-device)
-        check_device_ios_device
-        check_app_ios_device
-        ;;
-    android-emu|android-device)
-        check_device_android
-        check_app_android
-        ;;
-    desktop)
-        info "Desktop player — no device checks needed"
-        ;;
-    *)
-        fail "Unknown platform: $PLATFORM"
-        ;;
-esac
+if [[ "$PLATFORM" == "desktop" ]]; then
+    info "Desktop player — no device checks needed"
+else
+    check_device
+    check_app
+fi
 
 check_player_connection
 check_player_logs


### PR DESCRIPTION
## Summary

- Replaces all direct `xcrun simctl`, `xcrun devicectl`, `pymobiledevice3`, `idevice_id`, and `adb` calls in `tools/smoke-test.sh` with spyder CLI subcommands (`spyder devices`, `spyder resolve`, `spyder deploy`, `spyder list-apps`, `spyder device-state`, `spyder log`).
- The four per-platform branches (ios-sim, ios-device, android-emu, android-device) collapse into a single unified `check_device` / `check_app` flow. `--platform` is retained for backwards compatibility but ignored at runtime.
- All failure detection now branches on spyder's 17-code exit taxonomy (`case $?`) rather than grep-stderr patterns. `--install <path>` delegates to `spyder deploy` (atomic terminate→install→launch→PID-verify).
- `CLAUDE.md`'s "Mobile smoke testing" section updated: spyder selector examples, exit-code diagnostic table, updated invocation examples.

## Test plan

- [x] `bash -n tools/smoke-test.sh` passes (syntax clean)
- [x] `--help` prints and exits 0
- [x] Unknown option exits 1
- [x] `--platform desktop` still skips device checks (backwards compat)
- [ ] Full stack test requires a paired device and running `spyder serve` (out of scope for this PR per 🎯T33.1 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)