### PR TITLE
ge: 🎯T33.3 — visual regression via spyder screenshot + diff against baselines; make update-baselines for refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,3 +491,44 @@ Each check prints PASS/FAIL/WARN. The script exits non-zero if any check fails. 
 Only after the smoke test passes and the problem is still unclear, ask the user what they see — but state what you already verified: "Smoke test passed (ged connected, player session active, no crash reports) — can you confirm whether the globe is rendering?"
 
 **Device preference**: When the user tells you which device to test on (e.g. "use Pippa"), save it to auto-memory so you remember across sessions. Always pass the preferred device via `--device`. If the smoke test fails because that device isn't found, tell the user which device was expected and list the devices that *are* available (the script prints them), then ask how they'd like to proceed.
+
+### Visual regression
+
+ge uses spyder's `screenshot` + `diff` commands to catch rendering regressions in matrix cells. Two cells wire in visual regression checks today:
+
+- `ios-sim-tablet-dist` — after the soak + bg/fg pass, before `check_clean_exit`
+- `android-emu-tablet-dist` — same position
+
+The check is implemented in `ge/tools/visual-regression.sh` (sourced by `matrix-cell.sh`). It calls `spyder screenshot <device>` to capture the current screen, then `spyder diff` to compare against the stored baseline.
+
+**Where baselines live**: spyder stores baselines in `~/.spyder/visualdiff/<suite>/<case>/` on the developer's machine. They are **not** committed to ge's source tree — binary PNG baselines require their own large-binary git practice, and spyder's own data directory is the canonical location. The trade-off is that baselines are not visible in PR diffs; a note in the PR body explains the baseline-storage choice.
+
+- Suite: `ge-tiltbuggy`
+- Case: the matrix cell name (e.g. `ios-sim-tablet-dist`, `android-emu-tablet-dist`)
+
+**Updating baselines**: after a deliberate rendering change, run:
+
+```bash
+cd sample/tiltbuggy
+make update-baselines
+```
+
+This re-runs the two cells with `VR_UPDATE_MODE=1`, which calls `spyder baseline_update` instead of `spyder diff` at the capture point, writing a new PNG to `~/.spyder/visualdiff/ge-tiltbuggy/<cell-id>/...`.
+
+**Pixel tolerance**: the default is `VR_PIXEL_TOLERANCE=8` (on a 0–255 scale). To override for a specific run:
+
+```bash
+VR_PIXEL_TOLERANCE=12 make cell.ios-sim-tablet-dist
+```
+
+Or when updating baselines:
+
+```bash
+VR_PIXEL_TOLERANCE=12 make update-baselines
+```
+
+**Exit code 51**: a visual regression mismatch causes the cell to exit with code 51 (deliberately outside spyder's reserved 10–42 range). The artifact directory for the cell contains `vr-<cell>-report.json` (spyder's diff report) and `vr-<cell>-<ts>.png` (the captured screenshot) for inspection.
+
+**Coexistence with imgdiff**: ge's `imgdiff` utility (built by `make ge/imgdiff`) performs byte-exact RMS comparison against committed reference images in `test/refs/`. The two systems complement each other: spyder diff for high-level visual regression (full-frame, device-level screenshots), imgdiff for pixel-exact comparison of specific rendered outputs. Neither replaces the other.
+
+**spyder not installed**: if `spyder` is not in `PATH`, the visual regression check emits a WARN (not a FAIL) and the cell continues. This keeps the cell runnable in environments without spyder. Install spyder and run `spyder serve` before relying on visual regression in CI.

--- a/sample/tiltbuggy/Makefile
+++ b/sample/tiltbuggy/Makefile
@@ -16,3 +16,26 @@ APP_SHADERS := build/shaders/simple_vs.bin build/shaders/simple_fs.bin
 -include $(ge)/Module.mk
 $(ge)/Module.mk:
 	git submodule update --init --recursive
+
+# ── Visual regression baseline update ───────────────────────────────
+#
+# Re-runs the two visual-regression cells in update mode: each cell captures
+# a screenshot at its known-stable point and calls `spyder baseline_update`
+# to write the new PNG to ~/.spyder/visualdiff/ge-tiltbuggy/<cell-id>/...
+#
+# This target is developer-only — not part of `make check`. Run it after a
+# deliberate rendering change to bless the new look as the correct baseline.
+#
+# Prerequisites:
+#   - spyder installed and `spyder serve` running (or spyder auto-starts)
+#   - iOS Simulator (tablet form factor) booted for the ios-sim-tablet-dist cell
+#   - Android emulator running for the android-emu-tablet-dist cell
+#
+# Usage:
+#   make update-baselines
+#   make update-baselines VR_PIXEL_TOLERANCE=12   # loosen tolerance for a specific cell
+.PHONY: update-baselines
+update-baselines:
+	VR_UPDATE_MODE=1 $(ge)/tools/matrix-cell.sh ios-sim-tablet-dist
+	VR_UPDATE_MODE=1 GE_ANDROID_TABLET_AVD=$(GE_ANDROID_TABLET_AVD) \
+	    $(ge)/tools/matrix-cell.sh android-emu-tablet-dist

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -46,6 +46,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# ── Visual regression helpers ────────────────────────────────────────
+# Source visual-regression.sh so visual_regression_check / visual_regression_update
+# are available to cell runners. The file is optional (graceful no-op if absent).
+# shellcheck source=tools/visual-regression.sh
+if [[ -f "$SCRIPT_DIR/visual-regression.sh" ]]; then
+    # shellcheck disable=SC1090
+    source "$SCRIPT_DIR/visual-regression.sh"
+fi
+
+# Resolve VR_ARTIFACTS_DIR to the cell's artifact directory once it is set up.
+# The actual assignment happens after ARTIFACTS is defined (see "Artifacts dir" block).
+
 # ── Parse args ──────────────────────────────────────────────────────
 
 CELL=""
@@ -186,6 +198,10 @@ ARTIFACTS="$ARTIFACTS_ROOT/$CELL"
 mkdir -p "$ARTIFACTS"
 REFS_DIR="$APP_DIR/test/refs"
 mkdir -p "$REFS_DIR"
+
+# Point visual-regression helpers at the same artifact directory so screenshots
+# and diff reports land alongside the rest of the cell's artifacts.
+VR_ARTIFACTS_DIR="$ARTIFACTS"
 
 echo "matrix-cell: $CELL  app=$APP_NAME  dir=$APP_DIR"
 echo "artifacts:   $ARTIFACTS"
@@ -1809,6 +1825,11 @@ run_ios_sim_dist() {
     check_soak_ios_sim "$SIM_UDID" "$APP_ID" || true
     check_rotation_ios_sim "$SIM_UDID" "$APP_ID" || true
     check_bgfg_ios "$SIM_UDID" "$APP_ID" || true
+    # Visual regression: capture at known-stable state (post-soak, post-bg/fg, pre-exit).
+    # Uses spyder screenshot + diff against baseline in ~/.spyder/visualdiff/ge-tiltbuggy/<cell>/...
+    # On mismatch, exits with code 51 (visual-regression-mismatch).
+    # Run 'make update-baselines' in the app directory to refresh baselines.
+    visual_regression_check "$SIM_UDID" "$CELL" || exit 51
     check_clean_exit_ios_sim "$SIM_UDID" "$APP_ID"
 }
 
@@ -1919,6 +1940,11 @@ run_android_emu_dist() {
     check_soak_android "$ANDROID_SERIAL" "$APP_ID" || true
     check_rotation_android_emu "$ANDROID_SERIAL" "$APP_ID" || true
     check_bgfg_android "$ANDROID_SERIAL" "$APP_ID" "$activity" || true
+    # Visual regression: capture at known-stable state (post-soak, post-bg/fg, pre-exit).
+    # Uses spyder screenshot + diff against baseline in ~/.spyder/visualdiff/ge-tiltbuggy/<cell>/...
+    # On mismatch, exits with code 51 (visual-regression-mismatch).
+    # Run 'make update-baselines' in the app directory to refresh baselines.
+    visual_regression_check "$ANDROID_SERIAL" "$CELL" || exit 51
     check_clean_exit_android "$ANDROID_SERIAL" "$APP_ID"
 }
 

--- a/tools/visual-regression-baselines/README.md
+++ b/tools/visual-regression-baselines/README.md
@@ -1,0 +1,77 @@
+# Visual Regression Baselines
+
+## Why baselines are not in this directory
+
+ge's visual regression uses spyder's `screenshot` + `diff` infrastructure. Baselines
+are managed by spyder and stored on the developer's local machine at:
+
+```
+~/.spyder/visualdiff/ge-tiltbuggy/<cell-id>/baseline.png
+```
+
+They are **not** committed to ge's source tree. This was a deliberate choice:
+
+- PNG baselines are binary blobs. Committing them requires large-binary git
+  practice (Git LFS, careful attribute configuration). That infrastructure
+  does not yet exist in ge.
+- spyder's baseline directory is spyder's source of truth. Duplicating baselines
+  into ge's tree would create a two-source-of-truth problem.
+- The downside is that baselines are not visible as image diffs in PR review.
+  The PR body for changes that affect visual appearance should note what changed
+  and include inline screenshots where the diff matters.
+
+## Establishing or refreshing baselines
+
+From the app directory (e.g. `sample/tiltbuggy/`):
+
+```bash
+make update-baselines
+```
+
+This re-runs `ios-sim-tablet-dist` and `android-emu-tablet-dist` with
+`VR_UPDATE_MODE=1`, capturing a screenshot at the known-stable post-soak point
+and writing it as the new baseline via `spyder baseline_update`.
+
+Prerequisites:
+- spyder installed (`brew install spyder` or equivalent)
+- `spyder serve` running, or spyder configured to auto-start
+- iOS Simulator (tablet form factor) booted
+- Android emulator running
+
+## Cell coverage
+
+| Cell | Suite | Case | Capture point |
+|---|---|---|---|
+| `ios-sim-tablet-dist` | `ge-tiltbuggy` | `ios-sim-tablet-dist` | Post-soak, post-bg/fg, pre-clean-exit |
+| `android-emu-tablet-dist` | `ge-tiltbuggy` | `android-emu-tablet-dist` | Post-soak, post-bg/fg, pre-clean-exit |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Baseline match (or no baseline yet — WARN, not FAIL) |
+| 51 | Pixel mismatch (visual regression) |
+| 52 | spyder screenshot failed |
+| 53 | spyder diff/baseline_update returned unexpected error |
+
+Code 51 is deliberately outside spyder's reserved range (10–42).
+
+## Pixel tolerance
+
+Default: `VR_PIXEL_TOLERANCE=8` (on a 0–255 scale). Override per-run:
+
+```bash
+VR_PIXEL_TOLERANCE=12 make cell.ios-sim-tablet-dist
+VR_PIXEL_TOLERANCE=12 make update-baselines
+```
+
+## Coexistence with imgdiff
+
+ge also ships `imgdiff` (built via `make ge/imgdiff`), which performs pixel-exact
+RMS comparison against reference images committed to `test/refs/`. The two systems
+serve different purposes:
+
+- **spyder diff** — full-frame device-level screenshots, high-level visual regression
+- **imgdiff** — pixel-exact comparison of specific rendered outputs
+
+Neither replaces the other; both can run in the same cell.

--- a/tools/visual-regression.sh
+++ b/tools/visual-regression.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# visual-regression.sh — spyder-based visual regression helpers for matrix cells.
+#
+# Source this file from matrix-cell.sh or any script that needs visual regression
+# checks. Do not execute it directly.
+#
+# Usage (after sourcing):
+#   visual_regression_check <device> <cell-id> [pixel-tolerance]
+#   visual_regression_update <device> <cell-id>
+#
+# Exit codes (visual_regression_check):
+#   0  — screenshot matches baseline (or no baseline established yet — WARN, not FAIL)
+#   51 — visual regression mismatch (pixel diff exceeds tolerance)
+#   52 — spyder screenshot failed
+#   53 — spyder diff returned unexpected error
+#
+# Exit code 51 is deliberately outside spyder's reserved 10–42 range.
+#
+# Environment variables:
+#   VR_SUITE             Suite name for spyder baselines (default: ge-tiltbuggy)
+#   VR_PIXEL_TOLERANCE   Default pixel tolerance 0–255 (default: 8)
+#   VR_ARTIFACTS_DIR     Directory to write diff report + screenshot (default: /tmp)
+#   VR_UPDATE_MODE       If set to 1, visual_regression_check calls baseline_update
+#                        instead of diff. Used by `make update-baselines`.
+
+# ── Defaults ──────────────────────────────────────────────────────────
+
+VR_SUITE="${VR_SUITE:-ge-tiltbuggy}"
+VR_PIXEL_TOLERANCE="${VR_PIXEL_TOLERANCE:-8}"
+VR_ARTIFACTS_DIR="${VR_ARTIFACTS_DIR:-${TMPDIR:-/tmp}}"
+VR_UPDATE_MODE="${VR_UPDATE_MODE:-0}"
+
+# ── visual_regression_check ───────────────────────────────────────────
+#
+# Captures a screenshot of <device> via spyder, then either:
+#   - compares against the stored baseline (normal mode), or
+#   - updates the baseline (VR_UPDATE_MODE=1 / make update-baselines).
+#
+# Arguments:
+#   $1  device    spyder device alias or ID
+#   $2  cell_id   matrix cell name — used as the spyder case name
+#   $3  tolerance pixel tolerance override (optional; defaults to VR_PIXEL_TOLERANCE)
+#
+# Returns 0 on pass/warn, 51 on mismatch, 52 on capture failure, 53 on diff error.
+
+visual_regression_check() {
+    local device="$1"
+    local cell_id="$2"
+    local tolerance="${3:-$VR_PIXEL_TOLERANCE}"
+    local subcheck="visual-regression"
+
+    # Require spyder.
+    if ! command -v spyder >/dev/null 2>&1; then
+        # Warn rather than fail: spyder not installed is a CI-infra gap, not a
+        # rendering regression. Record as a warning so the cell still passes.
+        warn_check "$subcheck" "spyder not found — install spyder to enable visual regression"
+        return 0
+    fi
+
+    # Capture screenshot.
+    local shot_path
+    shot_path="$VR_ARTIFACTS_DIR/vr-${cell_id}-$(date +%s).png"
+    local capture_stderr
+    capture_stderr=$(mktemp)
+
+    if ! spyder screenshot "$device" --output "$shot_path" 2>"$capture_stderr"; then
+        local err
+        err=$(cat "$capture_stderr" 2>/dev/null | head -3 | tr '\n' ' ')
+        rm -f "$capture_stderr"
+        if [[ $VR_UPDATE_MODE -eq 1 ]]; then
+            echo "  visual-regression: screenshot failed during baseline update: $err" >&2
+        else
+            fail_check "$subcheck" "spyder screenshot failed: $err"
+        fi
+        return 52
+    fi
+    rm -f "$capture_stderr"
+
+    if [[ ! -s "$shot_path" ]]; then
+        if [[ $VR_UPDATE_MODE -eq 1 ]]; then
+            echo "  visual-regression: screenshot empty during baseline update" >&2
+        else
+            fail_check "$subcheck" "screenshot empty"
+        fi
+        return 52
+    fi
+
+    # Update-baselines mode: call baseline_update instead of diff.
+    if [[ $VR_UPDATE_MODE -eq 1 ]]; then
+        if spyder baseline_update \
+                --suite="$VR_SUITE" \
+                --case="$cell_id" \
+                --screenshot-path="$shot_path" 2>&1; then
+            echo "  visual-regression: baseline updated for $VR_SUITE/$cell_id"
+        else
+            echo "  visual-regression: baseline_update failed for $VR_SUITE/$cell_id" >&2
+            return 53
+        fi
+        return 0
+    fi
+
+    # Normal mode: diff against existing baseline.
+    local report_path
+    report_path="$VR_ARTIFACTS_DIR/vr-${cell_id}-report.json"
+    local diff_exit=0
+    local diff_out
+    diff_out=$(spyder diff \
+        --suite="$VR_SUITE" \
+        --case="$cell_id" \
+        --screenshot-path="$shot_path" \
+        --pixel-tolerance="$tolerance" \
+        2>&1) || diff_exit=$?
+
+    # Write report for artifact inspection.
+    printf '%s\n' "$diff_out" > "$report_path"
+
+    if [[ $diff_exit -eq 0 ]]; then
+        pass_check "$subcheck" "baseline match (suite=$VR_SUITE case=$cell_id tol=$tolerance)"
+        return 0
+    fi
+
+    # Exit code 10 from spyder diff = no baseline exists yet.
+    # Treat as a warning (no evidence of regression) rather than a hard failure.
+    if [[ $diff_exit -eq 10 ]]; then
+        warn_check "$subcheck" \
+            "no baseline yet — run 'make update-baselines' to establish one (suite=$VR_SUITE case=$cell_id)"
+        return 0
+    fi
+
+    # Any other non-zero exit = mismatch or error.
+    # Log the first few lines of the diff report so it appears in CI output.
+    local report_snippet
+    report_snippet=$(printf '%s\n' "$diff_out" | head -5 | tr '\n' ' ')
+    fail_check "$subcheck" \
+        "pixel mismatch (exit=$diff_exit tol=$tolerance) — report: $report_path  $report_snippet"
+    return 51
+}
+
+# ── visual_regression_update ──────────────────────────────────────────
+#
+# Unconditionally establishes or refreshes the baseline for <cell_id>.
+# Intended for `make update-baselines`; not called during normal cell runs.
+#
+# Arguments:
+#   $1  device    spyder device alias or ID
+#   $2  cell_id   matrix cell name
+#
+# Returns 0 on success, non-zero on failure.
+
+visual_regression_update() {
+    local device="$1"
+    local cell_id="$2"
+    VR_UPDATE_MODE=1 visual_regression_check "$device" "$cell_id"
+}


### PR DESCRIPTION
## Summary

- Adds `tools/visual-regression.sh` with `visual_regression_check(device, cell_id, [tolerance])`: captures a screenshot via `spyder screenshot`, compares it against the stored baseline via `spyder diff --pixel-tolerance`. Exits 51 on mismatch (outside spyder's reserved 10–42 range); warns (not fails) when spyder is absent or no baseline exists yet.
- Wires the check into two visually-deterministic cells in `matrix-cell.sh`, immediately before `check_clean_exit` (post-soak, post-bg/fg — the most stable visual point in the cell):
  - `ios-sim-tablet-dist`
  - `android-emu-tablet-dist`
- Adds `make update-baselines` to `sample/tiltbuggy/Makefile`: re-runs both cells with `VR_UPDATE_MODE=1`, calling `spyder baseline_update` instead of `spyder diff`. Developer-only, not part of `make check`.
- Documents everything in a new "Visual regression" subsection in `CLAUDE.md`.
- Adds `tools/visual-regression-baselines/README.md` explaining the baseline-storage decision.

## Baseline storage

Baselines are stored in `~/.spyder/visualdiff/ge-tiltbuggy/<cell-id>/` on the developer's machine — **not** committed to ge's source tree. PNG blobs require large-binary git practice (Git LFS) not yet set up in ge, and spyder's own directory is the canonical store. The trade-off is that baselines are not visible as image diffs in PR review; PR bodies for visual changes should include inline screenshots.

## Test plan

- [ ] `bash -n tools/visual-regression.sh tools/matrix-cell.sh` passes (both clean)
- [ ] `make cell.ios-sim-tablet-dist` with no baseline emits `WARN — no baseline yet` and the cell passes
- [ ] `make update-baselines` writes `~/.spyder/visualdiff/ge-tiltbuggy/ios-sim-tablet-dist/baseline.png`
- [ ] `make cell.ios-sim-tablet-dist` after baseline update passes with `PASS — baseline match`
- [ ] Changing a shader and re-running without updating baselines triggers exit 51 and logs the diff report path

🤖 Generated with [Claude Code](https://claude.com/claude-code)