### PR TITLE
ge: 🎯T33.5 — commit spyder pool config + make pool-init/drain rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,3 +575,33 @@ VR_PIXEL_TOLERANCE=12 make update-baselines
 **Coexistence with imgdiff**: ge's `imgdiff` utility (built by `make ge/imgdiff`) performs byte-exact RMS comparison against committed reference images in `test/refs/`. The two systems complement each other: spyder diff for high-level visual regression (full-frame, device-level screenshots), imgdiff for pixel-exact comparison of specific rendered outputs. Neither replaces the other.
 
 **spyder not installed**: if `spyder` is not in `PATH`, the visual regression check emits a WARN (not a FAIL) and the cell continues. This keeps the cell runnable in environments without spyder. Install spyder and run `spyder serve` before relying on visual regression in CI.
+
+### Spyder pool (one-time setup)
+
+The matrix's iOS sim and Android emu cells pay a ~10–30 s boot cost when no pre-warmed instance exists. `tools/spyder-pool.yaml` commits pool templates for the three matrix platforms so spyder keeps ready instances around.
+
+**One-time setup** (per developer machine, requires spyder v0.17.0+):
+
+```bash
+make pool-init
+```
+
+This symlinks `tools/spyder-pool.yaml` to `~/.spyder/pool.yaml`, restarts the spyder daemon, and warms one instance per template (~30–60 s total). The symlink means any future changes to `tools/spyder-pool.yaml` take effect on the next daemon restart without re-running `pool-init`.
+
+**Drain** (optional — frees emulator resources when not in use):
+
+```bash
+make pool-drain
+```
+
+This shuts down all pool instances and removes the symlink.
+
+**Pool templates** (defined in `tools/spyder-pool.yaml`):
+
+| Template | Platform | Device | Runtime |
+|----------|----------|--------|---------|
+| `ios-phone` | iOS sim | iPhone 16 Pro | iOS 18.4 |
+| `ios-tablet` | iOS sim | iPad Air 11-inch (M4) | iOS 18.4 |
+| `android-phone` | Android emu | Pixel 9 Pro XL | android-36, google_apis_playstore |
+
+The pool is transparent to the matrix — cells acquire a device normally, and spyder's resolver prefers a warm pool instance over creating a fresh one.

--- a/Module.mk
+++ b/Module.mk
@@ -835,6 +835,66 @@ check-list:
 	@echo "Cells excluded:"
 	@printf '  %s\n' $(filter-out $(ge/CHECK_CELLS),$(ge/CELLS))
 
+# ────────────────────────────────────────────────
+# Spyder pool management
+#
+# `make pool-init` symlinks tools/spyder-pool.yaml to ~/.spyder/pool.yaml so
+# spyder's daemon picks up pre-warm templates for the matrix's sim/emu cells.
+# This is a one-time setup step; re-running is safe (idempotent).
+#
+# `make pool-drain` shuts down all pool instances and removes the symlink.
+# Run before the machine goes idle for an extended period to avoid leaving
+# background emulators running.
+#
+# Pool template names mirror the three matrix platforms that benefit from
+# pre-warming:
+#   ios-phone   — iPhone 16 Pro sim, iOS 18.4
+#   ios-tablet  — iPad Air 11-inch (M4) sim, iOS 18.4
+#   android-phone — Pixel 9 Pro XL AVD (android-36, google_apis_playstore)
+# ────────────────────────────────────────────────
+
+ge/POOL_YAML    := $(ge)/tools/spyder-pool.yaml
+ge/POOL_DEST    := $(HOME)/.spyder/pool.yaml
+ge/POOL_TMPLS   := ios-phone ios-tablet android-phone
+
+.PHONY: pool-init
+pool-init:
+	@echo "── Spyder pool setup ──"
+	@command -v spyder >/dev/null 2>&1 || { echo "WARN: spyder not found; skipping pool setup. Install spyder v0.17.0+ to enable pre-warming."; exit 0; }
+	@mkdir -p "$(dir $(ge/POOL_DEST))"
+	@if [ -e "$(ge/POOL_DEST)" ] && [ ! -L "$(ge/POOL_DEST)" ]; then \
+	    echo "WARN: $(ge/POOL_DEST) exists and is not a symlink; leaving it alone."; \
+	    echo "  To adopt ge's pool config, remove the existing file and re-run."; \
+	else \
+	    ln -sf "$(abspath $(ge/POOL_YAML))" "$(ge/POOL_DEST)"; \
+	    echo "  Symlinked: $(ge/POOL_DEST) -> $(abspath $(ge/POOL_YAML))"; \
+	fi
+	@echo "  Restarting spyder daemon to pick up new pool config..."
+	@spyder daemon restart 2>/dev/null || spyder daemon start 2>/dev/null || \
+	    echo "  WARN: could not restart spyder daemon; restart it manually."
+	@echo "  Warming pool instances (this may take 30-60 s)..."
+	@for tmpl in $(ge/POOL_TMPLS); do \
+	    echo "    spyder pool_warm $$tmpl --count 1"; \
+	    spyder pool_warm "$$tmpl" --count 1 2>&1 || \
+	        echo "    WARN: pool_warm $$tmpl failed (daemon may still be starting; retry with 'make pool-init')"; \
+	done
+	@echo "  Pool ready. Run 'make pool-drain' to shut down instances."
+
+.PHONY: pool-drain
+pool-drain:
+	@echo "── Spyder pool drain ──"
+	@command -v spyder >/dev/null 2>&1 || { echo "WARN: spyder not found; nothing to drain."; exit 0; }
+	@for tmpl in $(ge/POOL_TMPLS); do \
+	    echo "  spyder pool_drain $$tmpl"; \
+	    spyder pool_drain "$$tmpl" 2>&1 || \
+	        echo "  WARN: pool_drain $$tmpl failed (may already be empty)"; \
+	done
+	@if [ -L "$(ge/POOL_DEST)" ]; then \
+	    rm "$(ge/POOL_DEST)"; \
+	    echo "  Removed symlink: $(ge/POOL_DEST)"; \
+	fi
+	@echo "  Pool drained."
+
 # Canned recipe for the parent to expand at the end of its init target.
 define ge/INIT_DONE
 	@echo ""

--- a/tools/spyder-pool.yaml
+++ b/tools/spyder-pool.yaml
@@ -1,0 +1,52 @@
+# ge spyder pool configuration
+#
+# Declares pre-warmed sim/emu templates for the ge matrix.  Symlink or copy
+# this file to ~/.spyder/pool.yaml and run `make pool-init` to activate.
+#
+# Schema reference: spyder/internal/pool/config.go (TemplateConfig)
+#   name                   — unique template identifier
+#   platform               — "ios" or "android"
+#   device_type            — simctl device-type ID (iOS) or template AVD name (Android)
+#   runtime_or_system_image — simctl runtime ID (iOS) or system-image package (Android)
+#   available_min          — floor for created-but-not-booted instances
+#   available_max          — cap before excess instances are deleted on linger expiry
+#   running_warm           — number of pre-booted idle instances
+#   tags                   — optional selector labels for spyder reserve --on
+
+templates:
+  # iOS phone simulator — iPhone 16 Pro, iOS 18.4
+  - name: ios-phone
+    platform: ios
+    device_type: com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro
+    runtime_or_system_image: com.apple.CoreSimulator.SimRuntime.iOS-18-4
+    available_min: 1
+    available_max: 2
+    running_warm: 1
+    tags:
+      - phone
+      - ios-sim
+
+  # iOS tablet simulator — iPad Air 11-inch (M4), iOS 18.4
+  - name: ios-tablet
+    platform: ios
+    device_type: com.apple.CoreSimulator.SimDeviceType.iPad-Air-11-inch-M4
+    runtime_or_system_image: com.apple.CoreSimulator.SimRuntime.iOS-18-4
+    available_min: 1
+    available_max: 2
+    running_warm: 1
+    tags:
+      - tablet
+      - ios-sim
+
+  # Android phone emulator — Pixel 9 Pro XL (android-36, google_apis_playstore, arm64-v8a)
+  # Cloned from the Pixel_9_Pro_XL template AVD (must exist; created by `make init`).
+  - name: android-phone
+    platform: android
+    device_type: Pixel_9_Pro_XL
+    runtime_or_system_image: "system-images;android-36;google_apis_playstore;arm64-v8a"
+    available_min: 1
+    available_max: 2
+    running_warm: 1
+    tags:
+      - phone
+      - android-emu


### PR DESCRIPTION
## Summary

- Adds `tools/spyder-pool.yaml` declaring three pre-warm templates (`ios-phone`, `ios-tablet`, `android-phone`) for the ge matrix's sim/emu cells
- `Module.mk` gains `pool-init` (symlink pool.yaml + restart daemon + warm) and `pool-drain` (drain instances + remove symlink) targets
- `CLAUDE.md` documents the one-time `make pool-init` developer setup step under a new "Spyder pool" subsection

## Schema fields used (spyder/internal/pool/config.go)

`name`, `platform`, `device_type`, `runtime_or_system_image`, `available_min`, `available_max`, `running_warm`, `tags`

## Devices

| Template | `device_type` | `runtime_or_system_image` |
|----------|--------------|--------------------------|
| `ios-phone` | `com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro` | `com.apple.CoreSimulator.SimRuntime.iOS-18-4` |
| `ios-tablet` | `com.apple.CoreSimulator.SimDeviceType.iPad-Air-11-inch-M4` | `com.apple.CoreSimulator.SimRuntime.iOS-18-4` |
| `android-phone` | `Pixel_9_Pro_XL` (template AVD) | `system-images;android-36;google_apis_playstore;arm64-v8a` |

## Test plan

- [ ] YAML parses cleanly: `python3 -c "import yaml; yaml.safe_load(open('tools/spyder-pool.yaml'))"`
- [ ] `make -n pool-init` prints expected shell commands without error
- [ ] `make -n pool-drain` prints expected shell commands without error
- [ ] `make pool-init` on a machine with spyder v0.17.0+ creates the symlink and warms instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)