### PR TITLE
ge: 🎯T7 — auto-pause audio when app is backgrounded; auto-resume on foreground

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,12 @@ The player has no app-specific code — it works with any ge app.
 
 The player retries on disconnect with exponential backoff: 10ms initial, doubling to 2000ms cap, reset on success. This means you can restart the server and the player will reconnect automatically.
 
+### Audio Lifecycle (iOS / Android)
+
+`AudioPlayer` automatically pauses all audio output when the OS backgrounds the app (`SDL_EVENT_DID_ENTER_BACKGROUND`) and resumes it when the app returns to the foreground (`SDL_EVENT_DID_ENTER_FOREGROUND`). This is wired via `SDL_AddEventWatch` inside `AudioPlayer`'s constructor — no game code or player-loop changes are required. The watch is removed in the destructor.
+
+Desktop builds are unaffected: SDL does not fire these events on macOS/Linux/Windows.
+
 ### Ged Quiet Mode
 
 Use `-no-open` to prevent ged from opening the dashboard in the browser on first server connection:

--- a/tools/AudioPlayer.cpp
+++ b/tools/AudioPlayer.cpp
@@ -1,3 +1,6 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
 #include "AudioPlayer.h"
 
 #include <SDL3/SDL.h>
@@ -30,6 +33,23 @@ void loopCallback(void* userdata, SDL_AudioStream* stream,
     }
 }
 
+// SDL event watch callback: pauses or resumes the audio device on app
+// background/foreground transitions. Registered by AudioPlayer on
+// construction; removed on destruction. Runs on the event-posting thread
+// — SDL_PauseAudioDevice / SDL_ResumeAudioDevice are thread-safe.
+bool lifecycleEventWatch(void* userdata, SDL_Event* event) {
+    auto* deviceID = static_cast<SDL_AudioDeviceID*>(userdata);
+    if (!deviceID || !*deviceID) return false;
+    if (event->type == SDL_EVENT_DID_ENTER_BACKGROUND) {
+        SPDLOG_INFO("AudioPlayer: backgrounded — pausing audio device");
+        SDL_PauseAudioDevice(*deviceID);
+    } else if (event->type == SDL_EVENT_DID_ENTER_FOREGROUND) {
+        SPDLOG_INFO("AudioPlayer: foregrounded — resuming audio device");
+        SDL_ResumeAudioDevice(*deviceID);
+    }
+    return false;  // do not filter the event
+}
+
 } // namespace
 
 struct AudioPlayer::M {
@@ -37,6 +57,9 @@ struct AudioPlayer::M {
     std::vector<Clip> clips;
 
     ~M() {
+        if (device) {
+            SDL_RemoveEventWatch(lifecycleEventWatch, &device);
+        }
         for (auto& clip : clips) {
             if (clip.stream) {
                 SDL_DestroyAudioStream(clip.stream);
@@ -65,10 +88,31 @@ AudioPlayer::AudioPlayer() : m(std::make_unique<M>()) {
     }
 
     SDL_ResumeAudioDevice(m->device);
+
+    // Auto-pause/resume on iOS/Android background transitions.
+    // SDL_AddEventWatch fires on the posting thread before SDL_PollEvent
+    // delivers the event to the main loop, so the device is paused/resumed
+    // as soon as the OS raises the transition event.
+    SDL_AddEventWatch(lifecycleEventWatch, &m->device);
+
     SPDLOG_INFO("AudioPlayer: Opened audio device");
 }
 
 AudioPlayer::~AudioPlayer() = default;
+
+void AudioPlayer::pause() {
+    if (m->device) {
+        SPDLOG_INFO("AudioPlayer: pause");
+        SDL_PauseAudioDevice(m->device);
+    }
+}
+
+void AudioPlayer::resume() {
+    if (m->device) {
+        SPDLOG_INFO("AudioPlayer: resume");
+        SDL_ResumeAudioDevice(m->device);
+    }
+}
 
 void AudioPlayer::loadClip(uint32_t id, uint32_t format, uint32_t flags,
                            const void* data, size_t size) {

--- a/tools/AudioPlayer.h
+++ b/tools/AudioPlayer.h
@@ -16,6 +16,12 @@ public:
                   const void* data, size_t size);
     void handleCommand(uint32_t command, uint32_t id, float volume);
 
+    // Pause/resume all audio output. Called automatically when the OS
+    // backgrounds/foregrounds the app via SDL_EVENT_DID_ENTER_BACKGROUND /
+    // SDL_EVENT_DID_ENTER_FOREGROUND. Game code does not need to call these.
+    void pause();
+    void resume();
+
 private:
     struct M;
     std::unique_ptr<M> m;


### PR DESCRIPTION
## Summary

- `AudioPlayer` self-registers an `SDL_AddEventWatch` callback in its constructor that calls `SDL_PauseAudioDevice` on `SDL_EVENT_DID_ENTER_BACKGROUND` and `SDL_ResumeAudioDevice` on `SDL_EVENT_DID_ENTER_FOREGROUND`
- The event watch is removed cleanly in `~M()` before `SDL_CloseAudioDevice`
- Public `pause()` and `resume()` methods added for callers that need explicit control
- Desktop builds are unaffected — SDL does not fire these lifecycle events on macOS/Linux/Windows
- No game code or player-loop changes required; behaviour is entirely transparent

## Architecture notes

`AudioPlayer` exists in `tools/` and is not yet wired into `player_core.cpp` — it's a standalone class. The `SDL_AddEventWatch` approach means the fix works the moment `AudioPlayer` is instantiated in any context, without threading changes or event-loop modifications.

## Test plan

- [ ] Build `ge/player` (`make ge/player` from `sample/tiltbuggy`) — no regressions
- [ ] Syntax-check `AudioPlayer.cpp` against ge vendor headers — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)