### PR TITLE
ge: 🎯T11.1 — declare wire protocol in protogen YAML; emit Go/Swift/Kotlin/C/TS bindings (codegen only, no consumer rewire)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,40 @@ ge/%:
 #   make cell.ios-sim-tablet-dist
 cell.%:
 	$(MAKE) -C $(SAMPLE) $@
+
+# ── Wire protocol codegen ──────────────────────────────────────────────────
+#
+# Regenerates all platform bindings from protocol/ge_wire.yaml using
+# pigeon-protogen (github.com/marcelocantos/pigeon/cmd/protogen).
+#
+# Install protogen once:
+#   GOBIN=$$HOME/go/bin go install github.com/marcelocantos/pigeon/cmd/protogen@v0.20.0
+#
+# Then regenerate:
+#   make protogen
+#
+# CI drift check (exits non-zero if generated files are out of date):
+#   make protogen-check
+#
+.PHONY: protogen protogen-check
+
+protogen:
+	scripts/run-protogen.sh
+
+# Regenerate into a temp copy and diff against repo; fail if anything changed.
+protogen-check:
+	@TMPDIR=$$(mktemp -d) && \
+	  cp -r . "$$TMPDIR/ge" && \
+	  PROTOGEN=$$(which protogen 2>/dev/null || echo "$${GOPATH:-$$HOME/go}/bin/protogen") \
+	    PROTOGEN=$$PROTOGEN "$$TMPDIR/ge/scripts/run-protogen.sh" && \
+	  git -C "$$TMPDIR/ge" diff --exit-code -- \
+	    protocol/gewire_gen.go \
+	    include/ge/generated/gewire_gen.h \
+	    src/generated/gewire_gen.c \
+	    tools/ios/generated/GeWireMachine.swift \
+	    tools/android/generated/GeWireMachine.kt \
+	    web/src/GeWireMachine.ts \
+	    formal/GeWire.tla \
+	    docs/gewire_transport.puml \
+	    docs/gewire_relay.puml && \
+	  rm -rf "$$TMPDIR" || { rm -rf "$$TMPDIR"; echo "ERROR: generated files are out of date; run 'make protogen'"; exit 1; }

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 3
 targets:
   T1:
     name: Game servers can run inside the player via WebAssembly
@@ -71,6 +71,22 @@ targets:
     context: Add github.com/marcelocantos/pigeon to ged's go.mod. ged lives at ge/ged/ with its own go.mod. Pigeon is at ../../marcelocantos/pigeon — use a replace directive for local dev.
     origin: decomposed from T11
     discovered: 2026-04-12
+  T11.1.1:
+    name: All Protocol.h consumers replaced with generated bindings; Protocol.h deleted
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'Every #include or import of Protocol.h''s hand-rolled constants in ge source files (SessionHost_brokered.mm, PlayerWireBridge.cpp, ServerWireBridge.mm, ged Go code) is replaced with the generated equivalents from protocol/ge_wire.yaml'
+    - Protocol.h itself is deleted from include/ge/
+    - The generated Go bindings are wired into ged as a proper Go package (using protogen --root-pkg=wire or equivalent)
+    - make protogen-check passes (generated files match YAML)
+    - ge/player still builds and passes smoke test
+    context: 🎯T11.1 established protocol/ge_wire.yaml as the new source of truth for the wire protocol and emitted generated bindings for Go/Swift/Kotlin/TypeScript/C. This follow-on completes the migration by replacing every hand-rolled usage of Protocol.h's constants with the generated equivalents, then deleting Protocol.h. The generated C header lives at include/ge/generated/gewire_gen.h; the Go package will need protogen --root-pkg= to emit into ged's module. Do not merge Protocol.h consumers until all platforms (C++, Go/ged, Swift, Kotlin) are wired up in a single consistent pass.
+    depends_on:
+    - T11.1
+    origin: forked from T11.1 during wire protocol YAML codegen PR
+    discovered: 2026-04-26
   T11.2:
     name: ged registers as a pigeon backend and accepts client connections
     status: identified
@@ -291,7 +307,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 2.0
     acceptance:
     - 'All 6 automated matrix-test cells pass on current hardware: desktop-dist, desktop-player, ios-sim-dist, ios-sim-player, android-emu-dist, android-emu-player'
@@ -336,7 +352,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 1.0
     acceptance:
     - rotation-stability-test.sh --platform ios-sim --app-id com.squz.tiltbuggy --cycles 10 reports PASS end-to-end against the iPad Air M4 simulator
@@ -351,7 +367,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - 'iPhone: dist + player smoke pass (cold launch, 60s soak, no crashes)'
@@ -369,7 +385,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - make ge/<platform>-debug (or equivalent) produces a debug binary / .app / APK distinct from the release build — assertions enabled, debug symbols retained
@@ -385,7 +401,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 5.0
     acceptance:
     - Android player reads a `ged_addr` intent extra (e.g. `adb shell am start -n com.squz.player/.GeActivity --es ged_addr host:port`) and connects directly, skipping QR onboarding
@@ -412,7 +428,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - '`make cell.android-emu-phone-dist` and `make cell.android-debug-dist` both pass end-to-end on the current canonical phone AVD'
     - Failure mode (GL-context error) either fixed at the bgfx config layer or worked around with a documented AVD requirement in Module.mk
@@ -436,7 +452,7 @@ targets:
     status: converging
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - '`make cell.ios-sim-tablet-player` passes the reconnect sub-check end-to-end'
     - '`make cell.android-emu-phone-player` passes the reconnect sub-check end-to-end'
@@ -449,7 +465,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     actual_cost: 3.0
     acceptance:
     - '`make cell.android-emu-phone-player` passes the startup-flash sub-check end-to-end with no false positive and no genuine flash'
@@ -471,7 +487,7 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - Per-cell soak sub-check runs for ~10s by default
     - A single dedicated long-soak cell runs the 60s sweep
@@ -498,7 +514,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - DirectRenderHost::pumpEvents routes each SDL event through synth->handle() (when synth is active) before forwarding to the user event handler; consumed events are NOT forwarded
     - DirectRenderHost drives synth->update() once per frame (beginFrame or endFrame) so the ease-back after Shift-release animates
@@ -513,7 +529,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - In a distribution build using DirectRenderHost, Shift-dragging produces a visible viewport tilt matching the player binary's visual behaviour on the same app
     - The tilt compose shader in DirectRenderHost is fed the current AccelSynth tilt each frame (same convention as PlayerRender.cpp ~line 346)
@@ -529,7 +545,7 @@ targets:
     status: converging
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - On an iOS simulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors and AccelSynth activates
     - Shift+mouse-drag inside the simulator window tilts the viewport and drives sensor-driven gameplay
@@ -547,7 +563,7 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - On an Android emulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors (or emulator's virtual sensors pass a simulator-detection check) and AccelSynth activates
     - Shift+mouse-drag inside the emulator window tilts the viewport and drives sensor-driven gameplay
@@ -598,7 +614,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - SDL_ttf is vendored under ge/vendor/github.com/libsdl-org/SDL_ttf — added as a git submodule (matching the existing SDL submodule at the same parent path) pinned to release-3.2.2 (requires SDL ≥ 3.2.6; ge's SDL is 3.4.0 so compatible)
     - ge/CMakeLists.txt's Android branch (currently lines 217-234) does add_subdirectory for SDL_ttf and links SDL3_ttf::SDL3_ttf into the ge target via PUBLIC
@@ -614,7 +630,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - A FontLoader implementation exists that works on Android (and is portable to desktop Linux/Windows if/when those are added) — likely FontLoader_sdl.cpp using SDL_IOStream + SDL_ttf directly, or FontLoader_android.cpp using AAssetManager. Name and approach at author's discretion.
     - 'ge/CMakeLists.txt selects the right FontLoader source per platform (FontLoader_apple.mm on Apple, the new one everywhere else) — no #ifdef sprawl inside a single file'
@@ -631,7 +647,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt calls add_subdirectory(${GE_ROOT}) and target_link_libraries(main PRIVATE ge)
     - The inline GE_SOURCES block (currently lines 79-96) and its accompanying Apple-only comment (lines 76-78) are deleted
@@ -648,7 +664,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - 'Confirmed where Triangle code actually lands. Inventory: vendor/src/triangle.c + vendor/include/triangle.h are vendored in ge''s repo; Module.mk exposes ge/TRIANGLE_OBJ as an opt-in object (built with -DTRILIBRARY -DREAL=double -DANSI_DECLARATORS -DNO_TIMER); no ge/src/ file #includes triangle.h or calls triangulate(); ge/CMakeLists.txt does not compile triangle.c into libge; the only known consumer is yourworld/yourworld2/tools/precompute.cpp (build-time tool, not a runtime artifact)'
     - 'Confirmed exactly what the licence permits and forbids. The text in vendor/src/triangle.c grants free use for private, research, and institutional use; permits redistribution if (a) copyright notices are kept, (b) no compensation is received for redistribution, (c) modifications keep original copyright + free source/object availability; **explicitly forbids distribution as part of a commercial system without direct arrangement with Shewchuk (jrs@cs.berkeley.edu)**, with one carve-out: if you don''t supply the code directly to the customer but instead point them at a free download, no arrangement needed'
@@ -664,7 +680,7 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    observable: true
+    showcase: true
     acceptance:
     - VideoDecoder's frame callback on Android delivers NV12 planar data (Y plane + interleaved UV plane with their respective strides), not pre-converted BGRA. The hand-rolled nv12ToBgra() function and reusable frameBuffer member in src/bridge/VideoDecoder_android.cpp (and the equivalent libswscale conversion in src/bridge/VideoDecoder_ffmpeg.cpp) are deleted
     - PlayerRender uploads Y as a bgfx R8 texture (w×h) and UV as a bgfx RG8 texture (w/2 × h/2) with proper pitch handling for MediaCodec's row stride

--- a/docs/gewire_relay.puml
+++ b/docs/gewire_relay.puml
@@ -1,0 +1,14 @@
+@startuml relay
+!theme plain
+skinparam backgroundColor white
+skinparam state {
+  BackgroundColor #f8f8f8
+  BorderColor #888
+}
+
+title GeWire — Relay
+
+' === Cross-actor interactions ===
+
+
+@enduml

--- a/docs/gewire_transport.puml
+++ b/docs/gewire_transport.puml
@@ -1,0 +1,14 @@
+@startuml transport
+!theme plain
+skinparam backgroundColor white
+skinparam state {
+  BackgroundColor #f8f8f8
+  BorderColor #888
+}
+
+title GeWire — Transport
+
+' === Cross-actor interactions ===
+
+
+@enduml

--- a/formal/GeWire.tla
+++ b/formal/GeWire.tla
@@ -1,0 +1,74 @@
+---- MODULE GeWire ----
+\* Auto-generated from protocol YAML. Do not edit.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+\* States for server
+server_Idle == "server_Idle"
+
+\* States for player
+player_Idle == "player_Idle"
+
+\* States for ged
+ged_Idle == "ged_Idle"
+
+\* Message types
+MSG_device_info == "device_info"
+MSG_safe_area == "safe_area"
+MSG_sdl_event == "sdl_event"
+MSG_session_end == "session_end"
+MSG_server_assigned == "server_assigned"
+MSG_session_config == "session_config"
+MSG_sqlpipe_msg == "sqlpipe_msg"
+MSG_video_stream == "video_stream"
+MSG_stream_start == "stream_start"
+MSG_stream_stop == "stream_stop"
+MSG_aspect_lock == "aspect_lock"
+
+\* Event types
+EVT_connected == "connected"
+
+
+
+CONSTANTS server_state, player_state, ged_state
+
+VARIABLES
+
+vars == <<>>
+
+Init ==
+    /\ server_state = server_Idle
+    /\ player_state = player_Idle
+    /\ ged_state = ged_Idle
+
+\* server: Idle -> Idle (connected)
+server_Idle_to_Idle_connected ==
+    /\ server_state = server_Idle
+    /\ server_state' = server_Idle
+
+
+\* player: Idle -> Idle (connected)
+player_Idle_to_Idle_connected ==
+    /\ player_state = player_Idle
+    /\ player_state' = player_Idle
+
+
+\* ged: Idle -> Idle (connected)
+ged_Idle_to_Idle_connected ==
+    /\ ged_state = ged_Idle
+    /\ ged_state' = ged_Idle
+
+
+Next ==
+    \/ server_Idle_to_Idle_connected
+    \/ player_Idle_to_Idle_connected
+    \/ ged_Idle_to_Idle_connected
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+\* ================================================================
+\* Invariants and properties
+\* ================================================================
+
+
+====

--- a/include/ge/Protocol.h
+++ b/include/ge/Protocol.h
@@ -1,5 +1,15 @@
 #pragma once
 
+// TODO: 🎯T11.1.1 — replace hand-rolled constants and structs in this file
+// with generated bindings from protocol/ge_wire.yaml.
+// Generated outputs (DO NOT EDIT — regenerate via `make protogen`):
+//   C header:  include/ge/generated/gewire_gen.h
+//   C impl:    src/generated/gewire_gen.c
+//   Go:        protocol/gewire_gen.go
+//   Swift:     tools/ios/generated/GeWireMachine.swift
+//   Kotlin:    tools/android/generated/GeWireMachine.kt
+//   TypeScript: web/src/GeWireMachine.ts
+
 #include <SDL3/SDL_video.h>
 
 #include <bit>

--- a/include/ge/generated/gewire_gen.h
+++ b/include/ge/generated/gewire_gen.h
@@ -1,0 +1,115 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from protocol/*.yaml. DO NOT EDIT.
+
+#ifndef PIGEON_GEWIRE_GEN_H
+#define PIGEON_GEWIRE_GEN_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// GeWire server states.
+typedef enum {
+	PIGEON_SERVER_IDLE = 0,
+	PIGEON_SERVER_STATE_COUNT
+} pigeon_server_state;
+
+// GeWire player states.
+typedef enum {
+	PIGEON_PLAYER_IDLE = 0,
+	PIGEON_PLAYER_STATE_COUNT
+} pigeon_player_state;
+
+// GeWire ged states.
+typedef enum {
+	PIGEON_GED_IDLE = 0,
+	PIGEON_GED_STATE_COUNT
+} pigeon_ged_state;
+
+// GeWire message types.
+typedef enum {
+	PIGEON_MSG_DEVICE_INFO = 0,
+	PIGEON_MSG_SAFE_AREA,
+	PIGEON_MSG_SDL_EVENT,
+	PIGEON_MSG_SESSION_END,
+	PIGEON_MSG_SERVER_ASSIGNED,
+	PIGEON_MSG_SESSION_CONFIG,
+	PIGEON_MSG_SQLPIPE_MSG,
+	PIGEON_MSG_VIDEO_STREAM,
+	PIGEON_MSG_STREAM_START,
+	PIGEON_MSG_STREAM_STOP,
+	PIGEON_MSG_ASPECT_LOCK,
+	PIGEON_MSG_COUNT
+} ge_wire_msg_type;
+
+// GeWire events.
+typedef enum {
+	PIGEON_EVENT_CONNECTED = 0,
+	PIGEON_EVENT_COUNT
+} ge_wire_event_id;
+
+// Wire constants.
+#define PIGEON_WIRE_MAGIC_DEVICE_INFO 1195717188 // "GE2D" player→ged: player dimensions/class/safe area
+#define PIGEON_WIRE_MAGIC_SAFE_AREA 1195717189 // "GE2E" player→server: safe area update on orientation change
+#define PIGEON_WIRE_MAGIC_SDL_EVENT 1195717193 // "GE2I" player→server: SDL input event forwarding
+#define PIGEON_WIRE_MAGIC_SESSION_END 1195717197 // "GE2M" ged→player: server disconnected
+#define PIGEON_WIRE_MAGIC_SERVER_ASSIGNED 1195717198 // "GE2N" ged→player: assigned server name
+#define PIGEON_WIRE_MAGIC_SESSION_CONFIG 1195717187 // "GE2C" server→player: session requirements (sensors, orientation)
+#define PIGEON_WIRE_MAGIC_SQLPIPE_MSG 1195717204 // "GE2T" bidirectional sqlpipe messages
+#define PIGEON_WIRE_MAGIC_VIDEO_STREAM 1195717206 // "GE2V" server→ged: H.264 NAL units
+#define PIGEON_WIRE_MAGIC_STREAM_START 1195717207 // "GE2W" ged→player: start streaming
+#define PIGEON_WIRE_MAGIC_STREAM_STOP 1195717208 // "GE2X" ged→player: stop streaming
+#define PIGEON_WIRE_MAGIC_ASPECT_LOCK 1195717216 // "GE2`" server→player: lock window aspect ratio
+#define PIGEON_WIRE_PROTOCOL_VERSION 6 // wire protocol version; bump on breaking changes
+#define PIGEON_WIRE_MAX_MESSAGE_SIZE 536870912 // maximum single message size in bytes (512 MiB); matches ged/bridge.go
+#define PIGEON_WIRE_SENSOR_ACCELEROMETER 1 // bitmask: request accelerometer data from player
+#define PIGEON_WIRE_ORIENTATION_UNKNOWN 0 // SDL_ORIENTATION_UNKNOWN — no orientation preference
+#define PIGEON_WIRE_ORIENTATION_LANDSCAPE 1 // SDL_ORIENTATION_LANDSCAPE
+#define PIGEON_WIRE_ORIENTATION_LANDSCAPE_FLIPPED 2 // SDL_ORIENTATION_LANDSCAPE_FLIPPED
+#define PIGEON_WIRE_ORIENTATION_PORTRAIT 3 // SDL_ORIENTATION_PORTRAIT
+#define PIGEON_WIRE_ORIENTATION_PORTRAIT_FLIPPED 4 // SDL_ORIENTATION_PORTRAIT_FLIPPED
+#define PIGEON_WIRE_DEVICE_CLASS_UNKNOWN 0 // device class: unknown
+#define PIGEON_WIRE_DEVICE_CLASS_PHONE 1 // device class: phone
+#define PIGEON_WIRE_DEVICE_CLASS_TABLET 2 // device class: tablet
+#define PIGEON_WIRE_DEVICE_CLASS_DESKTOP 3 // device class: desktop
+
+// Guard and action callback types.
+typedef bool (*pigeon_guard_fn)(void *ctx);
+typedef int  (*pigeon_action_fn)(void *ctx);
+typedef void (*pigeon_change_fn)(const char *var_name, void *ctx);
+
+// GeWire server state machine.
+typedef struct {
+	pigeon_server_state state;
+	pigeon_change_fn on_change;
+	void *userdata;
+} pigeon_server_machine;
+
+void pigeon_server_machine_init(pigeon_server_machine *m);
+int  pigeon_server_handle_message(pigeon_server_machine *m, ge_wire_msg_type msg);
+int  pigeon_server_step(pigeon_server_machine *m, ge_wire_event_id event);
+
+// GeWire player state machine.
+typedef struct {
+	pigeon_player_state state;
+	pigeon_change_fn on_change;
+	void *userdata;
+} pigeon_player_machine;
+
+void pigeon_player_machine_init(pigeon_player_machine *m);
+int  pigeon_player_handle_message(pigeon_player_machine *m, ge_wire_msg_type msg);
+int  pigeon_player_step(pigeon_player_machine *m, ge_wire_event_id event);
+
+// GeWire ged state machine.
+typedef struct {
+	pigeon_ged_state state;
+	pigeon_change_fn on_change;
+	void *userdata;
+} pigeon_ged_machine;
+
+void pigeon_ged_machine_init(pigeon_ged_machine *m);
+int  pigeon_ged_handle_message(pigeon_ged_machine *m, ge_wire_msg_type msg);
+int  pigeon_ged_step(pigeon_ged_machine *m, ge_wire_event_id event);
+
+#endif // PIGEON_GEWIRE_GEN_H

--- a/protocol/ge_wire.yaml
+++ b/protocol/ge_wire.yaml
@@ -1,0 +1,249 @@
+# ge wire protocol declaration.
+#
+# H.264 streaming protocol between the game server, ged broker daemon, and
+# player. The server renders headless via bgfx, encodes H.264 frames, and
+# streams them to the player over a ged-brokered WebSocket. The player
+# decodes frames and forwards SDL input back to the server.
+#
+# Protocol version: 6 (wire constant protocol_version).
+#
+# NOTE: ge's wire protocol is NOT a state machine — it is a simple
+# message-passing channel brokered by ged. Actors (server, player, ged) are
+# declared here only because pigeon's Validate() requires message from/to
+# fields to reference valid actor names. Each actor has a single-state
+# trivial machine (Idle → Idle) rather than a real state machine.
+#
+# The primary value of this YAML is wire_constants: — all magic numbers,
+# version constants, size limits, and sensor/orientation values — and the
+# messages: declarations that document the channel topology.
+#
+# Source of truth for C types: include/ge/Protocol.h
+# TODO: 🎯T11.1.1 — replace Protocol.h consumers with generated bindings.
+
+name: GeWire
+
+# Protocol wire constants — emitted as typed constants in Go, Swift,
+# Kotlin, TypeScript, and C for every platform that participates in the
+# ge wire protocol.
+wire_constants:
+  # Message magic numbers (ASCII "GE2x") — identify each message type.
+  # All sent as the first uint32 of a wire message header.
+  - name: magic_device_info
+    value: 0x47453244
+    type: int
+    group: message_magic
+    desc: '"GE2D" player→ged: player dimensions/class/safe area'
+  - name: magic_safe_area
+    value: 0x47453245
+    type: int
+    group: message_magic
+    desc: '"GE2E" player→server: safe area update on orientation change'
+  - name: magic_sdl_event
+    value: 0x47453249
+    type: int
+    group: message_magic
+    desc: '"GE2I" player→server: SDL input event forwarding'
+  - name: magic_session_end
+    value: 0x4745324D
+    type: int
+    group: message_magic
+    desc: '"GE2M" ged→player: server disconnected'
+  - name: magic_server_assigned
+    value: 0x4745324E
+    type: int
+    group: message_magic
+    desc: '"GE2N" ged→player: assigned server name'
+  - name: magic_session_config
+    value: 0x47453243
+    type: int
+    group: message_magic
+    desc: '"GE2C" server→player: session requirements (sensors, orientation)'
+  - name: magic_sqlpipe_msg
+    value: 0x47453254
+    type: int
+    group: message_magic
+    desc: '"GE2T" bidirectional sqlpipe messages'
+  - name: magic_video_stream
+    value: 0x47453256
+    type: int
+    group: message_magic
+    desc: '"GE2V" server→ged: H.264 NAL units'
+  - name: magic_stream_start
+    value: 0x47453257
+    type: int
+    group: message_magic
+    desc: '"GE2W" ged→player: start streaming'
+  - name: magic_stream_stop
+    value: 0x47453258
+    type: int
+    group: message_magic
+    desc: '"GE2X" ged→player: stop streaming'
+  - name: magic_aspect_lock
+    value: 0x47453260
+    type: int
+    group: message_magic
+    desc: '"GE2`" server→player: lock window aspect ratio'
+
+  # Protocol framing constants.
+  - name: protocol_version
+    value: 6
+    type: int
+    group: framing
+    desc: 'wire protocol version; bump on breaking changes'
+  - name: max_message_size
+    value: 536870912
+    type: int
+    group: framing
+    desc: 'maximum single message size in bytes (512 MiB); matches ged/bridge.go'
+
+  # Sensor bitmask flags (used in SessionConfig.sensors field).
+  - name: sensor_accelerometer
+    value: 1
+    type: int
+    group: sensors
+    desc: 'bitmask: request accelerometer data from player'
+
+  # Orientation lock constants (SDL_DisplayOrientation values).
+  # Assigned from SDL_DisplayOrientation enum; 0 = no lock.
+  - name: orientation_unknown
+    value: 0
+    type: int
+    group: orientation
+    desc: 'SDL_ORIENTATION_UNKNOWN — no orientation preference'
+  - name: orientation_landscape
+    value: 1
+    type: int
+    group: orientation
+    desc: 'SDL_ORIENTATION_LANDSCAPE'
+  - name: orientation_landscape_flipped
+    value: 2
+    type: int
+    group: orientation
+    desc: 'SDL_ORIENTATION_LANDSCAPE_FLIPPED'
+  - name: orientation_portrait
+    value: 3
+    type: int
+    group: orientation
+    desc: 'SDL_ORIENTATION_PORTRAIT'
+  - name: orientation_portrait_flipped
+    value: 4
+    type: int
+    group: orientation
+    desc: 'SDL_ORIENTATION_PORTRAIT_FLIPPED'
+
+  # Device class values (used in DeviceInfo.deviceClass field).
+  - name: device_class_unknown
+    value: 0
+    type: int
+    group: device_class
+    desc: 'device class: unknown'
+  - name: device_class_phone
+    value: 1
+    type: int
+    group: device_class
+    desc: 'device class: phone'
+  - name: device_class_tablet
+    value: 2
+    type: int
+    group: device_class
+    desc: 'device class: tablet'
+  - name: device_class_desktop
+    value: 3
+    type: int
+    group: device_class
+    desc: 'device class: desktop'
+
+# Message declarations — document the wire channel topology.
+# Struct field layouts are specified in include/ge/Protocol.h and reproduced
+# in desc fields below until 🎯T11.1.1 migrates consumers to generated bindings.
+#
+# Framing: each message is sent as MessageHeader{magic, length} followed by
+# the payload. Streamed over a ged-brokered WebSocket.
+messages:
+  device_info:
+    from: player
+    to: ged
+    desc: >-
+      Player capabilities sent after connecting.
+      Fields: magic(u32)=magic_device_info, version(u16)=protocol_version,
+      width(u16), height(u16), pixelRatio(u16), deviceClass(u8)=device_class_*,
+      orientation(u8)=orientation_*, safeX(u16), safeY(u16), safeW(u16), safeH(u16).
+  safe_area:
+    from: player
+    to: server
+    desc: >-
+      Safe area update sent on orientation change.
+      Fields: magic(u32)=magic_safe_area, safeX(u16), safeY(u16), safeW(u16), safeH(u16).
+  sdl_event:
+    from: player
+    to: server
+    desc: >-
+      SDL input event forwarded from player.
+      Fields: magic(u32)=magic_sdl_event followed by raw SDL_Event struct bytes.
+  session_end:
+    from: ged
+    to: player
+    desc: >-
+      Server disconnected; player should retry.
+      Fields: magic(u32)=magic_session_end, length(u32)=0.
+  server_assigned:
+    from: ged
+    to: player
+    desc: >-
+      Assigned server name for this player session.
+      Fields: magic(u32)=magic_server_assigned, length(u32), name(utf8).
+  session_config:
+    from: server
+    to: player
+    desc: >-
+      Session requirements sent once after setup.
+      Fields: magic(u32)=magic_session_config, sensors(u8) bitmask using sensor_*
+      constants, orientation(u8) using orientation_* constants, _pad(2 bytes).
+  sqlpipe_msg:
+    from: server
+    to: player
+    desc: >-
+      Bidirectional sqlpipe database sync message.
+      Fields: magic(u32)=magic_sqlpipe_msg, length(u32), payload(bytes).
+  video_stream:
+    from: server
+    to: ged
+    desc: >-
+      H.264 encoded NAL units for one frame.
+      Fields: magic(u32)=magic_video_stream, length(u32), nal_data(bytes).
+  stream_start:
+    from: ged
+    to: player
+    desc: >-
+      Signal to player to begin receiving H.264 frames.
+      Fields: magic(u32)=magic_stream_start, length(u32)=0.
+  stream_stop:
+    from: ged
+    to: player
+    desc: >-
+      Signal to player to stop receiving frames (server gone).
+      Fields: magic(u32)=magic_stream_stop, length(u32)=0.
+  aspect_lock:
+    from: server
+    to: player
+    desc: >-
+      Lock window aspect ratio.
+      Fields: magic(u32)=magic_aspect_lock, ratio(f32) = width/height
+      (e.g. 0.6948 for 954x1373); send 0.0 to unlock.
+
+# Actors — declared so message from/to fields validate correctly.
+# ge's protocol has no meaningful state machine; these actors exist only
+# to satisfy pigeon's schema. Each has a trivial single-state machine.
+actors:
+  server:
+    initial: Idle
+    transitions:
+      - {from: Idle, to: Idle, on: connected}
+  player:
+    initial: Idle
+    transitions:
+      - {from: Idle, to: Idle, on: connected}
+  ged:
+    initial: Idle
+    transitions:
+      - {from: Idle, to: Idle, on: connected}

--- a/protocol/gewire_gen.go
+++ b/protocol/gewire_gen.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from protocol/*.yaml. DO NOT EDIT.
+
+package protocol
+
+// GeWire server states.
+const (
+	GeWireServerIdle State = "Idle"
+)
+
+// GeWire player states.
+const (
+	GeWirePlayerIdle State = "Idle"
+)
+
+// GeWire ged states.
+const (
+	GeWireGedIdle State = "Idle"
+)
+
+// GeWire message types.
+const (
+	GeWireMsgDeviceInfo MsgType = "device_info"
+	GeWireMsgSafeArea MsgType = "safe_area"
+	GeWireMsgSdlEvent MsgType = "sdl_event"
+	GeWireMsgSessionEnd MsgType = "session_end"
+	GeWireMsgServerAssigned MsgType = "server_assigned"
+	GeWireMsgSessionConfig MsgType = "session_config"
+	GeWireMsgSqlpipeMsg MsgType = "sqlpipe_msg"
+	GeWireMsgVideoStream MsgType = "video_stream"
+	GeWireMsgStreamStart MsgType = "stream_start"
+	GeWireMsgStreamStop MsgType = "stream_stop"
+	GeWireMsgAspectLock MsgType = "aspect_lock"
+)
+
+// GeWire guards.
+const (
+)
+
+// GeWire events.
+const (
+	GeWireEventConnected EventID = "connected"
+)
+
+// Wire constants — protocol-level values shared across all platforms.
+// MessageMagic
+const (
+	MagicDeviceInfo = 1195717188 // "GE2D" player→ged: player dimensions/class/safe area
+	MagicSafeArea = 1195717189 // "GE2E" player→server: safe area update on orientation change
+	MagicSdlEvent = 1195717193 // "GE2I" player→server: SDL input event forwarding
+	MagicSessionEnd = 1195717197 // "GE2M" ged→player: server disconnected
+	MagicServerAssigned = 1195717198 // "GE2N" ged→player: assigned server name
+	MagicSessionConfig = 1195717187 // "GE2C" server→player: session requirements (sensors, orientation)
+	MagicSqlpipeMsg = 1195717204 // "GE2T" bidirectional sqlpipe messages
+	MagicVideoStream = 1195717206 // "GE2V" server→ged: H.264 NAL units
+	MagicStreamStart = 1195717207 // "GE2W" ged→player: start streaming
+	MagicStreamStop = 1195717208 // "GE2X" ged→player: stop streaming
+	MagicAspectLock = 1195717216 // "GE2`" server→player: lock window aspect ratio
+)
+
+// Framing
+const (
+	ProtocolVersion = 6 // wire protocol version; bump on breaking changes
+	MaxMessageSize = 536870912 // maximum single message size in bytes (512 MiB); matches ged/bridge.go
+)
+
+// Sensors
+const (
+	SensorAccelerometer = 1 // bitmask: request accelerometer data from player
+)
+
+// Orientation
+const (
+	OrientationUnknown = 0 // SDL_ORIENTATION_UNKNOWN — no orientation preference
+	OrientationLandscape = 1 // SDL_ORIENTATION_LANDSCAPE
+	OrientationLandscapeFlipped = 2 // SDL_ORIENTATION_LANDSCAPE_FLIPPED
+	OrientationPortrait = 3 // SDL_ORIENTATION_PORTRAIT
+	OrientationPortraitFlipped = 4 // SDL_ORIENTATION_PORTRAIT_FLIPPED
+)
+
+// DeviceClass
+const (
+	DeviceClassUnknown = 0 // device class: unknown
+	DeviceClassPhone = 1 // device class: phone
+	DeviceClassTablet = 2 // device class: tablet
+	DeviceClassDesktop = 3 // device class: desktop
+)
+
+func GeWire() *Protocol {
+	return &Protocol{
+		Name: "GeWire",
+		Actors: []Actor{
+			{Name: "server", Initial: "Idle", Transitions: []Transition{
+				{From: "Idle", To: "Idle", On: Internal("connected")},
+			}},
+			{Name: "player", Initial: "Idle", Transitions: []Transition{
+				{From: "Idle", To: "Idle", On: Internal("connected")},
+			}},
+			{Name: "ged", Initial: "Idle", Transitions: []Transition{
+				{From: "Idle", To: "Idle", On: Internal("connected")},
+			}},
+		},
+		Messages: []Message{
+			{Type: "device_info", From: "player", To: "ged", Desc: "Player capabilities sent after connecting. Fields: magic(u32)=magic_device_info, version(u16)=protocol_version, width(u16), height(u16), pixelRatio(u16), deviceClass(u8)=device_class_*, orientation(u8)=orientation_*, safeX(u16), safeY(u16), safeW(u16), safeH(u16)."},
+			{Type: "safe_area", From: "player", To: "server", Desc: "Safe area update sent on orientation change. Fields: magic(u32)=magic_safe_area, safeX(u16), safeY(u16), safeW(u16), safeH(u16)."},
+			{Type: "sdl_event", From: "player", To: "server", Desc: "SDL input event forwarded from player. Fields: magic(u32)=magic_sdl_event followed by raw SDL_Event struct bytes."},
+			{Type: "session_end", From: "ged", To: "player", Desc: "Server disconnected; player should retry. Fields: magic(u32)=magic_session_end, length(u32)=0."},
+			{Type: "server_assigned", From: "ged", To: "player", Desc: "Assigned server name for this player session. Fields: magic(u32)=magic_server_assigned, length(u32), name(utf8)."},
+			{Type: "session_config", From: "server", To: "player", Desc: "Session requirements sent once after setup. Fields: magic(u32)=magic_session_config, sensors(u8) bitmask using sensor_* constants, orientation(u8) using orientation_* constants, _pad(2 bytes)."},
+			{Type: "sqlpipe_msg", From: "server", To: "player", Desc: "Bidirectional sqlpipe database sync message. Fields: magic(u32)=magic_sqlpipe_msg, length(u32), payload(bytes)."},
+			{Type: "video_stream", From: "server", To: "ged", Desc: "H.264 encoded NAL units for one frame. Fields: magic(u32)=magic_video_stream, length(u32), nal_data(bytes)."},
+			{Type: "stream_start", From: "ged", To: "player", Desc: "Signal to player to begin receiving H.264 frames. Fields: magic(u32)=magic_stream_start, length(u32)=0."},
+			{Type: "stream_stop", From: "ged", To: "player", Desc: "Signal to player to stop receiving frames (server gone). Fields: magic(u32)=magic_stream_stop, length(u32)=0."},
+			{Type: "aspect_lock", From: "server", To: "player", Desc: "Lock window aspect ratio. Fields: magic(u32)=magic_aspect_lock, ratio(f32) = width/height (e.g. 0.6948 for 954x1373); send 0.0 to unlock."},
+		},
+		Vars: []VarDef{
+		},
+		Guards: []GuardDef{
+		},
+		Operators: []Operator{
+		},
+		AdvActions: []AdvAction{
+		},
+		Properties: []Property{
+		},
+		ChannelBound: 0,
+		OneShot: false,
+	}
+}
+
+// GeWireServerMachine is the generated state machine for the server actor.
+type GeWireServerMachine struct {
+	State State
+
+	Guards  map[GuardID]func() bool
+	Actions map[ActionID]func() error
+	OnChange func(varName string)
+}
+
+func NewGeWireServerMachine() *GeWireServerMachine {
+	return &GeWireServerMachine{
+		State: GeWireServerIdle,
+		Guards:  make(map[GuardID]func() bool),
+		Actions: make(map[ActionID]func() error),
+	}
+}
+
+func (m *GeWireServerMachine) HandleMessage(msg MsgType) (bool, error) {
+	switch {
+	}
+	return false, nil
+}
+
+func (m *GeWireServerMachine) Step(event EventID) (bool, error) {
+	switch {
+	case m.State == GeWireServerIdle && event == GeWireEventConnected:
+		m.State = GeWireServerIdle
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *GeWireServerMachine) HandleEvent(ev EventID) ([]CmdID, error) {
+	switch {
+	case m.State == GeWireServerIdle && ev == GeWireEventConnected:
+		m.State = GeWireServerIdle
+		return nil, nil
+	}
+	return nil, nil
+}
+
+// GeWirePlayerMachine is the generated state machine for the player actor.
+type GeWirePlayerMachine struct {
+	State State
+
+	Guards  map[GuardID]func() bool
+	Actions map[ActionID]func() error
+	OnChange func(varName string)
+}
+
+func NewGeWirePlayerMachine() *GeWirePlayerMachine {
+	return &GeWirePlayerMachine{
+		State: GeWirePlayerIdle,
+		Guards:  make(map[GuardID]func() bool),
+		Actions: make(map[ActionID]func() error),
+	}
+}
+
+func (m *GeWirePlayerMachine) HandleMessage(msg MsgType) (bool, error) {
+	switch {
+	}
+	return false, nil
+}
+
+func (m *GeWirePlayerMachine) Step(event EventID) (bool, error) {
+	switch {
+	case m.State == GeWirePlayerIdle && event == GeWireEventConnected:
+		m.State = GeWirePlayerIdle
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *GeWirePlayerMachine) HandleEvent(ev EventID) ([]CmdID, error) {
+	switch {
+	case m.State == GeWirePlayerIdle && ev == GeWireEventConnected:
+		m.State = GeWirePlayerIdle
+		return nil, nil
+	}
+	return nil, nil
+}
+
+// GeWireGedMachine is the generated state machine for the ged actor.
+type GeWireGedMachine struct {
+	State State
+
+	Guards  map[GuardID]func() bool
+	Actions map[ActionID]func() error
+	OnChange func(varName string)
+}
+
+func NewGeWireGedMachine() *GeWireGedMachine {
+	return &GeWireGedMachine{
+		State: GeWireGedIdle,
+		Guards:  make(map[GuardID]func() bool),
+		Actions: make(map[ActionID]func() error),
+	}
+}
+
+func (m *GeWireGedMachine) HandleMessage(msg MsgType) (bool, error) {
+	switch {
+	}
+	return false, nil
+}
+
+func (m *GeWireGedMachine) Step(event EventID) (bool, error) {
+	switch {
+	case m.State == GeWireGedIdle && event == GeWireEventConnected:
+		m.State = GeWireGedIdle
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *GeWireGedMachine) HandleEvent(ev EventID) ([]CmdID, error) {
+	switch {
+	case m.State == GeWireGedIdle && ev == GeWireEventConnected:
+		m.State = GeWireGedIdle
+		return nil, nil
+	}
+	return nil, nil
+}
+

--- a/scripts/run-protogen.sh
+++ b/scripts/run-protogen.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Copyright 2026 Marcelo Cantos
+# SPDX-License-Identifier: Apache-2.0
+#
+# run-protogen.sh — generate wire protocol bindings from protocol/ge_wire.yaml.
+#
+# Runs pigeon-protogen in a temporary scratch directory so its hardwired output
+# paths (Sources/Pigeon/, android/pigeon/..., c/include/pigeon/, etc.) don't
+# pollute the ge repo layout. After generation, moves each output to the
+# ge-appropriate location:
+#
+#   protogen default path                         → ge destination
+#   ─────────────────────────────────────────────────────────────────────
+#   protocol/gewire_gen.go                        → protocol/gewire_gen.go
+#   Sources/Pigeon/GeWireMachine.swift            → tools/ios/generated/GeWireMachine.swift
+#   android/pigeon/.../GeWireMachine.kt           → tools/android/generated/GeWireMachine.kt
+#   web/src/GeWireMachine.ts                      → web/src/GeWireMachine.ts
+#   c/include/pigeon/gewire_gen.h                 → include/ge/generated/gewire_gen.h
+#   c/src/gewire_gen.c                            → src/generated/gewire_gen.c
+#   formal/GeWire.tla                             → formal/GeWire.tla
+#   docs/transport.puml                           → docs/gewire_transport.puml
+#   docs/relay.puml                               → docs/gewire_relay.puml
+#
+# Usage:
+#   scripts/run-protogen.sh          # regenerate from protocol/ge_wire.yaml
+#   PROTOGEN=/path/to/protogen scripts/run-protogen.sh   # override binary
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+YAML="$REPO_ROOT/protocol/ge_wire.yaml"
+
+# Locate protogen binary. Preference order:
+#   1. $PROTOGEN env var
+#   2. $GOPATH/bin/protogen (from: go install github.com/marcelocantos/pigeon/cmd/protogen@v0.20.0)
+#   3. $(go env GOPATH)/bin/protogen
+GOBIN="${GOPATH:-$(go env GOPATH)}/bin"
+PROTOGEN="${PROTOGEN:-${GOBIN}/protogen}"
+
+if [[ ! -x "$PROTOGEN" ]]; then
+  echo "protogen not found at $PROTOGEN" >&2
+  echo "Install with: GOBIN=$GOBIN go install github.com/marcelocantos/pigeon/cmd/protogen@v0.20.0" >&2
+  exit 1
+fi
+
+# Run in a temp scratch directory so protogen's default output paths don't land
+# directly in the repo.
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# protogen reads the YAML and writes relative to its working directory.
+cd "$SCRATCH"
+"$PROTOGEN" "$YAML"
+
+# Move generated files to ge-appropriate locations.
+install -Dm644 "$SCRATCH/protocol/gewire_gen.go"           "$REPO_ROOT/protocol/gewire_gen.go"
+install -Dm644 "$SCRATCH/Sources/Pigeon/GeWireMachine.swift" "$REPO_ROOT/tools/ios/generated/GeWireMachine.swift"
+install -Dm644 "$SCRATCH/android/pigeon/src/main/kotlin/com/marcelocantos/pigeon/crypto/GeWireMachine.kt" \
+               "$REPO_ROOT/tools/android/generated/GeWireMachine.kt"
+install -Dm644 "$SCRATCH/web/src/GeWireMachine.ts"          "$REPO_ROOT/web/src/GeWireMachine.ts"
+install -Dm644 "$SCRATCH/c/include/pigeon/gewire_gen.h"     "$REPO_ROOT/include/ge/generated/gewire_gen.h"
+install -Dm644 "$SCRATCH/c/src/gewire_gen.c"                "$REPO_ROOT/src/generated/gewire_gen.c"
+install -Dm644 "$SCRATCH/formal/GeWire.tla"                 "$REPO_ROOT/formal/GeWire.tla"
+install -Dm644 "$SCRATCH/docs/transport.puml"               "$REPO_ROOT/docs/gewire_transport.puml"
+install -Dm644 "$SCRATCH/docs/relay.puml"                   "$REPO_ROOT/docs/gewire_relay.puml"
+
+echo "protogen: generated bindings written to ge layout"

--- a/src/generated/gewire_gen.c
+++ b/src/generated/gewire_gen.c
@@ -1,0 +1,68 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from protocol/*.yaml. DO NOT EDIT.
+
+#include "gewire_gen.h"
+#include <string.h>
+
+void pigeon_server_machine_init(pigeon_server_machine *m)
+{
+	memset(m, 0, sizeof(*m));
+	m->state = PIGEON_SERVER_IDLE;
+}
+
+int pigeon_server_handle_message(pigeon_server_machine *m, ge_wire_msg_type msg)
+{
+	return 0;
+}
+
+int pigeon_server_step(pigeon_server_machine *m, ge_wire_event_id event)
+{
+	if (m->state == PIGEON_SERVER_IDLE && event == PIGEON_EVENT_CONNECTED) {
+		m->state = PIGEON_SERVER_IDLE;
+		return 1;
+	}
+	return 0;
+}
+
+void pigeon_player_machine_init(pigeon_player_machine *m)
+{
+	memset(m, 0, sizeof(*m));
+	m->state = PIGEON_PLAYER_IDLE;
+}
+
+int pigeon_player_handle_message(pigeon_player_machine *m, ge_wire_msg_type msg)
+{
+	return 0;
+}
+
+int pigeon_player_step(pigeon_player_machine *m, ge_wire_event_id event)
+{
+	if (m->state == PIGEON_PLAYER_IDLE && event == PIGEON_EVENT_CONNECTED) {
+		m->state = PIGEON_PLAYER_IDLE;
+		return 1;
+	}
+	return 0;
+}
+
+void pigeon_ged_machine_init(pigeon_ged_machine *m)
+{
+	memset(m, 0, sizeof(*m));
+	m->state = PIGEON_GED_IDLE;
+}
+
+int pigeon_ged_handle_message(pigeon_ged_machine *m, ge_wire_msg_type msg)
+{
+	return 0;
+}
+
+int pigeon_ged_step(pigeon_ged_machine *m, ge_wire_event_id event)
+{
+	if (m->state == PIGEON_GED_IDLE && event == PIGEON_EVENT_CONNECTED) {
+		m->state = PIGEON_GED_IDLE;
+		return 1;
+	}
+	return 0;
+}
+

--- a/tools/android/generated/GeWireMachine.kt
+++ b/tools/android/generated/GeWireMachine.kt
@@ -1,0 +1,184 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Auto-generated from protocol definition. Do not edit.
+// Source of truth: protocol/*.yaml
+
+package com.marcelocantos.pigeon.crypto
+
+enum class GeWireServerState(val value: String) {
+    Idle("Idle");
+}
+
+enum class GeWirePlayerState(val value: String) {
+    Idle("Idle");
+}
+
+enum class GeWireGedState(val value: String) {
+    Idle("Idle");
+}
+
+/** The protocol transition table and shared type enums. */
+object GeWireProtocol {
+
+    enum class MessageType(val value: String) {
+        DeviceInfo("device_info"),
+        SafeArea("safe_area"),
+        SdlEvent("sdl_event"),
+        SessionEnd("session_end"),
+        ServerAssigned("server_assigned"),
+        SessionConfig("session_config"),
+        SqlpipeMsg("sqlpipe_msg"),
+        VideoStream("video_stream"),
+        StreamStart("stream_start"),
+        StreamStop("stream_stop"),
+        AspectLock("aspect_lock");
+    }
+
+    enum class EventID(val value: String) {
+        Connected("connected");
+    }
+
+    /** Protocol wire constants shared across all platforms. */
+    object Wire {
+        const val MAGIC_DEVICE_INFO = 1195717188
+        const val MAGIC_SAFE_AREA = 1195717189
+        const val MAGIC_SDL_EVENT = 1195717193
+        const val MAGIC_SESSION_END = 1195717197
+        const val MAGIC_SERVER_ASSIGNED = 1195717198
+        const val MAGIC_SESSION_CONFIG = 1195717187
+        const val MAGIC_SQLPIPE_MSG = 1195717204
+        const val MAGIC_VIDEO_STREAM = 1195717206
+        const val MAGIC_STREAM_START = 1195717207
+        const val MAGIC_STREAM_STOP = 1195717208
+        const val MAGIC_ASPECT_LOCK = 1195717216
+        const val PROTOCOL_VERSION = 6
+        const val MAX_MESSAGE_SIZE = 536870912
+        const val SENSOR_ACCELEROMETER = 1
+        const val ORIENTATION_UNKNOWN = 0
+        const val ORIENTATION_LANDSCAPE = 1
+        const val ORIENTATION_LANDSCAPE_FLIPPED = 2
+        const val ORIENTATION_PORTRAIT = 3
+        const val ORIENTATION_PORTRAIT_FLIPPED = 4
+        const val DEVICE_CLASS_UNKNOWN = 0
+        const val DEVICE_CLASS_PHONE = 1
+        const val DEVICE_CLASS_TABLET = 2
+        const val DEVICE_CLASS_DESKTOP = 3
+    }
+
+    /** server transition table. */
+    object ServerTable {
+        val initial = GeWireServerState.Idle
+
+        data class Transition(
+            val from: String,
+            val to: String,
+            val on: String,
+            val onKind: String,
+            val guard: String? = null,
+            val action: String? = null,
+            val sends: List<Pair<String, String>> = emptyList(),
+        )
+
+        val transitions = listOf(
+            Transition("Idle", "Idle", "connected", "internal", null, null, emptyList()),
+        )
+    }
+
+    /** player transition table. */
+    object PlayerTable {
+        val initial = GeWirePlayerState.Idle
+
+        data class Transition(
+            val from: String,
+            val to: String,
+            val on: String,
+            val onKind: String,
+            val guard: String? = null,
+            val action: String? = null,
+            val sends: List<Pair<String, String>> = emptyList(),
+        )
+
+        val transitions = listOf(
+            Transition("Idle", "Idle", "connected", "internal", null, null, emptyList()),
+        )
+    }
+
+    /** ged transition table. */
+    object GedTable {
+        val initial = GeWireGedState.Idle
+
+        data class Transition(
+            val from: String,
+            val to: String,
+            val on: String,
+            val onKind: String,
+            val guard: String? = null,
+            val action: String? = null,
+            val sends: List<Pair<String, String>> = emptyList(),
+        )
+
+        val transitions = listOf(
+            Transition("Idle", "Idle", "connected", "internal", null, null, emptyList()),
+        )
+    }
+
+}
+
+/** GeWireServerMachine is the generated state machine for the server actor. */
+class GeWireServerMachine {
+    var state: GeWireServerState = GeWireServerState.Idle
+        private set
+
+    /** Handle an event and return the list of commands to execute. */
+    fun handleEvent(ev: GeWireProtocol.EventID): List<String> {
+        val cmds: List<String> = when {
+            state == GeWireServerState.Idle && ev == GeWireProtocol.EventID.Connected ->
+                run {
+                    state = GeWireServerState.Idle
+                    emptyList()
+                }
+            else -> emptyList()
+        }
+        return cmds
+    }
+}
+
+/** GeWirePlayerMachine is the generated state machine for the player actor. */
+class GeWirePlayerMachine {
+    var state: GeWirePlayerState = GeWirePlayerState.Idle
+        private set
+
+    /** Handle an event and return the list of commands to execute. */
+    fun handleEvent(ev: GeWireProtocol.EventID): List<String> {
+        val cmds: List<String> = when {
+            state == GeWirePlayerState.Idle && ev == GeWireProtocol.EventID.Connected ->
+                run {
+                    state = GeWirePlayerState.Idle
+                    emptyList()
+                }
+            else -> emptyList()
+        }
+        return cmds
+    }
+}
+
+/** GeWireGedMachine is the generated state machine for the ged actor. */
+class GeWireGedMachine {
+    var state: GeWireGedState = GeWireGedState.Idle
+        private set
+
+    /** Handle an event and return the list of commands to execute. */
+    fun handleEvent(ev: GeWireProtocol.EventID): List<String> {
+        val cmds: List<String> = when {
+            state == GeWireGedState.Idle && ev == GeWireProtocol.EventID.Connected ->
+                run {
+                    state = GeWireGedState.Idle
+                    emptyList()
+                }
+            else -> emptyList()
+        }
+        return cmds
+    }
+}
+

--- a/tools/ios/generated/GeWireMachine.swift
+++ b/tools/ios/generated/GeWireMachine.swift
@@ -1,0 +1,241 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Auto-generated from protocol definition. Do not edit.
+// Source of truth: protocol/*.yaml
+
+import Foundation
+
+public enum GeWireServerState: String, Sendable {
+    case idle = "Idle"
+}
+
+public enum GeWirePlayerState: String, Sendable {
+    case idle = "Idle"
+}
+
+public enum GeWireGedState: String, Sendable {
+    case idle = "Idle"
+}
+
+/// Protocol wire constants shared across all platforms.
+public enum GeWireWire {
+    public static let magicDeviceInfo = 1195717188
+    public static let magicSafeArea = 1195717189
+    public static let magicSdlEvent = 1195717193
+    public static let magicSessionEnd = 1195717197
+    public static let magicServerAssigned = 1195717198
+    public static let magicSessionConfig = 1195717187
+    public static let magicSqlpipeMsg = 1195717204
+    public static let magicVideoStream = 1195717206
+    public static let magicStreamStart = 1195717207
+    public static let magicStreamStop = 1195717208
+    public static let magicAspectLock = 1195717216
+    public static let protocolVersion = 6
+    public static let maxMessageSize = 536870912
+    public static let sensorAccelerometer = 1
+    public static let orientationUnknown = 0
+    public static let orientationLandscape = 1
+    public static let orientationLandscapeFlipped = 2
+    public static let orientationPortrait = 3
+    public static let orientationPortraitFlipped = 4
+    public static let deviceClassUnknown = 0
+    public static let deviceClassPhone = 1
+    public static let deviceClassTablet = 2
+    public static let deviceClassDesktop = 3
+}
+
+/// The protocol transition table and shared type enums.
+public enum GeWireProtocol {
+
+    public enum MessageType: String, Sendable {
+        case deviceInfo = "device_info"
+        case safeArea = "safe_area"
+        case sdlEvent = "sdl_event"
+        case sessionEnd = "session_end"
+        case serverAssigned = "server_assigned"
+        case sessionConfig = "session_config"
+        case sqlpipeMsg = "sqlpipe_msg"
+        case videoStream = "video_stream"
+        case streamStart = "stream_start"
+        case streamStop = "stream_stop"
+        case aspectLock = "aspect_lock"
+    }
+
+    public enum EventID: String, Sendable {
+        case connected = "connected"
+    }
+
+
+    /// server transitions.
+    public static let serverInitial: GeWireServerState = .idle
+
+    public static let serverTransitions: [(from: String, to: String, on: String, onKind: String, guard: String?, action: String?, sends: [(to: String, msg: String)])] = [
+        (from: "Idle", to: "Idle", on: "connected", onKind: "internal", guard: nil, action: nil, sends: []),
+    ]
+
+    /// player transitions.
+    public static let playerInitial: GeWirePlayerState = .idle
+
+    public static let playerTransitions: [(from: String, to: String, on: String, onKind: String, guard: String?, action: String?, sends: [(to: String, msg: String)])] = [
+        (from: "Idle", to: "Idle", on: "connected", onKind: "internal", guard: nil, action: nil, sends: []),
+    ]
+
+    /// ged transitions.
+    public static let gedInitial: GeWireGedState = .idle
+
+    public static let gedTransitions: [(from: String, to: String, on: String, onKind: String, guard: String?, action: String?, sends: [(to: String, msg: String)])] = [
+        (from: "Idle", to: "Idle", on: "connected", onKind: "internal", guard: nil, action: nil, sends: []),
+    ]
+}
+
+/// GeWireServerMachine is the generated state machine for the server actor.
+public final class GeWireServerMachine: @unchecked Sendable {
+    public typealias MessageType = GeWireProtocol.MessageType
+    public typealias GuardID = GeWireProtocol.GuardID
+    public typealias ActionID = GeWireProtocol.ActionID
+    public typealias EventID = GeWireProtocol.EventID
+
+    public private(set) var state: GeWireServerState
+
+    public var guards: [GuardID: () -> Bool] = [:]
+    public var actions: [ActionID: () throws -> Void] = [:]
+
+    public init() {
+        self.state = .idle
+    }
+
+    /// Handle any event (message receipt or internal). Returns emitted commands.
+    @discardableResult
+    public func handleEvent(_ ev: EventID) throws -> [String] {
+        switch (state, ev) {
+        case (.idle, .connected):
+            state = .idle
+            return []
+        default:
+            return []
+        }
+    }
+
+    /// Process a received message. Returns the new state, or nil if rejected.
+    @discardableResult
+    public func handleMessage(_ msg: MessageType) throws -> GeWireServerState? {
+        switch (state, msg) {
+        default:
+            return nil
+        }
+    }
+
+    /// Attempt an internal transition. Returns the new state, or nil if none available.
+    @discardableResult
+    public func step() throws -> GeWireServerState? {
+        switch state {
+        case .idle:
+            state = .idle
+            return state
+        default:
+            return nil
+        }
+    }
+}
+
+/// GeWirePlayerMachine is the generated state machine for the player actor.
+public final class GeWirePlayerMachine: @unchecked Sendable {
+    public typealias MessageType = GeWireProtocol.MessageType
+    public typealias GuardID = GeWireProtocol.GuardID
+    public typealias ActionID = GeWireProtocol.ActionID
+    public typealias EventID = GeWireProtocol.EventID
+
+    public private(set) var state: GeWirePlayerState
+
+    public var guards: [GuardID: () -> Bool] = [:]
+    public var actions: [ActionID: () throws -> Void] = [:]
+
+    public init() {
+        self.state = .idle
+    }
+
+    /// Handle any event (message receipt or internal). Returns emitted commands.
+    @discardableResult
+    public func handleEvent(_ ev: EventID) throws -> [String] {
+        switch (state, ev) {
+        case (.idle, .connected):
+            state = .idle
+            return []
+        default:
+            return []
+        }
+    }
+
+    /// Process a received message. Returns the new state, or nil if rejected.
+    @discardableResult
+    public func handleMessage(_ msg: MessageType) throws -> GeWirePlayerState? {
+        switch (state, msg) {
+        default:
+            return nil
+        }
+    }
+
+    /// Attempt an internal transition. Returns the new state, or nil if none available.
+    @discardableResult
+    public func step() throws -> GeWirePlayerState? {
+        switch state {
+        case .idle:
+            state = .idle
+            return state
+        default:
+            return nil
+        }
+    }
+}
+
+/// GeWireGedMachine is the generated state machine for the ged actor.
+public final class GeWireGedMachine: @unchecked Sendable {
+    public typealias MessageType = GeWireProtocol.MessageType
+    public typealias GuardID = GeWireProtocol.GuardID
+    public typealias ActionID = GeWireProtocol.ActionID
+    public typealias EventID = GeWireProtocol.EventID
+
+    public private(set) var state: GeWireGedState
+
+    public var guards: [GuardID: () -> Bool] = [:]
+    public var actions: [ActionID: () throws -> Void] = [:]
+
+    public init() {
+        self.state = .idle
+    }
+
+    /// Handle any event (message receipt or internal). Returns emitted commands.
+    @discardableResult
+    public func handleEvent(_ ev: EventID) throws -> [String] {
+        switch (state, ev) {
+        case (.idle, .connected):
+            state = .idle
+            return []
+        default:
+            return []
+        }
+    }
+
+    /// Process a received message. Returns the new state, or nil if rejected.
+    @discardableResult
+    public func handleMessage(_ msg: MessageType) throws -> GeWireGedState? {
+        switch (state, msg) {
+        default:
+            return nil
+        }
+    }
+
+    /// Attempt an internal transition. Returns the new state, or nil if none available.
+    @discardableResult
+    public func step() throws -> GeWireGedState? {
+        switch state {
+        case .idle:
+            state = .idle
+            return state
+        default:
+            return nil
+        }
+    }
+}
+

--- a/web/src/GeWireMachine.ts
+++ b/web/src/GeWireMachine.ts
@@ -1,0 +1,166 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Auto-generated from protocol definition. Do not edit.
+// Source of truth: protocol/*.yaml
+
+export enum GeWireServerState {
+    Idle = "Idle",
+}
+
+export enum GeWirePlayerState {
+    Idle = "Idle",
+}
+
+export enum GeWireGedState {
+    Idle = "Idle",
+}
+
+/** The protocol transition table and shared type enums. */
+export namespace GeWireProtocol {
+
+    export enum MessageType {
+        DeviceInfo = "device_info",
+        SafeArea = "safe_area",
+        SdlEvent = "sdl_event",
+        SessionEnd = "session_end",
+        ServerAssigned = "server_assigned",
+        SessionConfig = "session_config",
+        SqlpipeMsg = "sqlpipe_msg",
+        VideoStream = "video_stream",
+        StreamStart = "stream_start",
+        StreamStop = "stream_stop",
+        AspectLock = "aspect_lock",
+    }
+
+    export enum EventID {
+        Connected = "connected",
+    }
+
+    /** Protocol wire constants shared across all platforms. */
+    export const Wire = {
+        MAGIC_DEVICE_INFO: 1195717188,
+        MAGIC_SAFE_AREA: 1195717189,
+        MAGIC_SDL_EVENT: 1195717193,
+        MAGIC_SESSION_END: 1195717197,
+        MAGIC_SERVER_ASSIGNED: 1195717198,
+        MAGIC_SESSION_CONFIG: 1195717187,
+        MAGIC_SQLPIPE_MSG: 1195717204,
+        MAGIC_VIDEO_STREAM: 1195717206,
+        MAGIC_STREAM_START: 1195717207,
+        MAGIC_STREAM_STOP: 1195717208,
+        MAGIC_ASPECT_LOCK: 1195717216,
+        PROTOCOL_VERSION: 6,
+        MAX_MESSAGE_SIZE: 536870912,
+        SENSOR_ACCELEROMETER: 1,
+        ORIENTATION_UNKNOWN: 0,
+        ORIENTATION_LANDSCAPE: 1,
+        ORIENTATION_LANDSCAPE_FLIPPED: 2,
+        ORIENTATION_PORTRAIT: 3,
+        ORIENTATION_PORTRAIT_FLIPPED: 4,
+        DEVICE_CLASS_UNKNOWN: 0,
+        DEVICE_CLASS_PHONE: 1,
+        DEVICE_CLASS_TABLET: 2,
+        DEVICE_CLASS_DESKTOP: 3,
+    } as const;
+
+    export interface Transition {
+        readonly from: string;
+        readonly to: string;
+        readonly on: string;
+        readonly onKind: "recv" | "internal";
+        readonly guard?: string;
+        readonly action?: string;
+        readonly sends?: ReadonlyArray<{ readonly to: string; readonly msg: string }>;
+    }
+
+    export interface ActorTable {
+        readonly initial: string;
+        readonly transitions: ReadonlyArray<Transition>;
+    }
+
+    /** server transition table. */
+    export const serverTable: ActorTable = {
+        initial: GeWireServerState.Idle,
+        transitions: [
+            { from: "Idle", to: "Idle", on: "connected", onKind: "internal" },
+        ],
+    };
+
+    /** player transition table. */
+    export const playerTable: ActorTable = {
+        initial: GeWirePlayerState.Idle,
+        transitions: [
+            { from: "Idle", to: "Idle", on: "connected", onKind: "internal" },
+        ],
+    };
+
+    /** ged transition table. */
+    export const gedTable: ActorTable = {
+        initial: GeWireGedState.Idle,
+        transitions: [
+            { from: "Idle", to: "Idle", on: "connected", onKind: "internal" },
+        ],
+    };
+
+}
+
+/** GeWireServerMachine is the generated state machine for the server actor. */
+export class GeWireServerMachine {
+    readonly protocol = GeWireProtocol;
+    state: GeWireServerState;
+
+    constructor() {
+        this.state = GeWireServerState.Idle;
+    }
+
+    handleEvent(ev: GeWireProtocol.EventID): string[] {
+        switch (true) {
+            case this.state === GeWireServerState.Idle && ev === GeWireProtocol.EventID.Connected: {
+                this.state = GeWireServerState.Idle;
+                return [];
+            }
+        }
+        return [];
+    }
+}
+
+/** GeWirePlayerMachine is the generated state machine for the player actor. */
+export class GeWirePlayerMachine {
+    readonly protocol = GeWireProtocol;
+    state: GeWirePlayerState;
+
+    constructor() {
+        this.state = GeWirePlayerState.Idle;
+    }
+
+    handleEvent(ev: GeWireProtocol.EventID): string[] {
+        switch (true) {
+            case this.state === GeWirePlayerState.Idle && ev === GeWireProtocol.EventID.Connected: {
+                this.state = GeWirePlayerState.Idle;
+                return [];
+            }
+        }
+        return [];
+    }
+}
+
+/** GeWireGedMachine is the generated state machine for the ged actor. */
+export class GeWireGedMachine {
+    readonly protocol = GeWireProtocol;
+    state: GeWireGedState;
+
+    constructor() {
+        this.state = GeWireGedState.Idle;
+    }
+
+    handleEvent(ev: GeWireProtocol.EventID): string[] {
+        switch (true) {
+            case this.state === GeWireGedState.Idle && ev === GeWireProtocol.EventID.Connected: {
+                this.state = GeWireGedState.Idle;
+                return [];
+            }
+        }
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `protocol/ge_wire.yaml` as the new source of truth for ge's wire protocol — 11 message magic numbers, framing constants, sensor/orientation/device-class values, and message channel-topology declarations.
- Runs [pigeon protogen](https://github.com/marcelocantos/pigeon) to emit bindings for Go, Swift, Kotlin, TypeScript, C, TLA+, and PlantUML.
- Adds `make protogen` / `make protogen-check` targets so regeneration is a one-liner and CI can detect drift.
- **No existing consumers are changed** — Protocol.h's hand-rolled constants stay in place. This PR validates that protogen works for ge's protocol shape and establishes the YAML as the new source of truth.

## Output path decisions

Protogen writes to hardwired paths relative to CWD (designed for pigeon's own repo layout). `scripts/run-protogen.sh` runs protogen in a scratch dir and moves outputs to ge-appropriate locations:

| Generated file | ge location |
|---|---|
| `protocol/gewire_gen.go` | `protocol/gewire_gen.go` (future ged use; needs `--root-pkg=wire` for a standalone package) |
| `Sources/Pigeon/GeWireMachine.swift` | `tools/ios/generated/GeWireMachine.swift` |
| `android/pigeon/.../GeWireMachine.kt` | `tools/android/generated/GeWireMachine.kt` |
| `web/src/GeWireMachine.ts` | `web/src/GeWireMachine.ts` |
| `c/include/pigeon/gewire_gen.h` | `include/ge/generated/gewire_gen.h` |
| `c/src/gewire_gen.c` | `src/generated/gewire_gen.c` |
| `formal/GeWire.tla` | `formal/GeWire.tla` |
| `docs/transport.puml` | `docs/gewire_transport.puml` |
| `docs/relay.puml` | `docs/gewire_relay.puml` |

## Pigeon protogen quirks / schema gaps noted

1. **No typed wire struct support** — pigeon's message declarations have no field schema (only `from`, `to`, `desc`). The C structs (`DeviceInfo`, `SafeAreaUpdate`, `AspectLock`, `SessionConfig`, `MessageHeader`) are documented in `desc` fields for now. T11.1.1 will need to either extend pigeon's schema or keep struct definitions in Protocol.h and only generate constants.

2. **Actors required for messages** — `Validate()` requires message `from`/`to` to reference declared actor names, even when there's no real state machine. Three trivial actors (`server`, `player`, `ged`) are declared with single-state `Idle → Idle` machines. This is documented in the YAML header comment.

3. **Magic numbers as decimal in generated C** — pigeon emits `int` wire constants as `%d` not `0x%08X`. Values are numerically correct but less readable than the hex literals in Protocol.h. This is a protogen limitation.

4. **`protocol/gewire_gen.go` has `package protocol`** — it assumes it lives inside `github.com/marcelocantos/pigeon/protocol`. To use it in ged, T11.1.1 should run `protogen --root-pkg=wire` to emit a standalone `wire` package.

## New target

🎯T11.1.1 — consumer rewire + Protocol.h deletion (depends on T11.1).

## Test plan

- [ ] `scripts/run-protogen.sh` runs without error (requires `protogen` in `$PATH` or `$GOBIN`; install: `GOBIN=$HOME/go/bin go install github.com/marcelocantos/pigeon/cmd/protogen@v0.20.0`)
- [ ] `make protogen` regenerates all outputs idempotently
- [ ] `make protogen-check` passes after `make protogen`
- [ ] `ge/player` still builds (no C++ source changes)
- [ ] Protocol.h comment points at the correct generated file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)