### PR TITLE
ge: bake playerForceOrientation into libge so direct-mode apps link clean

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,18 @@ set(GE_DIRECT_RENDER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/render/DirectRenderHost.mm
 )
 
+# DirectRenderHost calls playerForceOrientation() in send(); the symbol
+# lives in tools/player_orientation_{ios,stub}.{mm,cpp}. iOS bundles want
+# the swizzle (Apple TN3192); every other platform takes the no-op stub.
+# Bundling either one into libge so consuming apps don't have to remember.
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    list(APPEND GE_DIRECT_RENDER_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tools/player_orientation_ios.mm)
+else()
+    list(APPEND GE_DIRECT_RENDER_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tools/player_orientation_stub.cpp)
+endif()
+
 if(GE_DIRECT)
     # Direct mode: app owns the frame loop; ge provides bgfx init,
     # DirectRenderHost, SDL context, font loader, and utilities.

--- a/Module.mk
+++ b/Module.mk
@@ -111,7 +111,8 @@ ge/SRC_DIRECT = \
 	$(ge)/src/BgfxContext.mm \
 	$(ge)/src/Signal.cpp \
 	$(ge)/src/SessionHost.mm \
-	$(ge)/src/render/DirectRenderHost.mm
+	$(ge)/src/render/DirectRenderHost.mm \
+	$(ge)/tools/player_orientation_stub.cpp
 
 ge/SRC_BROKERED = \
 	$(ge)/src/bridge/SessionHost_brokered.mm \
@@ -124,8 +125,10 @@ ge/SRC_BROKERED = \
 
 ge/SRC = $(ge/SRC_DIRECT) $(ge/SRC_BROKERED)
 
-ge/OBJ = $(patsubst $(ge)/src/%.cpp,$(BUILD_DIR)/ge/src/%.o,$(filter %.cpp,$(ge/SRC))) \
-         $(patsubst $(ge)/src/%.mm,$(BUILD_DIR)/ge/src/%.o,$(filter %.mm,$(ge/SRC)))
+ge/OBJ = $(patsubst $(ge)/src/%.cpp,$(BUILD_DIR)/ge/src/%.o,$(filter $(ge)/src/%.cpp,$(ge/SRC))) \
+         $(patsubst $(ge)/src/%.mm,$(BUILD_DIR)/ge/src/%.o,$(filter $(ge)/src/%.mm,$(ge/SRC))) \
+         $(patsubst $(ge)/tools/%.cpp,$(BUILD_DIR)/ge/tools/%.o,$(filter $(ge)/tools/%.cpp,$(ge/SRC))) \
+         $(patsubst $(ge)/tools/%.mm,$(BUILD_DIR)/ge/tools/%.o,$(filter $(ge)/tools/%.mm,$(ge/SRC)))
 ge/LIB = $(BUILD_DIR)/libge.a
 
 # Desktop player (H.264 receiver). Built on demand via `make player`.
@@ -288,6 +291,13 @@ $(BUILD_DIR)/ge/src/%.o: $(ge)/src/%.cpp
 
 # Engine + render + bridge objects (.mm)
 $(BUILD_DIR)/ge/src/%.o: $(ge)/src/%.mm
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(SDL_CFLAGS) -MMD -MP -c $< -o $@
+
+# tools/ objects (currently just player_orientation_stub.cpp — pulled into
+# libge.a so DirectRenderHost::send's playerForceOrientation() call resolves
+# without consuming desktop apps having to add the stub object themselves).
+$(BUILD_DIR)/ge/tools/%.o: $(ge)/tools/%.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(SDL_CFLAGS) -MMD -MP -c $< -o $@
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -910,6 +910,43 @@ targets:
     - showcase
     origin: manual
     discovered: 2026-04-26
+  T35:
+    name: ge has a single CMake-driven build path; Module.mk and the hand-rolled iOS template retire
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - Top-level `CMakeLists.txt` is the single source of truth for ge's source lists, compile flags, and link line
+    - '`Module.mk` is removed from the tree; README and CLAUDE.md no longer reference it'
+    - Sample apps (`sample/tiltbuggy`, `sample/tiltcal`) build via `cmake -B build && cmake --build build` (or a thin Makefile wrapper); their old hand-written Makefiles are gone or reduced to wrappers
+    - iOS template (`tools/ios-template/CMakeLists.txt.in`) consumes ge via `add_subdirectory(ge)` like the Android template, instead of listing GE_SOURCES directly
+    - An engine-side change that adds a new source file or compile flag requires editing exactly one place to land on macOS desktop + Android + iOS
+    - 'Direct-edit escape hatch documented in CLAUDE.md: how to invoke a one-off compile command, inspect generated build commands, add a non-CMake test target'
+    context: |-
+      ge currently maintains three different ways for apps to integrate the engine:
+
+      1. `Module.mk` — Makefile include, used by macOS/Linux desktop apps. Hand-listed source files, hand-written compile/link rules, hand-managed include flags.
+      2. `CMakeLists.txt` (top-level) — `add_subdirectory(ge)` integration, used by the Android template (post-T30.3 / PR #36). Same engine sources listed independently here.
+      3. `tools/ios-template/CMakeLists.txt.in` — hand-rolled iOS bundle build that lists ge sources directly without going through either path 1 or 2.
+
+      The same source-list information lives in three places. Drift between them has caused multiple bugs in v0.1.0 → v0.2.0:
+      - T30.x dual-shader compile rules required parallel updates in Module.mk, CMakeLists.txt, and the iOS template.
+      - The Android renderer flag changes (Vulkan + GLES, MULTITHREADED=0, GLESv2 → GLESv3) had to land in two separate CMake stanzas after the post-T30.3 restructure.
+      - v0.2.0 shipped with `playerForceOrientation` undefined in libge — DirectRenderHost::send calls it but the stub was missing from both Module.mk and the top-level CMake. Fixed in PR #49 for v0.3.0; required edits in both build paths.
+
+      Each engine-side change has a "did you remember to update all three?" tax that's already cost development time on multiple occasions.
+
+      Resolution: unify on CMake. Make ge's top-level `CMakeLists.txt` the single source of truth for sources, flags, and link line. Convert sample apps' Makefiles into thin CMake wrappers (or their own small CMakeLists.txt). Convert the iOS template from hand-rolled GE_SOURCES to `add_subdirectory(ge)` like the Android template. Retire `Module.mk`.
+
+      The user-side cost is small: each consuming game's Makefile becomes a 2-line wrapper around `cmake -B build && cmake --build build`, or a small CMakeLists.txt. The engine-side benefit is one canonical source list / flag list per platform-conditional section.
+
+      User reservations (acknowledged 2026-05-02): "I'm just uneasy about relinquishing control to a controlled build system. Plus, I haven't had particularly good experiences using CMake in the past, but if it's the path of least resistance, I'm okay with it." Adopt modern (3.20+) CMake idiom: target-based, no `file(GLOB)`, no `find_package` for vendored deps. Document escape hatches (direct compile commands, `cmake --build -v`).
+
+      Constraint that makes pure-Module.mk untenable: Android's Gradle requires CMake or ndk-build to drive the native build. There is no externalNativeBuild type for Make. ge would need at minimum a CMakeLists.txt shim invoked by Gradle even if Module.mk stayed authoritative — and that shim would have to duplicate the source list anyway. So the choice is "CMake everywhere as the canonical path" vs "Module.mk + a CMake shim that mirrors it" — the former is one source of truth, the latter is two.
+
+      Trigger for re-prioritising: each future bug caused by source-list drift is evidence the tax is biting. If a few weeks pass without drift causing a problem, defer further. The release skill's discover.sh and homebrew-tap status checks remain orthogonal.
+    origin: filed-during-v0.3.0-prep — surfaced repeatedly during v0.1.0 → v0.2.0 development as the same kind of bug kept hitting the same source-list-drift problem
+    discovered: 2026-05-02
   T4:
     name: playerLoop takes a config struct with named fields
     status: achieved


### PR DESCRIPTION
Bug shipped in v0.2.0: `DirectRenderHost::send` unconditionally calls `playerForceOrientation()`, but neither `libge.a` (Module.mk path) nor the CMake `ge` target included an implementation. Every desktop/Android consumer hits an undefined-symbol error and has to add the stub object manually:

```make
ORIENTATION_OBJ := $(BUILD_DIR)/ge/tools/player_orientation_stub.o
APP_LIBS        := $(ge/BOX2D_OBJ) $(ORIENTATION_OBJ)
```

That's an engine implementation detail leaking into every consumer. Fix in both build paths so apps don't have to know:

- **`Module.mk`**: `SRC_DIRECT` now includes `tools/player_orientation_stub.cpp`. Patsubst rules extended to handle `$(ge)/tools/%` paths and a compile rule for `$(BUILD_DIR)/ge/tools/%.o` was added.
- **`CMakeLists.txt`**: `GE_DIRECT_RENDER_SOURCES` picks `tools/player_orientation_ios.mm` on iOS and the stub everywhere else, so the CMake `ge` target is self-contained for `add_subdirectory(ge)` consumers (Android template, future iOS unification).

Verified: tiltbuggy desktop rebuilds with `player_orientation_stub.o` baked into `libge.a` and no consumer-side workaround needed. iOS apps using `tools/ios-template/CMakeLists.txt` already include the swizzle directly and bypass `libge`, so no duplicate-symbol risk on that path either.

Tag for v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
