### PR TITLE
ge: document iPad orientation lock + API caveat for v0.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,14 +326,23 @@ The Vite dev server proxies `/api`, `/ws`, and `/mcp` to ged at `localhost:42069
 
 ### iOS orientation lock (iPadOS 26+)
 
-**Do not edit `Info.plist` to lock orientation on iPad. It does not work.** iPadOS 26 ignores `UISupportedInterfaceOrientations`, `UIRequiresFullScreen`, `SDL_HINT_ORIENTATIONS`, and `requestGeometryUpdate` on iPad — every app is treated as resizable for multitasking. This has been tried and failed; see commit `e0da016` ("Revert Info.plist portrait-only experiment").
+**Locking iPad orientation is a TWO-knob setup, and you need both:**
 
-The **only** working mechanism is the swizzle in [`tools/player_orientation_ios.mm`](tools/player_orientation_ios.mm), which overrides `UIViewController.prefersInterfaceOrientationLocked` (Apple TN3192, the official replacement for `UIRequiresFullScreen`). Commit `5c2f2a5` introduced it; tested working on iPadOS 26.4.
+1. **`Info.plist` — `UISupportedInterfaceOrientations`** narrows the *set* iOS will rotate to at launch. Narrow this to the orientations you want allowed.
+2. **`SessionHostConfig.orientation` — non-zero** tells the engine to call `playerForceOrientation()`, which activates the `prefersInterfaceOrientationLocked` swizzle (Apple TN3192) and freezes the UI in whatever orientation iOS picked at launch.
 
-- **Player apps** get this for free — `wire::SessionConfig.orientation` from the server triggers `playerForceOrientation()` automatically.
-- **Direct-render apps** (`DirectRenderHost`-mode, e.g. TiltBuggy) must call `playerForceOrientation(wire::kOrientationLandscape)` themselves at startup, and link `tools/player_orientation_ios.mm` (or its stub on non-iOS) into the app bundle. `DirectRenderHost::applyHints` is the natural call site.
+`Info.plist` *alone* is **not** enough on iPadOS 26+ — the OS treats every iPad app as resizable under multitasking, so the swivel gesture would re-rotate you mid-play. The swizzle *alone* without a narrowed plist locks "whatever orientation the user happened to be holding the device in at launch," which is also rarely what you want. Ship both.
 
-If you find yourself editing `UISupportedInterfaceOrientations` to fix an orientation problem, stop and read this section again.
+This was the takeaway of a long debugging session in v0.1.0 (see commit `e0da016`, "Revert Info.plist portrait-only experiment", for the failed plist-only attempt; and `5c2f2a5` for the swizzle that completed the picture, tested on iPadOS 26.4). Things that *also* don't work alone and have all been tried: `UIRequiresFullScreen`, `SDL_HINT_ORIENTATIONS`, `requestGeometryUpdate`, `setNeedsUpdateOfSupportedInterfaceOrientations`. The full list is in the banner comment at the top of `tools/player_orientation_ios.mm`.
+
+**How games request the lock:**
+
+- **Direct-render apps** (`DirectRenderHost`-mode, e.g. TiltBuggy): set `SessionHostConfig.orientation = wire::kOrientationLandscape` (or any non-zero `wire::kOrientation*` constant). The engine calls `playerForceOrientation` from `DirectRenderHost::send` automatically. The orientation stub/swizzle is now linked into `libge` (v0.3.0+), so apps don't need to add anything to their build.
+- **Player apps** get this for free — `wire::SessionConfig.orientation` from the server triggers `playerForceOrientation()` over the wire.
+
+**API caveat (v0.3.0):** the `wire::kOrientation*` enum has four constants (Landscape, LandscapeFlipped, Portrait, PortraitFlipped) but `playerForceOrientation` currently treats the field as a **boolean** — any non-zero value enables the lock; the *specific* value is not honoured. The orientation that gets locked is whichever one iOS picked at launch, bounded by your `UISupportedInterfaceOrientations`. To force "specifically LandscapeLeft only," narrow the plist to `LandscapeLeft` only — don't rely on passing `kOrientationLandscape` vs `kOrientationLandscapeFlipped` to differentiate, because today they don't. 🎯T36 tracks aligning the API with its behaviour (either collapse to a boolean or make the constants authoritative).
+
+If you find yourself editing `UISupportedInterfaceOrientations` to fix an orientation problem, you're in the right place — but make sure you've also set `SessionHostConfig.orientation` non-zero, or the lock won't survive the iPad's swivel gesture.
 
 ## ged Features
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ include ge/Module.mk
 
 This exports variables (`ge/LIB`, `ge/OBJ`, `ge/FRAMEWORK_LIBS`, etc.) and pattern rules for compiling engine sources, test sources, and shaders. There is no standalone build.
 
+### iOS / iPad orientation lock
+
+iPadOS 26+ ignores the usual single-knob orientation locks (`UIRequiresFullScreen`, `SDL_HINT_ORIENTATIONS`, `requestGeometryUpdate`, even narrowing `UISupportedInterfaceOrientations` alone). To lock orientation on iPad you need **two things together**:
+
+1. Narrow `UISupportedInterfaceOrientations` in your `Info.plist` to the orientation(s) you want allowed (e.g. just `LandscapeLeft` and `LandscapeRight` for a landscape-only game).
+2. Set `SessionHostConfig.orientation = wire::kOrientationLandscape` (or any other non-zero `wire::kOrientation*`) when calling `ge::run`. The engine handles the swizzle (Apple TN3192 — `prefersInterfaceOrientationLocked`) for you, and the orientation source is linked into `libge` from v0.3.0+.
+
+Plist alone won't survive iPad multitasking; the swizzle alone locks "whatever orientation the user happened to be holding the device in at launch." Ship both. Setting different `kOrientation*` constants is currently a boolean ("lock yes/no"); the plist decides *which* orientation. See `agents-guide.md` and `CLAUDE.md` (search for "iOS orientation lock") for the full background and history.
+
 ## Structure
 
 ```

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -256,9 +256,22 @@ go there.
   (mobile-crashes guard, drawable-as-truth patch, shaderc CMake build). Don't rebase onto upstream
   without verifying all three patches still apply.
 
-- **Android uses Vulkan, not GLES.** The Apple EGL translator caps at GLES 3.0; requesting 3.1
-  triggers `EGL_BAD_CONFIG` → bgfx fatal on modern Adreno 830 AVDs. bgfx loads `libvulkan.so`
-  dynamically and builds its own swap-chain from the `ANativeWindow*`.
+- **Android dual-renderer: Vulkan on emulator, OpenGL ES 3.1 on real devices.** From v0.2.0,
+  bgfx compiles both backends and `BgfxContext.mm` runtime-selects via `ro.kernel.qemu` /
+  `ro.hardware`. Vulkan on the Apple-Silicon AVD (its EGL translator caps at GLES 3.0; a 3.1
+  request trips `EGL_BAD_CONFIG`); OpenGL ES on real Adreno/Mali devices (the Vulkan path
+  silently stalls after the first present — see `docs/papers/adreno-830-bgfx-vulkan-crash.md`).
+  Single-threaded mode (`BGFX_CONFIG_MULTITHREADED=0`) is non-negotiable on Android so the
+  swap-chain teardown on background can be gated by SDL3's `WINDOW_FOCUS_LOST` handler.
+
+- **iOS / iPad orientation lock needs BOTH `Info.plist` and `SessionHostConfig.orientation`.**
+  iPadOS 26+ ignores plist orientation alone (multitasking treats every iPad app as resizable).
+  Narrow `UISupportedInterfaceOrientations` *and* set `SessionHostConfig.orientation` non-zero
+  so the engine activates the `prefersInterfaceOrientationLocked` swizzle (Apple TN3192). The
+  swizzle's library file is bundled into `libge` from v0.3.0; consumers don't need to add it
+  to their build. The specific `wire::kOrientation*` value is currently a boolean
+  ("lock yes/no") — *which* orientation gets locked is the plist's job. See `CLAUDE.md`'s
+  "iOS orientation lock (iPadOS 26+)" section for the full background.
 
 - **`ged_addr` is consumed-once on Android.** Pass it via `--es ged_addr "host:port"` to
   `am start`. Subsequent launches without the flag fall through to QR scan. The matrix-cell harness

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -947,6 +947,52 @@ targets:
       Trigger for re-prioritising: each future bug caused by source-list drift is evidence the tax is biting. If a few weeks pass without drift causing a problem, defer further. The release skill's discover.sh and homebrew-tap status checks remain orthogonal.
     origin: filed-during-v0.3.0-prep — surfaced repeatedly during v0.1.0 → v0.2.0 development as the same kind of bug kept hitting the same source-list-drift problem
     discovered: 2026-05-02
+  T36:
+    name: SessionConfig.orientation API matches its behaviour — either authoritative per-orientation lock or a clean boolean
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'Either: SessionConfig.orientation is renamed/repurposed as a boolean (option 1), or: passing different kOrientation* constants produces different runtime behaviour (option 2)'
+    - The API surface in Protocol.h matches what the implementation does — no constant in the enum is silently equivalent to another
+    - TiltBuggy and any other consuming app declare their orientation intent in one place that's actually authoritative
+    - iOS direct-render apps work correctly when the user wants exactly one specific orientation that the plist alone can't enforce (e.g., 'LandscapeLeft only, even if device is held in LandscapeRight at launch')
+    - v0.4.0 docs (CLAUDE.md, README, agents-guide, Protocol.h comment) get updated again to drop the 'specific value reserved for future use' caveat once the API is honest
+    context: |-
+      The orientation-lock API surface is misleading as of v0.3.0:
+
+      The header in `include/ge/Protocol.h` defines four specific constants:
+
+          constexpr uint8_t kOrientationLandscape        = SDL_ORIENTATION_LANDSCAPE;
+          constexpr uint8_t kOrientationLandscapeFlipped = SDL_ORIENTATION_LANDSCAPE_FLIPPED;
+          constexpr uint8_t kOrientationPortrait         = SDL_ORIENTATION_PORTRAIT;
+          constexpr uint8_t kOrientationPortraitFlipped  = SDL_ORIENTATION_PORTRAIT_FLIPPED;
+
+      …suggesting per-orientation lock control. But `playerForceOrientation()` in `tools/player_orientation_ios.mm` only branches on 0-vs-non-0:
+
+          void playerForceOrientation(uint8_t orientation) {
+              if (orientation == 0) return;
+              g_orientationLocked = YES;
+              …
+          }
+
+      The actual orientation that gets locked is whatever iOS chose at launch, bounded by `UISupportedInterfaceOrientations` in `Info.plist` — never by the constant value. So `kOrientationLandscape` and `kOrientationLandscapeFlipped` are functionally identical inputs at runtime.
+
+      A game dev passing `wire::kOrientationLandscape` expecting "lock to LandscapeLeft regardless of how the user is holding the device" gets "lock to whatever iOS picked, which the plist's allowed set decides." That mismatch will cost time the next time someone integrates ge for a portrait-or-landscape-specific app.
+
+      Three design options were discussed (2026-05-02) and the user deferred to keep release momentum, choosing to ship v0.4.0 as a doc-only update describing current behaviour:
+
+      1. **Collapse to boolean.** Rename `SessionConfig.orientation` → `SessionConfig.lockOrientation` (bool). Plist owns the "which orientation" axis. Honest, simple. Loses the option to add per-orientation lock without an API break.
+
+      2. **Make the constant authoritative.** When the engine sees `kOrientationLandscape`, it programmatically narrows `supportedInterfaceOrientations` to `{LandscapeLeft, LandscapeRight}` via swizzling that property too, regardless of Info.plist. Plist becomes the *fallback*. Fully expressive; adds a runtime override of a launch-time decision.
+
+      3. **Document and live with it.** Currently shipped path (v0.4.0).
+
+      The trigger for picking between #1 and #2: a game wants per-orientation-only lock that the plist alone can't easily express (e.g., "lock to LandscapeLeft, never LandscapeRight, never adapt to device flip mid-play"). At that point, #2 is the right choice. Until then, #1 is honesty.
+
+      Constraint to remember: the only iPad orientation-lock mechanism that survives iPadOS 26 multitasking is the `prefersInterfaceOrientationLocked` swizzle (Apple TN3192). Both options have to keep using it; only the input shape changes.
+    origin: filed-during-v0.4.0-prep — surfaced when user asked 'do we allow setting any landscape or a specific landscape or both?' and the honest answer was 'the API suggests per-orientation control but the implementation treats the field as a boolean'
+    discovered: 2026-05-02
   T4:
     name: playerLoop takes a config struct with named fields
     status: achieved

--- a/include/ge/Protocol.h
+++ b/include/ge/Protocol.h
@@ -75,6 +75,24 @@ struct SessionConfig {
 constexpr uint8_t kSensorAccelerometer = 1;
 
 // Orientation constants — assigned from SDL_DisplayOrientation.
+//
+// CAVEAT (v0.3.0): playerForceOrientation() treats this field as a
+// boolean — any non-zero value enables the iPad orientation lock; the
+// SPECIFIC constant is not honoured at runtime. The orientation that
+// gets locked is whichever one iOS picked at launch, constrained by
+// the app bundle's UISupportedInterfaceOrientations in Info.plist.
+//
+// To force a specific orientation, narrow the plist:
+//   * "any landscape"   → LandscapeLeft + LandscapeRight
+//   * "LandscapeLeft only" → LandscapeLeft
+//   * "portrait only"   → Portrait + PortraitUpsideDown (or just Portrait)
+//
+// Setting kOrientationLandscape vs kOrientationLandscapeFlipped today
+// is a no-op difference; both are simply "non-zero, lock please."
+//
+// 🎯T36 tracks aligning the API with its behaviour (either collapse to
+// a boolean field, or make these constants authoritative by having the
+// engine narrow supportedInterfaceOrientations at runtime).
 constexpr uint8_t kOrientationLandscape        = SDL_ORIENTATION_LANDSCAPE;
 constexpr uint8_t kOrientationLandscapeFlipped = SDL_ORIENTATION_LANDSCAPE_FLIPPED;
 constexpr uint8_t kOrientationPortrait         = SDL_ORIENTATION_PORTRAIT;


### PR DESCRIPTION
Doc-only release for v0.4.0. Two gaps filled:

1. **iPad orientation lock setup is now visible across all canonical surfaces.** Previously only `CLAUDE.md` had it, and the section had two stale references (a removed `applyHints` call site, and a now-obsolete instruction to call `playerForceOrientation` directly from the app). The README and `agents-guide.md` had nothing — a new game integrator reading either would not know about the iPad trap until they hit it. Locking iPad orientation needs **both** Info.plist narrowing **and** `SessionHostConfig.orientation` non-zero; either alone is insufficient under iPadOS 26+.

2. **`wire::kOrientation*` API caveat documented.** The enum looks like four-way per-orientation control but the runtime treats the field as boolean — any non-zero value enables the lock; *which* orientation gets locked is plist-driven. Setting `kOrientationLandscape` vs `kOrientationLandscapeFlipped` is currently a no-op difference. Surface this honestly in the header and CLAUDE.md so consumers don't write code that depends on the distinction. 🎯T36 (filed) tracks aligning the API with its behaviour.

## Files

- `CLAUDE.md` — rewrote the "iOS orientation lock (iPadOS 26+)" section.
- `README.md` — new "iOS / iPad orientation lock" subsection under Integration.
- `agents-guide.md` — refreshed the stale "Android uses Vulkan, not GLES" gotcha (v0.2.0 dual-renderer changed the picture) and added a new orientation-lock gotcha.
- `include/ge/Protocol.h` — comment block on the `kOrientation*` constants explaining the boolean-ish behaviour and the 🎯T36 plan.

No source-level changes; ge runtime behaviour unchanged from v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
