### PR TITLE
ge: 🎯T27 — cut per-cell soak to 10s, add cell.long-soak for 60s sweep

### DIFF
--- a/Module.mk
+++ b/Module.mk
@@ -783,6 +783,21 @@ ge/android-release: $(ge/APP_SHADERS_SPIRV) $(ge/RENDER_SHADERS_SPIRV) $(ge/APP_
 #
 # Glob syntax: `*` matches any run of characters within a cell name.
 # Multiple patterns: space-separated.
+#
+# Soak timing:
+#   Standard cells run a 10s soak (SOAK_TIMEOUT=10). This keeps `make -j check`
+#   well under 8 minutes on M4 Max with primed caches. To run with the full 60s
+#   soak across all cells: `make check SOAK_TIMEOUT=60`.
+#
+#   For the dedicated long-soak reliability sweep (always 60s, no override
+#   needed): `make cell.long-soak`.
+#
+# Parallelism:
+#   `make -j check` runs all cells concurrently. Cells targeting different
+#   devices run in parallel. Cells racing for the same device serialise via
+#   spyder's reservation queue. Desktop cells are always concurrent.
+#   Same-platform cells (e.g. ios-sim-tablet-dist + ios-sim-tablet-player)
+#   resolve to distinct sims when two are available in the spyder pool.
 
 # Device pin variables — passed to matrix-cell.sh to target a specific inventory
 # alias or UDID for each device class.  When set, the cell skips spyder reserve
@@ -800,6 +815,13 @@ GE_IOS_PHONE_DEVICE   ?=
 GE_IOS_TABLET_DEVICE  ?= Pippa
 GE_ANDROID_PHONE_DEVICE  ?=
 GE_ANDROID_TABLET_DEVICE ?=
+
+# Soak timeout for standard cells (seconds). Default 10s — fast enough for
+# `make -j check` to finish well under 8 min. Override on the command line:
+#   make check SOAK_TIMEOUT=60       # run all cells with the full 60s soak
+# For a single long-soak sweep at 60s against the representative desktop cell,
+# use the dedicated `make cell.long-soak` target.
+SOAK_TIMEOUT ?= 10
 
 # Canonical 24-cell list. Cells are grouped for readability.
 ge/CELLS := \
@@ -833,30 +855,37 @@ ge/CHECK_CELLS := $(filter-out $(ge/CHECK_EXCLUDE_PATTERNS),$(ge/CELLS))
 # Cells targeting different devices run concurrently under parallel make.
 # Cells racing for the same device serialise via spyder's reservation queue.
 .PHONY: $(addprefix cell.,$(ge/CELLS))
-cell.desktop-dist:               ; $(ge)/tools/matrix-cell.sh desktop-dist
-cell.desktop-player:             ; $(ge)/tools/matrix-cell.sh desktop-player
-cell.ios-sim-phone-dist:         ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-phone-dist
-cell.ios-sim-phone-player:       ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-phone-player
-cell.ios-sim-tablet-dist:        ; GE_IOS_SIM_TABLET_DEVICE=$(GE_IOS_SIM_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-tablet-dist
-cell.ios-sim-tablet-player:      ; GE_IOS_SIM_TABLET_DEVICE=$(GE_IOS_SIM_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-tablet-player
-cell.ios-device-phone-dist:      ; GE_IOS_PHONE_DEVICE=$(GE_IOS_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-phone-dist
-cell.ios-device-phone-player:    ; GE_IOS_PHONE_DEVICE=$(GE_IOS_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-phone-player
-cell.ios-device-tablet-dist:     ; GE_IOS_TABLET_DEVICE=$(GE_IOS_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-tablet-dist
-cell.ios-device-tablet-player:   ; GE_IOS_TABLET_DEVICE=$(GE_IOS_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-tablet-player
-cell.android-emu-phone-dist:     ; GE_ANDROID_EMU_PHONE_DEVICE=$(GE_ANDROID_EMU_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-phone-dist
-cell.android-emu-phone-player:   ; GE_ANDROID_EMU_PHONE_DEVICE=$(GE_ANDROID_EMU_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-phone-player
-cell.android-emu-tablet-dist:    ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-tablet-dist
-cell.android-emu-tablet-player:  ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-tablet-player
-cell.android-device-phone-dist:  ; GE_ANDROID_PHONE_DEVICE=$(GE_ANDROID_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-device-phone-dist
-cell.android-device-phone-player: ; GE_ANDROID_PHONE_DEVICE=$(GE_ANDROID_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-device-phone-player
-cell.android-device-tablet-dist: ; GE_ANDROID_TABLET_DEVICE=$(GE_ANDROID_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-device-tablet-dist
-cell.android-device-tablet-player: ; GE_ANDROID_TABLET_DEVICE=$(GE_ANDROID_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-device-tablet-player
-cell.desktop-debug-dist:         ; $(ge)/tools/matrix-cell.sh desktop-debug-dist
-cell.desktop-debug-player:       ; $(ge)/tools/matrix-cell.sh desktop-debug-player
-cell.ios-debug-dist:             ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-debug-dist
-cell.ios-debug-player:           ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-debug-player
-cell.android-debug-dist:         ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-debug-dist
-cell.android-debug-player:       ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-debug-player
+cell.desktop-dist:               ; $(ge)/tools/matrix-cell.sh desktop-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.desktop-player:             ; $(ge)/tools/matrix-cell.sh desktop-player --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-sim-phone-dist:         ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-phone-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-sim-phone-player:       ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-phone-player --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-sim-tablet-dist:        ; GE_IOS_SIM_TABLET_DEVICE=$(GE_IOS_SIM_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-tablet-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-sim-tablet-player:      ; GE_IOS_SIM_TABLET_DEVICE=$(GE_IOS_SIM_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-sim-tablet-player --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-device-phone-dist:      ; GE_IOS_PHONE_DEVICE=$(GE_IOS_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-phone-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-device-phone-player:    ; GE_IOS_PHONE_DEVICE=$(GE_IOS_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-phone-player --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-device-tablet-dist:     ; GE_IOS_TABLET_DEVICE=$(GE_IOS_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-tablet-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-device-tablet-player:   ; GE_IOS_TABLET_DEVICE=$(GE_IOS_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh ios-device-tablet-player --soak-timeout $(SOAK_TIMEOUT)
+cell.android-emu-phone-dist:     ; GE_ANDROID_EMU_PHONE_DEVICE=$(GE_ANDROID_EMU_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-phone-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.android-emu-phone-player:   ; GE_ANDROID_EMU_PHONE_DEVICE=$(GE_ANDROID_EMU_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-phone-player --soak-timeout $(SOAK_TIMEOUT)
+cell.android-emu-tablet-dist:    ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-tablet-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.android-emu-tablet-player:  ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-emu-tablet-player --soak-timeout $(SOAK_TIMEOUT)
+cell.android-device-phone-dist:  ; GE_ANDROID_PHONE_DEVICE=$(GE_ANDROID_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-device-phone-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.android-device-phone-player: ; GE_ANDROID_PHONE_DEVICE=$(GE_ANDROID_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh android-device-phone-player --soak-timeout $(SOAK_TIMEOUT)
+cell.android-device-tablet-dist: ; GE_ANDROID_TABLET_DEVICE=$(GE_ANDROID_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-device-tablet-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.android-device-tablet-player: ; GE_ANDROID_TABLET_DEVICE=$(GE_ANDROID_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-device-tablet-player --soak-timeout $(SOAK_TIMEOUT)
+cell.desktop-debug-dist:         ; $(ge)/tools/matrix-cell.sh desktop-debug-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.desktop-debug-player:       ; $(ge)/tools/matrix-cell.sh desktop-debug-player --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-debug-dist:             ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-debug-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.ios-debug-player:           ; GE_IOS_SIM_PHONE_DEVICE=$(GE_IOS_SIM_PHONE_DEVICE) $(ge)/tools/matrix-cell.sh ios-debug-player --soak-timeout $(SOAK_TIMEOUT)
+cell.android-debug-dist:         ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-debug-dist --soak-timeout $(SOAK_TIMEOUT)
+cell.android-debug-player:       ; GE_ANDROID_EMU_TABLET_DEVICE=$(GE_ANDROID_EMU_TABLET_DEVICE) $(ge)/tools/matrix-cell.sh android-debug-player --soak-timeout $(SOAK_TIMEOUT)
+
+# Long-soak cell: runs the desktop-dist cell with a 60s soak.
+# This is the dedicated reliability sweep preserved so the standard 10s cells
+# don't regress into missing crash-over-time failures. Run independently:
+#   make cell.long-soak
+.PHONY: cell.long-soak
+cell.long-soak: ; $(ge)/tools/matrix-cell.sh desktop-dist --soak-timeout 60
 
 .PHONY: check matrix-test
 check matrix-test: $(addprefix cell.,$(ge/CHECK_CELLS))
@@ -873,6 +902,8 @@ check-list:
 	@printf '  %s\n' $(ge/CHECK_CELLS)
 	@echo "Cells excluded:"
 	@printf '  %s\n' $(filter-out $(ge/CHECK_CELLS),$(ge/CELLS))
+	@echo "Soak timeout: $(SOAK_TIMEOUT)s  (override with SOAK_TIMEOUT=N)"
+	@echo "Long-soak cell: 'make cell.long-soak'  (always 60s, desktop-dist)"
 
 # ────────────────────────────────────────────────
 # Spyder pool management

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -19,17 +19,19 @@
 #   <cell-name>       One of the 24 canonical cell names (see list below).
 #
 # Options:
-#   --app <dir>       App root dir (default: current dir).
-#   --timeout <s>     Sub-check timeout override.
-#                     Defaults: cold-launch=8s, soak=60s, debug-soak=10s.
-#   --capture-refs    Record reference screenshots instead of comparing.
-#   --rms <f>         Image-diff RMS threshold (default 0.08).
-#   --verbose         Echo sub-command output.
-#   --device <alias>  Pin a specific device alias (skip spyder reserve --on).
-#                     Normally passed internally by the self-wrap; callers can
-#                     also use it to target a known inventory alias directly.
-#   --skip-spyder-run Internal flag. Means this invocation is already running
-#                     inside a `spyder run` wrapper — skip the self-wrap.
+#   --app <dir>           App root dir (default: current dir).
+#   --timeout <s>         Cold-launch timeout override (default 8s).
+#   --soak-timeout <s>    Soak phase duration override (default 10s; use 60 for
+#                         the long-soak cell).  Debug cells always use 10s
+#                         regardless of this value.
+#   --capture-refs        Record reference screenshots instead of comparing.
+#   --rms <f>             Image-diff RMS threshold (default 0.08).
+#   --verbose             Echo sub-command output.
+#   --device <alias>      Pin a specific device alias (skip spyder reserve --on).
+#                         Normally passed internally by the self-wrap; callers can
+#                         also use it to target a known inventory alias directly.
+#   --skip-spyder-run     Internal flag. Means this invocation is already running
+#                         inside a `spyder run` wrapper — skip the self-wrap.
 #
 # Canonical cell names:
 #   desktop-dist  desktop-player
@@ -100,7 +102,7 @@ fi
 CELL=""
 APP_DIR="$(pwd)"
 COLD_LAUNCH_TIMEOUT=8
-SOAK_TIMEOUT=60
+SOAK_TIMEOUT=10
 DEBUG_SOAK_TIMEOUT=10
 CAPTURE_REFS=0
 RMS=0.08
@@ -124,7 +126,8 @@ CELL="$1"; shift
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --app)             APP_DIR="$(cd "$2" && pwd)"; shift 2 ;;
-        --timeout)         COLD_LAUNCH_TIMEOUT="$2"; SOAK_TIMEOUT="$2"; shift 2 ;;
+        --timeout)         COLD_LAUNCH_TIMEOUT="$2"; shift 2 ;;
+        --soak-timeout)    SOAK_TIMEOUT="$2"; shift 2 ;;
         --capture-refs)    CAPTURE_REFS=1; shift ;;
         --rms)             RMS="$2"; shift 2 ;;
         --verbose)         VERBOSE=1; shift ;;
@@ -343,6 +346,7 @@ resolve_and_wrap() {
     retry_spyder_run "$alias" "$owner" "$0" "$CELL" \
         --app "$APP_DIR" \
         --timeout "$COLD_LAUNCH_TIMEOUT" \
+        --soak-timeout "$SOAK_TIMEOUT" \
         --rms "$RMS" \
         --device "$alias" \
         --skip-spyder-run \
@@ -367,6 +371,7 @@ if [[ $NEEDS_DEVICE -eq 1 && $SKIP_SPYDER_RUN -eq 0 ]]; then
         retry_spyder_run "$resolved_alias" "$owner" "$0" "$CELL" \
             --app "$APP_DIR" \
             --timeout "$COLD_LAUNCH_TIMEOUT" \
+            --soak-timeout "$SOAK_TIMEOUT" \
             --rms "$RMS" \
             --device "$resolved_alias" \
             --skip-spyder-run \


### PR DESCRIPTION
## Summary

- **Soak timeout cut from 60s → 10s** for all standard cells. New `SOAK_TIMEOUT ?= 10` variable in Module.mk is passed as `--soak-timeout` to every `cell.*` rule.
- **`cell.long-soak` target** runs `desktop-dist` with a hardcoded 60s soak — the dedicated reliability sweep that keeps the long-soak coverage alive.
- **`--soak-timeout` flag** added to `matrix-cell.sh`, split from `--timeout` (cold-launch). Both self-wrap paths (pinned-alias and selector-dispatch) forward it to the inner execution.

## Timing

| | Before | After (estimated) |
|--|--|--|
| Soak budget per cell | 60 s | 10 s |
| Serial soak total (22 cells) | 1,320 s | 220 s |
| Wall-clock (`make -j check`, primed caches) | 10–20 min | ~3–5 min |

The 8-minute target should be comfortably met. Full timing to be confirmed in the user's environment.

## Escape hatches

```bash
# Full 60s soak across all cells:
make check SOAK_TIMEOUT=60

# Single dedicated 60s reliability sweep:
make cell.long-soak
```

## Parallelism note

Same-platform cells (e.g. `ios-sim-tablet-dist` + `ios-sim-tablet-player`) already resolve to distinct sims when two are available via spyder selector dispatch. No device-selection changes were needed — the pool handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)