### PR TITLE
ge: 🎯T28.3 — AccelSynth autodrive + ios-sim-tablet-dist accelsynth check

### DIFF
--- a/src/render/AccelSynth.h
+++ b/src/render/AccelSynth.h
@@ -20,6 +20,15 @@
 // in the screen plane. One rotation about one axis — no gimballing.
 // No cap on displacement: let the user "flip the device upside down"
 // if they want, with the physics following sin(angle) naturally.
+//
+// GE_ACCELSYNTH_AUTODRIVE (iOS Simulator only):
+// When this environment variable is set to "1", update() drives a
+// synthetic 100-pixel X-axis tilt for the first 2 seconds, then
+// releases into easing. This lets the matrix cell (ios-sim-tablet-dist)
+// assert the AccelSynth path produces non-zero sensor output without
+// requiring any mouse input — simctl cannot inject GCKeyboard Shift events.
+// This path is compiled and active ONLY on TARGET_OS_SIMULATOR; it is
+// unreachable on real devices.
 #pragma once
 
 #include <SDL3/SDL.h>
@@ -30,6 +39,7 @@
 #endif
 
 #include <cmath>
+#include <cstdlib>
 #include <functional>
 
 namespace ge {
@@ -110,7 +120,41 @@ public:
     // Called once per frame by the host. Drives tilt easing back to
     // zero after Shift is released. No-op while Shift is held or after the
     // tilt has fully decayed.
+    //
+    // On TARGET_OS_SIMULATOR with GE_ACCELSYNTH_AUTODRIVE=1: drives a
+    // synthetic 100-pixel X tilt for 2 s then triggers easing. The autodrive
+    // state is initialised on the first update() call (checked once via
+    // autodriveChecked_).
     void update() {
+#if defined(__APPLE__) && TARGET_OS_SIMULATOR
+        if (!autodriveChecked_) {
+            autodriveChecked_ = true;
+            const char* env = std::getenv("GE_ACCELSYNTH_AUTODRIVE");
+            if (env && env[0] == '1') {
+                autodriveActive_ = true;
+                autodriveStartNs_ = SDL_GetPerformanceCounter();
+                SPDLOG_INFO("AccelSynth: GE_ACCELSYNTH_AUTODRIVE active");
+            }
+        }
+        if (autodriveActive_) {
+            const uint64_t freq = SDL_GetPerformanceFrequency();
+            const float elapsed = float(SDL_GetPerformanceCounter() - autodriveStartNs_) / float(freq);
+            if (elapsed < 2.0f) {
+                // Hold a 100 px X-axis tilt while in the drive window.
+                tilt_.x = 100.f;
+                tilt_.y = 0.f;
+                shiftDown_ = true;
+                emitSensorFromTilt();
+                return;
+            }
+            // Drive window expired — release shift and start easing.
+            autodriveActive_ = false;
+            shiftDown_ = false;
+            easing_ = true;
+            lastTickNs_ = 0;
+            SPDLOG_INFO("AccelSynth: GE_ACCELSYNTH_AUTODRIVE drive complete, easing");
+        }
+#endif  // TARGET_OS_SIMULATOR
         if (!easing_) return;
         const uint64_t now = SDL_GetPerformanceCounter();
         if (lastTickNs_ == 0) {
@@ -169,6 +213,11 @@ private:
     uint64_t lastTickNs_ = 0;
     SDL_Window* window_ = nullptr;
     std::function<void(const SDL_Event&)> emit_;
+#if defined(__APPLE__) && TARGET_OS_SIMULATOR
+    bool autodriveChecked_ = false;
+    bool autodriveActive_  = false;
+    uint64_t autodriveStartNs_ = 0;
+#endif
 };
 
 } // namespace ge

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -1499,6 +1499,95 @@ check_soak_desktop() {
     pass_check "$subcheck" "${SOAK_TIME}s — app alive, no crash reports"
 }
 
+# check_accelsynth_ios_sim <udid> <bundle_id>
+#
+# Verifies that AccelSynth is active (no real sensor) and produces non-zero
+# sensor output on an iOS Simulator distribution build (🎯T28.3).
+#
+# Strategy: relaunch the app with GE_ACCELSYNTH_AUTODRIVE=1 via the
+# SIMCTL_CHILD_ prefix mechanism. AccelSynth.h's update() method drives a
+# synthetic 100 px X-axis tilt for the first 2 seconds when this env var is
+# set, gated strictly on TARGET_OS_SIMULATOR. NSLog output from the app is
+# captured via `xcrun simctl spawn <udid> log stream` filtered by process
+# name. The check asserts:
+#   1. The "Shift-mouse accelerometer synthesis enabled" line appears — synth
+#      was constructed because no real sensor was found.
+#   2. An "AccelSynth: emit g=" line with a non-zero gx value appears —
+#      the autodrive actually fired and produced sensor events.
+check_accelsynth_ios_sim() {
+    local subcheck="accelsynth"
+    local udid="$1"; local bundle_id="$2"
+
+    local log_file="$ARTIFACTS/accelsynth-log.txt"
+
+    # Terminate any running instance so we get a clean log window.
+    xcrun simctl terminate "$udid" "$bundle_id" 2>/dev/null || true
+    sleep 0.3
+
+    # Start log stream, capturing all info-level output from the sim.
+    # We grep for our AccelSynth strings afterwards — filtering by predicate
+    # in the command is fragile due to quoting, and the log volume during a
+    # 5 s window is manageable.
+    local log_pid
+    xcrun simctl spawn "$udid" log stream --level info \
+        > "$log_file" 2>/dev/null &
+    log_pid=$!
+
+    # Launch with GE_ACCELSYNTH_AUTODRIVE=1. The SIMCTL_CHILD_ prefix injects
+    # the variable into the sim process environment.
+    SIMCTL_CHILD_GE_ACCELSYNTH_AUTODRIVE=1 \
+        xcrun simctl launch "$udid" "$bundle_id" >/dev/null 2>&1 || true
+
+    # Wait up to 5 s for the autodrive window plus a margin.
+    local waited=0
+    while [[ $waited -lt 5 ]]; do
+        sleep 1
+        waited=$((waited + 1))
+        if grep -q "AccelSynth: emit g=" "$log_file" 2>/dev/null; then
+            break
+        fi
+    done
+
+    kill "$log_pid" 2>/dev/null || true
+    wait "$log_pid" 2>/dev/null || true
+
+    # Sub-check 1: synth was enabled (no real sensor found).
+    if ! grep -q "accelerometer synthesis enabled" "$log_file" 2>/dev/null; then
+        fail_check "$subcheck" "synth-enabled log line not found (real sensor may be present, or NSLog sink not wired)"
+        return 1
+    fi
+
+    # Sub-check 2: autodrive produced a non-zero emit.
+    # The emit line looks like: AccelSynth: emit g=(2.54,0.00)
+    # We parse out gx and verify it is not zero.
+    if ! grep -q "AccelSynth: emit g=" "$log_file" 2>/dev/null; then
+        fail_check "$subcheck" "no AccelSynth emit line found in log"
+        return 1
+    fi
+    local sample_line
+    sample_line=$(grep "AccelSynth: emit g=" "$log_file" 2>/dev/null | head -1)
+    local gx
+    gx=$(echo "$sample_line" | sed -n 's/.*g=(\([^,]*\),.*/\1/p')
+    if [[ -z "$gx" ]]; then
+        warn_check "$subcheck" "could not parse gx from emit line: $sample_line"
+        return 0
+    fi
+    # Any non-zero float passes. Zero appears as "0" or "0.0..." variants.
+    if [[ "$gx" =~ ^-?0(\.0+)?$ ]]; then
+        fail_check "$subcheck" "AccelSynth emitted zero gx — autodrive may not have fired (gx=$gx)"
+        return 1
+    fi
+    pass_check "$subcheck" "synth active, non-zero emit confirmed (gx=$gx)"
+}
+
+# Helper: derive a process name from a bundle ID for log stream filtering.
+# Tries the last component of the reverse-DNS ID (e.g. "tiltbuggy" from
+# "com.squz.tiltbuggy"). Falls back to the full bundle ID.
+app_name_from_bundle() {
+    local bundle_id="$1"
+    echo "$bundle_id" | awk -F. '{print $NF}'
+}
+
 check_soak_ios_sim() {
     local subcheck="soak"
     local udid="$1"; local bundle_id="$2"
@@ -2067,6 +2156,11 @@ run_ios_sim_dist() {
     check_soak_ios_sim "$SIM_UDID" "$APP_ID" || true
     check_rotation_ios_sim "$SIM_UDID" "$APP_ID" || true
     check_bgfg_ios "$SIM_UDID" "$APP_ID" || true
+    # AccelSynth verification (🎯T28.3): confirm no real sensor → synth
+    # constructs, and the GE_ACCELSYNTH_AUTODRIVE path produces non-zero
+    # sensor output. Relaunches the app with the autodrive env var via
+    # SIMCTL_CHILD_ and reads NSLog output from xcrun simctl spawn log stream.
+    check_accelsynth_ios_sim "$SIM_UDID" "$APP_ID" || true
     # Visual regression: capture at known-stable state (post-soak, post-bg/fg, pre-exit).
     # Uses spyder screenshot + diff against baseline in ~/.spyder/visualdiff/ge-tiltbuggy/<cell>/...
     # On mismatch, exits with code 51 (visual-regression-mismatch).


### PR DESCRIPTION
## Summary

- Add `GE_ACCELSYNTH_AUTODRIVE=1` env var to `AccelSynth.h`, gated strictly on `TARGET_OS_SIMULATOR`. When set, `update()` drives a synthetic 100 px X-axis tilt for 2 s (then eases), allowing the matrix cell to assert non-zero sensor output without mouse/keyboard input — `simctl` cannot inject GCKeyboard Shift events.
- Add `check_accelsynth_ios_sim()` to `matrix-cell.sh` that relaunches the app with `SIMCTL_CHILD_GE_ACCELSYNTH_AUTODRIVE=1`, reads NSLog/spdlog output via `xcrun simctl spawn log stream`, and asserts: (1) synth was constructed (no real sensor), (2) a non-zero `gx` emit was produced.
- Wire the check into `run_ios_sim_dist()` after `check_bgfg_ios` and before the visual regression capture.

## Approach

Chose option (b) — debug instrumentation — over XCUITest. The autodrive env var is faster, requires no extra Xcode test target, and the `TARGET_OS_SIMULATOR` guard ensures it is physically unreachable on real devices. The check exercises the full path: `realSensorAvailable()` → 0 sensors → synth constructed → `update()` fires → sensor events emitted → logged.

## Test plan

- [ ] Build `ios-sim-tablet-dist` cell: `cd sample/tiltbuggy && make ge/ios-release`
- [ ] Run: `../../tools/matrix-cell.sh ios-sim-tablet-dist` — verify `accelsynth` sub-check passes
- [ ] Confirm real-device cell (`ios-device-tablet-dist`) is unaffected — `TARGET_OS_SIMULATOR` guard prevents autodrive; check simply passes through log assertion with synth disabled (real sensor present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)