### PR TITLE
ge: 🎯T30.3 — android-template build.gradle.in requires cmake 3.31.4 for add_subdirectory(ge)

### DIFF
--- a/tools/android-template/app/build.gradle.in
+++ b/tools/android-template/app/build.gradle.in
@@ -37,6 +37,7 @@ android {
     externalNativeBuild {
         cmake {
             path = file('src/main/cpp/CMakeLists.txt')
+            version "3.31.4"
         }
     }
 


### PR DESCRIPTION
The android CMakeLists template was updated in 279b708 to use
add_subdirectory(ge) instead of a hand-picked GE_SOURCES list. The ge
root CMakeLists.txt requires cmake ≥ 3.28; the Android SDK bundles
3.22.1 by default. Without an explicit version pin in build.gradle.in
the Gradle build would silently select the old 3.22.1 bundled cmake,
which fails at the cmake_minimum_required check in ge/CMakeLists.txt.

Add `version "3.31.4"` to the externalNativeBuild.cmake block so
generated android/ projects pick up the newer SDK-bundled cmake.

Verified: tiltbuggy APK builds successfully (assembleDebug) and
launches on Galaxy Tab A9 (SM-X110) — accelerometer events flowing,
no crashes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
