### PR TITLE
AccelSynth: emit iOS SDL_SENSOR_ACCEL counter-gravity convention

### DIFF
--- a/src/render/AccelSynth.h
+++ b/src/render/AccelSynth.h
@@ -145,15 +145,21 @@ public:
 private:
     void emitSensorFromTilt() {
         if (!emit_) return;
-        // Map displacement → gravity-along-screen-plane, i.e. g·sin(angle)
-        // in the direction of the displacement. Bounded naturally by ±g.
+        // Emit in iOS SDL_SENSOR_ACCEL convention: values are the
+        // counter-gravity vector in device frame. When the device is
+        // tilted in some direction, gravity rotates that way in device
+        // frame, and the reported accel rotates the OPPOSITE way.
+        // Hence the sign-flip on tilt_.{x,y} below. tilt_.y is not
+        // further inverted: SDL mouse-y grows downward, matching
+        // iOS's +Y-points-toward-top convention (drag down → virtual
+        // device leans forward → counter-gravity +Y component).
         float mag = std::sqrt(tilt_.x * tilt_.x + tilt_.y * tilt_.y);
         float gx = 0.f, gy = 0.f;
         if (mag > 0.f) {
             float angle = mag * kTiltRadPerPixel;
             float s = std::sin(angle);
-            gx =  kG * s * tilt_.x / mag;
-            gy = -kG * s * tilt_.y / mag;
+            gx = -kG * s * tilt_.x / mag;
+            gy =  kG * s * tilt_.y / mag;
         }
         SPDLOG_INFO("AccelSynth: emit g=({},{})", gx, gy);  // TEMP: T28.3 diagnostic
         SDL_Event se{};


### PR DESCRIPTION
## Summary
- `AccelSynth::emitSensorFromTilt` flipped to emit counter-gravity (matching iOS / SDL real accelerometer convention) instead of gravity-direction.
- Apps that compensate for iOS accel signs (e.g. `inputGravity.x = -data[0]`) now produce identical behaviour on real-device tilt and desktop shift-mouse synthesis.

## Background
Discovered while verifying multimaze2 on Pippa: shift-mouse worked on desktop after one sign flip, but real iOS accel was reversed. Root cause: AccelSynth was emitting the gravity vector, while iOS reports counter-gravity. Apps that follow the iOS convention then double-invert on synth.

## Test plan
- [ ] sample/tiltbuggy: shift-mouse drag right → buggy rolls right (was rolls left).
- [ ] iOS device with real accelerometer: tilt right → identical roll direction (no behaviour change for apps that already follow iOS convention).
- [ ] Existing T28.x AccelSynth diagnostic logs still fire correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)