### PR TITLE
DirectRenderHost: fold Android density bucket into pixelsPerPt

### DIFF
--- a/src/render/DirectRenderHost.mm
+++ b/src/render/DirectRenderHost.mm
@@ -277,7 +277,13 @@ DirectRenderHost::DirectRenderHost(const SessionHostConfig& config)
     i_->ctx->setUiSafeInsets(uiSafeInsets());
     {
         SDL_Window* win = i_->bgfxCtx->window();
-        const float ppt = win ? SDL_GetWindowPixelDensity(win) : 1.0f;
+        // SDL_GetWindowDisplayScale = pixelDensity × displayContentScale.
+        // On iOS the second factor is always 1.0, so this matches
+        // SDL_GetWindowPixelDensity (== UIKit nativeScale). On Android
+        // the pixel density is always 1.0 (SDL exposes the surface in
+        // raw pixels) and the density bucket lives in the content scale,
+        // so this is what folds Android density into pixelsPerPt.
+        const float ppt = win ? SDL_GetWindowDisplayScale(win) : 1.0f;
         i_->ctx->setPixelsPerPt(ppt > 0.0f ? ppt : 1.0f);
         i_->ctx->setDeviceUiScale(computeDeviceUiScale(deviceClass(), i_->width, i_->height, ppt));
     }
@@ -491,7 +497,13 @@ void DirectRenderHost::beginFrame() {
         i_->ctx->setDrawSafeInsets(drawSafeInsets());
         i_->ctx->setUiSafeInsets(uiSafeInsets());
         SDL_Window* win = i_->bgfxCtx->window();
-        const float ppt = win ? SDL_GetWindowPixelDensity(win) : 1.0f;
+        // SDL_GetWindowDisplayScale = pixelDensity × displayContentScale.
+        // On iOS the second factor is always 1.0, so this matches
+        // SDL_GetWindowPixelDensity (== UIKit nativeScale). On Android
+        // the pixel density is always 1.0 (SDL exposes the surface in
+        // raw pixels) and the density bucket lives in the content scale,
+        // so this is what folds Android density into pixelsPerPt.
+        const float ppt = win ? SDL_GetWindowDisplayScale(win) : 1.0f;
         i_->ctx->setPixelsPerPt(ppt > 0.0f ? ppt : 1.0f);
         i_->ctx->setDeviceUiScale(computeDeviceUiScale(deviceClass(), i_->width, i_->height, ppt));
     }


### PR DESCRIPTION
## Summary
- `Context::pixelsPerPt()` was effectively broken on Android: `SDL_GetWindowPixelDensity` returns 1.0 because SDL exposes the Android surface in raw device pixels (the bucket multiplier sits in `SDL_GetDisplayContentScale` instead). iOS phones returned 2.0–3.0 from the same call, so a 32pt button rendered ~3× smaller on Android than on iPhone at the same point size.
- Switching to `SDL_GetWindowDisplayScale`, which is documented as `pixelDensity × displayContentScale`, folds the two into a single value: unchanged on iOS (content scale is always 1.0 there → matches `WindowPixelDensity`), correct on Android (pixel density is 1.0 → picks up the bucket).
- `computeDeviceUiScale` already divides by `pixelsPerPt`, so its short-side-mm estimate now lands closer to physical truth on Android too.

## Test plan
- [x] iPhone 13 + iPad mini (A17): bar height unchanged.
- [x] Tab A9 (xhdpi) + S20 Ultra (xxhdpi): bar height now within ~1% of screen height of the iOS counterparts at the same kBarHeightPt.
- [ ] Visual regression cells (MultiMaze 2 / TiltBuggy) — flagged in case any baselines need refreshing for the new Android sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)