### PR TITLE
Release prep v0.10.0: canonical ge.GeActivity (🎯T41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,27 @@ Module.mk defines these targets so the parent doesn't need to:
 | `ge/ios` | Generate the iOS Xcode project (TODO: needs bgfx port) |
 | `ge/android` | Build the Android debug APK (TODO: needs bgfx port) |
 
+### Android Activity (🎯T41)
+
+ge ships a canonical Android Activity (`ge.GeActivity`) at `android-shared/src/main/java/ge/GeActivity.java`. Consumer apps reference it directly from their AndroidManifest.xml (`android:name="ge.GeActivity"`); no per-app Activity subclass is needed. Gradle source-includes the file from the engine submodule:
+
+```gradle
+sourceSets {
+    main {
+        java.srcDirs = [
+            "${rootDir}/<ge-rel-path>/android-shared/src/main/java",
+            "${rootDir}/<ge-rel-path>/vendor/github.com/libsdl-org/SDL/android-project/app/src/main/java"
+        ]
+    }
+}
+```
+
+`tools/init-android.sh` (`make ge/android-init`) writes the manifest and gradle config above and **does not** scaffold an `app/src/main/java/.../Activity.java` — the per-app Activity tree is gone.
+
+`GeActivity` contains all the SDLActivity boilerplate the engine relies on: `getLibraries()` (returns `{"SDL3", "main"}`), display-cutout listener + `getDisplayCutoutInsets()`, sensor-fused attitude listener + `getAttitude()`, and `applyImmersive()`. Adding new engine-side hooks (more JNI helpers, new lifecycle behaviour) only requires bumping the engine submodule pointer in the consumer; consumer apps inherit the change without editing Java.
+
+**Apps that need custom Activity behaviour** can subclass `ge.GeActivity` in their own `app/src/main/java/<package>/` tree, add `'src/main/java'` back to `java.srcDirs`, and point the manifest at the subclass. Zero-customisation is the supported default — reach for a subclass only when the engine surface genuinely doesn't suffice.
+
 ### Developer Setup
 
 `ge/init` installs common prerequisites (Homebrew packages, Git LFS, VS Code settings, compiledb). The parent's `init` target should depend on it and expand the `ge/INIT_DONE` canned recipe at the end:

--- a/android-shared/src/main/java/ge/GeActivity.java
+++ b/android-shared/src/main/java/ge/GeActivity.java
@@ -1,4 +1,30 @@
-package __PACKAGE__;
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Canonical Android Activity for ge consumers.
+//
+// Apps reference ge.GeActivity directly from their AndroidManifest.xml
+// (android:name="ge.GeActivity"); no per-app subclass is required.
+// Gradle source-includes this file from the engine submodule via
+// sourceSets.main.java.srcDirs, so the Activity bumps in lockstep with
+// the engine and consumer apps inherit new engine-side hooks (sensor
+// listeners, lifecycle callbacks, future plumbing) just by updating
+// the ge submodule pointer — no Java drift.
+//
+// Contains:
+//   * getLibraries() — returns {"SDL3", "main"}; ge always builds the
+//     consumer app's native code as libmain.so.
+//   * Display-cutout insets — drives Context::drawSafeRect via JNI to
+//     getDisplayCutoutInsets().
+//   * Immersive mode — applyImmersive() called from native when
+//     SessionHostConfig.immersive is set.
+//   * Sensor-fused attitude — registers TYPE_GAME_ROTATION_VECTOR
+//     while resumed, exposes the latest quaternion via getAttitude()
+//     for the parallax pipeline.
+//
+// Apps that genuinely need to customise Activity behaviour subclass
+// GeActivity; the supported default is zero-customisation.
+package ge;
 
 import android.content.Context;
 import android.graphics.Insets;
@@ -12,7 +38,7 @@ import android.view.WindowInsetsController;
 
 import org.libsdl.app.SDLActivity;
 
-public class __ACTIVITY__ extends SDLActivity implements SensorEventListener {
+public class GeActivity extends SDLActivity implements SensorEventListener {
     @Override
     protected String[] getLibraries() {
         return new String[]{"SDL3", "main"};
@@ -66,8 +92,6 @@ public class __ACTIVITY__ extends SDLActivity implements SensorEventListener {
     public void onSensorChanged(SensorEvent ev) {
         if (ev.sensor.getType() != Sensor.TYPE_GAME_ROTATION_VECTOR) return;
         float qx = ev.values[0], qy = ev.values[1], qz = ev.values[2];
-        // values[3] (w) is provided since API 18 — defensively recover
-        // it from the vector part if absent.
         float qw;
         if (ev.values.length > 3) {
             qw = ev.values[3];
@@ -81,14 +105,14 @@ public class __ACTIVITY__ extends SDLActivity implements SensorEventListener {
     @Override
     public void onAccuracyChanged(Sensor sensor, int accuracy) { }
 
+    // Called from native (CutoutInsets_android.cpp) each frame to
+    // populate Context::drawSafeRect on Android.
+    public int[] getDisplayCutoutInsets() { return cutoutInsets; }
+
     // Called from native (Attitude_android.cpp) each frame to populate
     // Context::parallax(). Returns the current quaternion as a four-
     // element float array (x, y, z, w).
     public float[] getAttitude() { return attitude; }
-
-    // Called from native (CutoutInsets_android.cpp) each frame to
-    // populate Context::drawSafeRect on Android.
-    public int[] getDisplayCutoutInsets() { return cutoutInsets; }
 
     // Called from native (Immersive_android.cpp) when the app's
     // SessionHostConfig.immersive flag changes. Hides or restores

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1140,6 +1140,21 @@ targets:
     origin: manual
     discovered: 2026-05-09
     achieved: 2026-05-09
+  T41:
+    name: ge ships a one-size-fits-all Android Activity that consumers reference directly
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'ge ships a single GeActivity class (proposed: ge.GeActivity) containing all the SDLActivity boilerplate currently duplicated across consumers - getLibraries returning SDL3 plus main, cutoutInsets field with OnApplyWindowInsetsListener, getDisplayCutoutInsets, applyImmersive, getAttitude and the sensor listener, and any future engine-mandated hooks'
+    - Consumer apps reference ge.GeActivity directly from their AndroidManifest.xml; there is no per-app Activity subclass required for engine functionality
+    - ge.GeActivity is delivered via a mechanism that does not require consumers to copy or maintain Java source - Gradle source-include from the submodule (e.g. sourceSets.main.java.srcDirs += '../ge/android-shared/src/main/java'), Gradle subproject, or published AAR. Choice documented in ge/CLAUDE.md
+    - Apps that need custom Activity behaviour can subclass ge.GeActivity - but zero-customisation is the supported default
+    - ge/tools/android-template no longer scaffolds a per-app Activity.java; android-init configures Gradle to pull GeActivity from ge instead
+    - Existing consumers (multimaze2, esfera2, yourworld2, tiltbuggy) drop their per-app Activity .java file and update AndroidManifest.xml. Migration steps documented
+    - Drift between consumer Activities and ge's expected Java surface becomes structurally impossible - bumping the ge submodule pointer is sufficient to pick up new engine-side hooks
+    origin: multimaze2 5/2026 - hit a crash because MultiMazeActivity was 2-3 ge versions behind the template (missing getAttitude); the per-app Activity is pure boilerplate that drifts
+    discovered: 2026-05-09
   T5:
     name: Player has a connection management screen
     status: identified
@@ -1183,7 +1198,7 @@ targets:
     discovered: 2026-04-15
   T9:
     name: ge exposes device tilt as optional parallax input to games
-    status: identified
+    status: converging
     value: 5.0
     cost: 5.0
     acceptance:

--- a/docs/rendering-library-choice.md
+++ b/docs/rendering-library-choice.md
@@ -164,14 +164,33 @@ Once all three have shipped, the bullseye target tracking the migration moves fr
 
 ### Migration plan (sketch, not committed)
 
-To be elaborated when the migration target unblocks. The 🎯T53 (Dawn → bgfx) migration cost ~2–4 focused weeks across ge + consumers; sokol's smaller surface and closer architectural fit suggest a similar or slightly lower estimate, but this needs a real scoping pass before starting.
+To be elaborated when the migration target unblocks. The 🎯T53 (Dawn → bgfx) migration cost ~2–4 focused weeks across ge + consumers; sokol's smaller surface and closer architectural fit suggest a similar estimate, with the caveats below pushing the upper bound.
 
 Affected repos: `ge`, `yourworld2`, `multimaze2`, `esfera2`, `ge-t30.1`, plus any sample/test programs.
+
+#### Known scope items (cost going in, not discovered later)
+
+1. **Wrap sokol's streaming primitives in a transient-buffer-shaped helper at ge's abstraction layer.**
+   bgfx's `allocTransientVertexBuffer` / `allocTransientIndexBuffer` is the per-frame dynamic-geometry pattern ge uses extensively. sokol's equivalent is `SG_USAGE_STREAM` buffers updated via `sg_update_buffer` / `sg_append_buffer`, with restrictions (one `sg_update_buffer` per frame; fixed staging-buffer size, default ~16 MB, configurable at init). The mapping is close but not identical. Audit every transient-buffer call site in ge and consumers, design a thin wrapper at ge's abstraction layer that preserves the transient-buffer mental model, and tune the staging buffer size for the heaviest frame (likely yourworld2's atlas region streaming or any level-transition particle bursts).
+2. **Multi-threading regression risk.**
+   bgfx has a deferred command-recording model with a separate render thread. sokol is essentially single-threaded — rendering happens on whichever thread the caller is on. Current ge workloads do not appear CPU-submission-bound, but this is a one-way door: if a future title hits CPU-submission limits on sokol, the answer is "rewrite around it" not "flip a flag." **Mitigation:** profile the heaviest scenes (yourworld2 globe + carousel; multimaze2 win-animation; any other scene with high draw-call counts) under sokol on a low-end Android device *early* in the migration, not at the end. Bail out / re-evaluate if submission cost dominates a frame.
+3. **Compute is on the table now.**
+   sokol's compute support has matured (dispatch, storage buffers, storage images, available across all shipping backends). Earlier framing of "compute is bgfx-only" no longer holds. ge doesn't lean on compute today, so this isn't a migration cost — but it's worth recording that the option exists post-migration for things like GPU-driven particles or culling.
+4. **Debugging tooling parity.**
+   bgfx ships RenderDoc-aware annotations (named views, stat counters). sokol has a basic validation layer and resource labels, no first-class RenderDoc integration. RenderDoc captures Metal/Vulkan/D3D directly regardless of which library sits on top, so this is mostly a loss of named-view annotations in capture views — a minor inconvenience, not a blocker. Add string labels to sokol resources (`sg_*_desc.label`) liberally during the migration to compensate.
+
+#### Open questions to resolve during scoping
+
+- Does ge currently rely on bgfx's multithreaded renderer, or is it effectively single-threaded already? (If the latter, the multi-threading concern above is theoretical.)
+- What is the peak transient-buffer footprint in a single frame across all titles? (Drives the staging buffer sizing.)
+- Are there any bgfx features in active use that I haven't inventoried — occlusion queries, indirect draws, MRT configurations, MSAA settings — that need explicit mapping?
 
 ## Sources
 
 - 🎯T52 — H.264 streaming dev mode (replaced Dawn wire)
 - 🎯T53 — Migrate from Dawn/WebGPU to bgfx
 - 🎯T24 — Fix Adreno 830 crash in bgfx transient buffer update (resolved by GLES switch)
+- 🎯T38 — ge engine has migrated from bgfx to sokol_gfx (deferred until releases ship)
 - [`papers/adreno-830-bgfx-vulkan-crash.md`](papers/adreno-830-bgfx-vulkan-crash.md)
 - Broader discussion: `~/think` session 2026-04-20 covering declarative rendering APIs and OSS rendering library landscape
+- Sokol vs bgfx scope-items added 2026-05-09 after Grok comparison surfaced multi-threading and transient-buffer mapping as concrete migration cost items

--- a/tools/android-template/app/build.gradle.in
+++ b/tools/android-template/app/build.gradle.in
@@ -41,11 +41,16 @@ android {
         }
     }
 
-    // Include SDL3 Java sources from the ge engine's vendored SDL.
+    // Include Java sources from ge: the canonical GeActivity (so apps
+    // never copy the SDLActivity boilerplate) and the vendored SDL3
+    // android-project. Drop 'src/main/java' from the list — the
+    // template no longer scaffolds a per-app Activity.java; apps that
+    // genuinely need to customise behaviour subclass ge.GeActivity in
+    // their own java tree and add it back here.
     sourceSets {
         main {
             java.srcDirs = [
-                'src/main/java',
+                "${rootDir}/__GE_REL__/android-shared/src/main/java",
                 "${rootDir}/__GE_REL__/vendor/github.com/libsdl-org/SDL/android-project/app/src/main/java"
             ]
         }

--- a/tools/android-template/app/src/main/AndroidManifest.xml.in
+++ b/tools/android-template/app/src/main/AndroidManifest.xml.in
@@ -13,7 +13,7 @@
         android:hardwareAccelerated="true">
 
         <activity
-            android:name="__PACKAGE__.__ACTIVITY__"
+            android:name="ge.GeActivity"
             android:label="@string/app_name"
             android:theme="@android:style/Theme.Material.NoActionBar.Fullscreen"
             android:alwaysRetainTaskState="true"

--- a/tools/init-android.sh
+++ b/tools/init-android.sh
@@ -26,10 +26,12 @@ APP_NAME="$2"
 
 # Derive names from app name (strip spaces for class/project names).
 STRIPPED="$(echo "$APP_NAME" | tr -d ' ')"
-ACTIVITY="${STRIPPED}Activity"
 CMAKE_PROJECT="$STRIPPED"
-# Java source directory: package dots → slashes.
-JAVA_DIR="$(echo "$PACKAGE" | tr '.' '/')"
+# As of 🎯T41 (v0.10.0+), the Activity is canonical-engine-owned —
+# AndroidManifest.xml hardcodes android:name="ge.GeActivity" and
+# Gradle source-includes it from $GE_ROOT/android-shared. Apps no
+# longer scaffold a per-app Activity.java. Apps that need custom
+# behaviour subclass ge.GeActivity in their own java tree.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATE_DIR="$SCRIPT_DIR/android-template"
@@ -49,7 +51,7 @@ fi
 echo "Generating Android project:"
 echo "  Package:  $PACKAGE"
 echo "  App name: $APP_NAME"
-echo "  Activity: $PACKAGE.$ACTIVITY"
+echo "  Activity: ge.GeActivity (canonical, source-included from \$GE/android-shared)"
 echo "  Output:   $OUT_DIR"
 echo "  ge:       $GE_REL (from android/)"
 echo
@@ -69,7 +71,6 @@ cp "$TEMPLATE_DIR/.gitignore"         "$OUT_DIR/" 2>/dev/null || true
 subst() {
     sed -e "s|__PACKAGE__|$PACKAGE|g" \
         -e "s|__APP_NAME__|$APP_NAME|g" \
-        -e "s|__ACTIVITY__|$ACTIVITY|g" \
         -e "s|__CMAKE_PROJECT__|$CMAKE_PROJECT|g" \
         -e "s|__GE_REL__|$GE_REL|g" \
         "$1"
@@ -87,8 +88,9 @@ subst "$TEMPLATE_DIR/app/src/main/AndroidManifest.xml.in" > "$OUT_DIR/app/src/ma
 mkdir -p "$OUT_DIR/app/src/main/res/values"
 subst "$TEMPLATE_DIR/app/src/main/res/values/strings.xml.in" > "$OUT_DIR/app/src/main/res/values/strings.xml"
 
-mkdir -p "$OUT_DIR/app/src/main/java/$JAVA_DIR"
-subst "$TEMPLATE_DIR/app/src/main/java/Activity.java.in" > "$OUT_DIR/app/src/main/java/$JAVA_DIR/$ACTIVITY.java"
+# No per-app Activity.java is scaffolded — AndroidManifest.xml binds
+# directly to ge.GeActivity, which Gradle source-includes from
+# $GE_ROOT/android-shared/src/main/java (see app/build.gradle).
 
 # Auto-detect Android SDK.
 if [ -d "$HOME/Library/Android/sdk" ]; then


### PR DESCRIPTION
## Summary

🎯T41 — `ge.GeActivity` is now the canonical Android Activity. Consumer apps reference it directly from their AndroidManifest; no per-app Activity subclass is needed; bumping the ge submodule pointer is sufficient to pick up new engine-side Java hooks.

## Why

multimaze2 hit a crash recently because its `MultiMazeActivity` was 2–3 ge versions behind the template and missed `getAttitude()`. The per-app Activity is pure boilerplate (`getLibraries()`, cutout listener, immersive control, sensor listener) that drifts; standardising it on a single engine-owned class makes that class of drift structurally impossible.

## Changes

- New `android-shared/src/main/java/ge/GeActivity.java` carries every hook the engine relies on:
  - `getLibraries()` returning `{"SDL3", "main"}`.
  - Display-cutout listener + `getDisplayCutoutInsets()`.
  - Sensor-fused attitude listener + `getAttitude()` (registers `TYPE_GAME_ROTATION_VECTOR` in `onResume`, unregisters in `onPause`).
  - `applyImmersive()` for the immersive-mode toggle.
- `tools/android-template/app/build.gradle.in` source-includes `android-shared` from the engine root and drops `src/main/java` from the list (no per-app Activity to compile).
- `tools/android-template/app/src/main/AndroidManifest.xml.in` binds to `ge.GeActivity`.
- `tools/android-template/app/src/main/java/Activity.java.in` deleted (migrated to `android-shared/`).
- `tools/init-android.sh` drops the Activity scaffolding step and the `__ACTIVITY__` substitution.
- `CLAUDE.md` documents the new pattern + the customisation escape hatch (subclass `ge.GeActivity`, add `'src/main/java'` back).

Apps that need custom Activity behaviour subclass `ge.GeActivity`; zero-customisation is the supported default.

## Out of repo scope

- Per-app Activity removal in multimaze2 / esfera2 / yourworld2 — those happen in their respective repos against this ge bump.
- `sample/tiltbuggy` regenerates `android/` from the template on each `ge/android-init` (the dir is gitignored), so it picks up the new shape on the next run. Verified by regenerating in this branch — manifest binds to `ge.GeActivity`, no per-app Java is scaffolded.

## Bundled

`docs/rendering-library-choice.md` gains a "known scope items" section (sokol streaming buffers, multi-threading regression risk, compute availability, debugging tooling parity) plus open scoping questions for the bgfx → sokol_gfx migration. Filed by another agent in this working tree before this session; orthogonal to T41 but folded into the same release rather than left in working-tree limbo.

## Test plan

- [x] tiltbuggy + libge build clean against the new headers (no Java affects native build, but sanity check).
- [x] `tools/init-android.sh` regenerates `sample/tiltbuggy/android/` cleanly, no per-app Java tree, manifest binds to `ge.GeActivity`, gradle source-includes `android-shared`.
- [ ] Squash-merge to master, tag v0.10.0, GitHub release.
- [ ] Real Android build verification (gradle / apk install) — happens against consumer repos when they bump.
