### PR TITLE
Release prep v0.16.0: Rect enrichments + British → US spelling sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Engine-internal variables use the `ge/` prefix. These are read-only — the pare
 | `ge/BGFX_LIBS` | bgfx static libraries (`libbgfx.a`, `libbimg.a`, `libbx.a`) |
 | `ge/SDL_LIBS` | SDL3 static libraries (SDL3, SDL3_image, SDL3_ttf, freetype, harfbuzz, etc.) |
 | `ge/TEST_SRC`, `ge/TEST_OBJ` | Unit test sources and objects |
-| `ge/TRIANGLE_OBJ` | Triangle library object — **opt-in; not linked into `libge.a`**. Commercial builds should not reference this without first reading NOTICES.md's Triangle section (restrictive licence; commercial distribution requires arrangement with the author). |
+| `ge/TRIANGLE_OBJ` | Triangle library object — **opt-in; not linked into `libge.a`**. Commercial builds should not reference this without first reading NOTICES.md's Triangle section (restrictive license; commercial distribution requires arrangement with the author). |
 | `ge/PLAYER` | ge player binary path (`bin/player`) |
 
 ### Shared Variables
@@ -197,7 +197,7 @@ ge ships a build-time tool, `bin/ge-icon-gen`, that takes one source SVG and wri
 
 - iOS: `Assets.xcassets/AppIcon.appiconset/icon.png` (1024×1024) + `Contents.json`. Single-source mode (Xcode 15+) — Xcode generates the smaller per-size icons automatically at build time.
 - Android legacy: `mipmap-{m,h,xh,xxh,xxxh}dpi/ic_launcher.png` and matching `_round.png` at 48 / 72 / 96 / 144 / 192 px.
-- Android adaptive: `drawable/ic_launcher_foreground.png` (432×432, full-bleed master SVG) + `drawable/ic_launcher_background.xml` (solid colour from `ge/APP_ICON_BG_COLOR`, default white) + `mipmap-anydpi-v26/ic_launcher.xml` and `_round.xml` adaptive manifests.
+- Android adaptive: `drawable/ic_launcher_foreground.png` (432×432, full-bleed master SVG) + `drawable/ic_launcher_background.xml` (solid color from `ge/APP_ICON_BG_COLOR`, default white) + `mipmap-anydpi-v26/ic_launcher.xml` and `_round.xml` adaptive manifests.
 
 **Override knobs in `Module.mk`:**
 
@@ -210,7 +210,7 @@ ge ships a build-time tool, `bin/ge-icon-gen`, that takes one source SVG and wri
 
 **Constraints:** SVG-only input. PNG / JPEG sources are rejected with a clear error pointing at SVG. Multi-size resampling of raster sources is not supported — author the icon as SVG.
 
-**Limitations not covered yet:** explicit `icons/icon-foreground.svg` + `icons/icon-background.svg` for split adaptive-icon control on Android (today: full-bleed master goes into the foreground, background is a solid colour). iOS 18 light/dark/tinted variants. iOS animated app icons. All deferable to future targets when a real consumer needs them.
+**Limitations not covered yet:** explicit `icons/icon-foreground.svg` + `icons/icon-background.svg` for split adaptive-icon control on Android (today: full-bleed master goes into the foreground, background is a solid color). iOS 18 light/dark/tinted variants. iOS animated app icons. All deferable to future targets when a real consumer needs them.
 
 ### Android Activity (🎯T41)
 
@@ -229,9 +229,9 @@ sourceSets {
 
 `tools/init-android.sh` (`make ge/android-init`) writes the manifest and gradle config above and **does not** scaffold an `app/src/main/java/.../Activity.java` — the per-app Activity tree is gone.
 
-`GeActivity` contains all the SDLActivity boilerplate the engine relies on: `getLibraries()` (returns `{"SDL3", "main"}`), display-cutout listener + `getDisplayCutoutInsets()`, sensor-fused attitude listener + `getAttitude()`, and `applyImmersive()`. Adding new engine-side hooks (more JNI helpers, new lifecycle behaviour) only requires bumping the engine submodule pointer in the consumer; consumer apps inherit the change without editing Java.
+`GeActivity` contains all the SDLActivity boilerplate the engine relies on: `getLibraries()` (returns `{"SDL3", "main"}`), display-cutout listener + `getDisplayCutoutInsets()`, sensor-fused attitude listener + `getAttitude()`, and `applyImmersive()`. Adding new engine-side hooks (more JNI helpers, new lifecycle behavior) only requires bumping the engine submodule pointer in the consumer; consumer apps inherit the change without editing Java.
 
-**Apps that need custom Activity behaviour** can subclass `ge.GeActivity` in their own `app/src/main/java/<package>/` tree, add `'src/main/java'` back to `java.srcDirs`, and point the manifest at the subclass. Zero-customisation is the supported default — reach for a subclass only when the engine surface genuinely doesn't suffice.
+**Apps that need custom Activity behavior** can subclass `ge.GeActivity` in their own `app/src/main/java/<package>/` tree, add `'src/main/java'` back to `java.srcDirs`, and point the manifest at the subclass. Zero-customization is the supported default — reach for a subclass only when the engine surface genuinely doesn't suffice.
 
 ### Developer Setup
 
@@ -398,7 +398,7 @@ This was the takeaway of a long debugging session in v0.1.0 (see commit `e0da016
 - **Direct-render apps** (`DirectRenderHost`-mode, e.g. TiltBuggy): set `SessionHostConfig.orientation = wire::kOrientationLandscape` (or any non-zero `wire::kOrientation*` constant). The engine calls `playerForceOrientation` from `DirectRenderHost::send` automatically. The orientation stub/swizzle is now linked into `libge` (v0.3.0+), so apps don't need to add anything to their build.
 - **Player apps** get this for free — `wire::SessionConfig.orientation` from the server triggers `playerForceOrientation()` over the wire.
 
-**API caveat (v0.3.0):** the `wire::kOrientation*` enum has four constants (Landscape, LandscapeFlipped, Portrait, PortraitFlipped) but `playerForceOrientation` currently treats the field as a **boolean** — any non-zero value enables the lock; the *specific* value is not honoured. The orientation that gets locked is whichever one iOS picked at launch, bounded by your `UISupportedInterfaceOrientations`. To force "specifically LandscapeLeft only," narrow the plist to `LandscapeLeft` only — don't rely on passing `kOrientationLandscape` vs `kOrientationLandscapeFlipped` to differentiate, because today they don't. 🎯T36 tracks aligning the API with its behaviour (either collapse to a boolean or make the constants authoritative).
+**API caveat (v0.3.0):** the `wire::kOrientation*` enum has four constants (Landscape, LandscapeFlipped, Portrait, PortraitFlipped) but `playerForceOrientation` currently treats the field as a **boolean** — any non-zero value enables the lock; the *specific* value is not honored. The orientation that gets locked is whichever one iOS picked at launch, bounded by your `UISupportedInterfaceOrientations`. To force "specifically LandscapeLeft only," narrow the plist to `LandscapeLeft` only — don't rely on passing `kOrientationLandscape` vs `kOrientationLandscapeFlipped` to differentiate, because today they don't. 🎯T36 tracks aligning the API with its behavior (either collapse to a boolean or make the constants authoritative).
 
 If you find yourself editing `UISupportedInterfaceOrientations` to fix an orientation problem, you're in the right place — but make sure you've also set `SessionHostConfig.orientation` non-zero, or the lock won't survive the iPad's swivel gesture.
 
@@ -464,7 +464,7 @@ ge has a small, unified surface for "rasterize/load → texture → draw". One `
 - **`ge::loadImage(path)`** (`<ge/png.h>`) — load PNG / JPEG / BMP / etc. via SDL3_image. Path resolved via `ge::resource` (iOS bundle / Android APK / desktop fs). Premultiplies alpha before upload.
 - **`ge::rasterizeText(text, font, sizePt, color)`** (`<ge/text.h>`) — single-line text via FreeType. `font` is a `FontRef` from `ge::resolveFont`. Premul output. Single line / no wrapping today.
 
-ge ships [lunasvg](https://github.com/sammycage/lunasvg) (with its bundled plutovg) as the canonical SVG rasterizer. SDL_image's built-in nanosvg path can't render text or `clipPath`; ge bypasses it. See [NOTICES.md](NOTICES.md) for the licence chain (lunasvg + plutovg + FreeType-derived raster code + stb_*).
+ge ships [lunasvg](https://github.com/sammycage/lunasvg) (with its bundled plutovg) as the canonical SVG rasterizer. SDL_image's built-in nanosvg path can't render text or `clipPath`; ge bypasses it. See [NOTICES.md](NOTICES.md) for the license chain (lunasvg + plutovg + FreeType-derived raster code + stb_*).
 
 **Lunasvg features supported:** path, rect, circle, ellipse, polygon, polyline; fills (solid, linearGradient, radialGradient, pattern); strokes; clipPath; mask; gradients; opacity; nested groups; transforms; `<text>` (basic); CSS via `applyStyleSheet`; CSS selectors via `querySelectorAll`; hit testing via `elementFromPoint`. **Not** a SVG 2 / animation engine — no SMIL, no scripting.
 

--- a/Module.mk
+++ b/Module.mk
@@ -300,7 +300,7 @@ APP_OBJ     ?= $(patsubst %.cpp,$(BUILD_DIR)/%.o,$(APP_SRC))
 APP_DISPLAY_NAME ?= $(APP_NAME)
 
 # Extra static libs/objects the app needs beyond the ge engine (e.g. ship a
-# specialised third-party library). Defaults to Box2D since many ge apps use
+# specialized third-party library). Defaults to Box2D since many ge apps use
 # it and its link cost is negligible for those that don't.
 APP_LIBS    ?= $(ge/BOX2D_OBJ)
 
@@ -565,7 +565,7 @@ $(ge/ICON_GEN): $(ge)/tools/icon-gen.cpp $(ge/LIB) $(ge/BGFX_LIBS)
 # Override knobs: ge/APP_ICON_SVG, ge/APP_ICON_BG_COLOR, ge/APP_ICON_IOS_OUT,
 # ge/APP_ICON_ANDROID_RES_OUT.
 ge/APP_ICON_SVG            ?= icons/icon.svg
-# Hex fill colour for the Android adaptive-icon background. NO '#' here —
+# Hex fill color for the Android adaptive-icon background. NO '#' here —
 # Make treats '#' as the start of a comment and would set this to empty.
 # icon-gen prepends '#' itself.
 ge/APP_ICON_BG_COLOR       ?= FFFFFF
@@ -587,7 +587,7 @@ ge/app-icons: $(ge/ICON_GEN) $(ge/APP_ICON_SVG)
 # Tests link against libge.a, so they have access to all engine headers
 # and engine-defined classes. The runner reaches into bgfx/SDL only at
 # link time (libge.a's references resolve through them); the tests
-# themselves don't initialise bgfx, so they're side-effect free.
+# themselves don't initialize bgfx, so they're side-effect free.
 # ────────────────────────────────────────────────
 
 ge/TEST_BIN = bin/ge-test
@@ -790,7 +790,7 @@ ged-test:
 # Debug build
 #
 # `make ge/debug` builds bin/$(APP_NAME)-debug with assertions enabled,
-# debug symbols, and no optimisation.  The debug matrix cells exercise
+# debug symbols, and no optimization.  The debug matrix cells exercise
 # this binary rather than the default release binary.
 # ────────────────────────────────────────────────
 
@@ -903,7 +903,7 @@ ge/android-release: $(ge/APP_SHADERS_SPIRV) $(ge/RENDER_SHADERS_SPIRV) $(ge/APP_
 #
 # Parallelism:
 #   `make -j check` runs all cells concurrently. Cells targeting different
-#   devices run in parallel. Cells racing for the same device serialise via
+#   devices run in parallel. Cells racing for the same device serialize via
 #   spyder's reservation queue. Desktop cells are always concurrent.
 #   Same-platform cells (e.g. ios-sim-tablet-dist + ios-sim-tablet-player)
 #   resolve to distinct sims when two are available in the spyder pool.
@@ -962,7 +962,7 @@ ge/CHECK_CELLS := $(filter-out $(ge/CHECK_EXCLUDE_PATTERNS),$(ge/CELLS))
 # spyder resolve via selector predicates (--on platform=ios-sim,...).
 #
 # Cells targeting different devices run concurrently under parallel make.
-# Cells racing for the same device serialise via spyder's reservation queue.
+# Cells racing for the same device serialize via spyder's reservation queue.
 .PHONY: $(addprefix cell.,$(ge/CELLS))
 cell.desktop-dist:               ; $(ge)/tools/matrix-cell.sh desktop-dist --soak-timeout $(SOAK_TIMEOUT)
 cell.desktop-player:             ; $(ge)/tools/matrix-cell.sh desktop-player --soak-timeout $(SOAK_TIMEOUT)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rendering and asset engine for Dawn (WebGPU) + SDL3 applications. Provides RAII 
 - [spdlog](https://github.com/gabime/spdlog) — Logging (header-only)
 - [linalg.h](https://github.com/sgorsten/linalg) — Linear algebra (header-only)
 - [doctest](https://github.com/doctest/doctest) — Testing (header-only)
-- [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) — Constrained Delaunay triangulation *(opt-in only; not linked into `libge.a`. Non-commercial licence — see [`NOTICES.md`](NOTICES.md#triangle-j-r-shewchuk) before shipping in a paid product.)*
+- [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) — Constrained Delaunay triangulation *(opt-in only; not linked into `libge.a`. Non-commercial license — see [`NOTICES.md`](NOTICES.md#triangle-j-r-shewchuk) before shipping in a paid product.)*
 
 Dependencies live in `vendor/` as git submodules or vendored sources.
 

--- a/include/ge/FrameLog.h
+++ b/include/ge/FrameLog.h
@@ -26,11 +26,11 @@ struct FrameLog {
     bool running = true;
     std::thread dumper;
 
-    FrameLog(AnalyseFn analyse, int reserveSize = 4096)
+    FrameLog(AnalyseFn analyze, int reserveSize = 4096)
         : freq(SDL_GetPerformanceFrequency()) {
         buffers[0].reserve(reserveSize);
         buffers[1].reserve(reserveSize);
-        dumper = std::thread([this, analyse] {
+        dumper = std::thread([this, analyze] {
             while (running) {
                 SDL_Delay(2000);
                 std::vector<Entry>* readBuf;
@@ -40,7 +40,7 @@ struct FrameLog {
                     writeIdx = 1 - writeIdx;
                 }
                 if (!readBuf->empty()) {
-                    analyse(*readBuf, freq);
+                    analyze(*readBuf, freq);
                     readBuf->clear();
                 }
             }

--- a/include/ge/Protocol.h
+++ b/include/ge/Protocol.h
@@ -80,7 +80,7 @@ constexpr uint8_t kSensorAccelerometer = 1;
 //
 // CAVEAT (v0.3.0): playerForceOrientation() treats this field as a
 // boolean — any non-zero value enables the iPad orientation lock; the
-// SPECIFIC constant is not honoured at runtime. The orientation that
+// SPECIFIC constant is not honored at runtime. The orientation that
 // gets locked is whichever one iOS picked at launch, constrained by
 // the app bundle's UISupportedInterfaceOrientations in Info.plist.
 //
@@ -92,7 +92,7 @@ constexpr uint8_t kSensorAccelerometer = 1;
 // Setting kOrientationLandscape vs kOrientationLandscapeFlipped today
 // is a no-op difference; both are simply "non-zero, lock please."
 //
-// 🎯T36 tracks aligning the API with its behaviour (either collapse to
+// 🎯T36 tracks aligning the API with its behavior (either collapse to
 // a boolean field, or make these constants authoritative by having the
 // engine narrow supportedInterfaceOrientations at runtime).
 constexpr uint8_t kOrientationLandscape        = SDL_ORIENTATION_LANDSCAPE;

--- a/include/ge/RenderHost.h
+++ b/include/ge/RenderHost.h
@@ -68,7 +68,7 @@ public:
     virtual void beginFrame() = 0;
     virtual void endFrame(uint32_t bgfxFrameNumber) = 0;
 
-    // True when the render subsystem has signalled shutdown (window close,
+    // True when the render subsystem has signaled shutdown (window close,
     // wire closed, SIGINT, etc.).
     virtual bool shouldQuit() const = 0;
 
@@ -94,7 +94,7 @@ public:
     // stay out of Context construction.
     //
     // Valid once the host is ready — DirectRenderHost from
-    // construction; ServerWireBridge after initialise() (which the
+    // construction; ServerWireBridge after initialize() (which the
     // run loop calls when DeviceInfo arrives).
     virtual const Context& context() const = 0;
 };

--- a/include/ge/Resource.h
+++ b/include/ge/Resource.h
@@ -15,7 +15,7 @@ std::string resource(const std::string& relativePath);
 //   * Apple platforms (Metal)             → "build/shaders"
 //   * Android (Vulkan, on emulator)       → "build/shaders-spirv"
 //   * Android (OpenGL ES, real devices)   → "build/shaders-gles"
-// Must be called AFTER bgfx is initialised (BgfxContext constructed).
+// Must be called AFTER bgfx is initialized (BgfxContext constructed).
 std::string shaderDir();
 
 // Same as shaderDir() but for ge's internal compose-pass shaders, which

--- a/include/ge/SessionHost.h
+++ b/include/ge/SessionHost.h
@@ -65,9 +65,10 @@ struct Rect {
     la::float2 bl() const { return {x,     y + h}; }
     la::float2 br() const { return {x + w, y + h}; }
 
-    // Size and centre helpers.
-    la::float2 size()   const { return {w, h}; }
-    la::float2 center() const { return {x + w * 0.5f, y + h * 0.5f}; }
+    // Size and center helpers.
+    la::float2 size()        const { return {w, h}; }
+    la::float2 halfExtents() const { return {w * 0.5f, h * 0.5f}; }
+    la::float2 center()      const { return {x + w * 0.5f, y + h * 0.5f}; }
 
     // Empty when w or h is non-positive. Empty rects are "no area" —
     // they intersect nothing and are absorbed by `unioned`.
@@ -103,11 +104,41 @@ struct Rect {
     Rect inset(float dx, float dy) const {
         return Rect{x + dx, y + dy, w - 2 * dx, h - 2 * dy};
     }
+    // Symmetric inset — equivalent to inset(d, d). Reads cleaner at
+    // call sites where a single border thickness is shrunk on all sides.
+    Rect inset(float d) const { return inset(d, d); }
     // Shrink by per-edge safe-area insets.
     Rect inset(const SafeAreaInsets& s) const;
+
+    // Outset (grow). Equivalent to inset(-dx, -dy) / inset(-d) — sugar
+    // for the common case of expanding a rect by a border thickness.
+    Rect outset(float dx, float dy) const { return inset(-dx, -dy); }
+    Rect outset(float d)            const { return inset(-d); }
+
     // Translated copy.
     Rect translated(la::float2 d) const {
         return Rect{x + d.x, y + d.y, w, h};
+    }
+
+    // Uniform scale of all four fields. Useful for converting between
+    // coordinate systems related by a single scalar (e.g. pixel-rect to
+    // normalized UV: `pixelRect / atlasSize`).
+    Rect operator*(float s) const { return Rect{x * s, y * s, w * s, h * s}; }
+    Rect operator/(float s) const { return Rect{x / s, y / s, w / s, h / s}; }
+
+    // Factory: rect of size `sz` whose center is at `c`.
+    static Rect centered(la::float2 c, la::float2 sz) {
+        return Rect{c.x - sz.x * 0.5f, c.y - sz.y * 0.5f, sz.x, sz.y};
+    }
+
+    // Factory: smallest axis-aligned rect containing both points. Order
+    // of `a`, `b` does not matter; w / h are always non-negative.
+    static Rect between(la::float2 a, la::float2 b) {
+        const float lx = a.x < b.x ? a.x : b.x;
+        const float rx = a.x < b.x ? b.x : a.x;
+        const float ty = a.y < b.y ? a.y : b.y;
+        const float by = a.y < b.y ? b.y : a.y;
+        return Rect{lx, ty, rx - lx, by - ty};
     }
 };
 

--- a/include/ge/png.h
+++ b/include/ge/png.h
@@ -19,7 +19,7 @@ namespace ge {
 //
 // On failure (file missing, unsupported format, OOM), returns a null
 // `Sprite` and logs the error via `spdlog::error`. `bgfx` must be
-// initialised before calling.
+// initialized before calling.
 Sprite loadImage(const std::string& path);
 
 } // namespace ge

--- a/include/ge/sprite.h
+++ b/include/ge/sprite.h
@@ -56,8 +56,8 @@ struct Sprite {
 // `src/render/shaders/ge_sprite_{vs,fs}.sc`).
 struct SpriteVertex {
     float    x, y, z;   // position in whatever space the caller is in
-    float    u, v;      // texcoord (normalised 0..1)
-    uint32_t abgr;      // tint colour (ABGR byte order; 0xFFFFFFFF for none)
+    float    u, v;      // texcoord (normalized 0..1)
+    uint32_t abgr;      // tint color (ABGR byte order; 0xFFFFFFFF for none)
 };
 
 // Batched sprite renderer. Each `addSprite` queues a quad transformed
@@ -94,7 +94,7 @@ public:
                    uint32_t color = 0xFFFFFFFFu);
 
     // As above, but with a UV sub-rect for atlasing. `uvSubRect` is in
-    // normalised UV space (0..1)²; the unit-square model corners then
+    // normalized UV space (0..1)²; the unit-square model corners then
     // sample from that sub-window of the source texture.
     void addSprite(const la::float4x4& modelToWorld,
                    const Sprite& sprite,
@@ -106,7 +106,7 @@ public:
     void submit(bgfx::ViewId view);
 
     // Internal quad record — public so test helpers can inspect geometry
-    // without bgfx initialisation.
+    // without bgfx initialization.
     struct Quad {
         bgfx::TextureHandle tex;
         SpriteVertex        verts[6];  // two triangles
@@ -118,7 +118,7 @@ private:
     std::vector<Quad> quads_;
     uint64_t          blendState_;
 
-    // Lazy-initialised bgfx resources (program + sampler + layout).
+    // Lazy-initialized bgfx resources (program + sampler + layout).
     bool ensureState();
 };
 

--- a/include/ge/text.h
+++ b/include/ge/text.h
@@ -31,7 +31,7 @@ struct TextPixels {
 //             premultiplied: `out_rgb = color.rgb * alpha * glyph_alpha`,
 //             `out_a       = color.a * glyph_alpha`.
 //
-// Single line; no wrapping or kerning. Basic ASCII Latin; behaviour for
+// Single line; no wrapping or kerning. Basic ASCII Latin; behavior for
 // codepoints > 127 depends on the font's glyph coverage.
 //
 // Empty TextPixels on failure with a logged error.

--- a/sample/tiltbuggy/icons/icon.svg
+++ b/sample/tiltbuggy/icons/icon.svg
@@ -61,7 +61,7 @@
 
   <!-- Yellow buggy, tilted — sits over the pond at a jaunty angle.
        Chassis is rotated 12°; the rotation pivot is (510, 540) to keep
-       the buggy body roughly centred on the pond. -->
+       the buggy body roughly centered on the pond. -->
   <g transform="rotate(-12 510 540)">
     <!-- shadow -->
     <ellipse cx="510" cy="610" rx="180" ry="22" fill="#000000" fill-opacity="0.25"/>

--- a/sample/tiltbuggy/src/Renderer.cpp
+++ b/sample/tiltbuggy/src/Renderer.cpp
@@ -140,34 +140,38 @@ bgfx::ShaderHandle loadShader(const char* shaderDir, const char* name) {
 }
 
 // Append two triangles forming an axis-aligned rect (world space).
-void pushRect(std::vector<PosColorVertex>& verts,
-              float l, float t, float r, float b,
-              uint32_t abgr) {
-    verts.push_back({l, t, 0.0f, abgr});
-    verts.push_back({r, t, 0.0f, abgr});
-    verts.push_back({r, b, 0.0f, abgr});
-    verts.push_back({l, t, 0.0f, abgr});
-    verts.push_back({r, b, 0.0f, abgr});
-    verts.push_back({l, b, 0.0f, abgr});
+void pushRect(std::vector<PosColorVertex>& verts, ge::Rect r, uint32_t abgr) {
+    const float x0 = r.x;
+    const float x1 = r.x + r.w;
+    const float y0 = r.y;
+    const float y1 = r.y + r.h;
+    verts.push_back({x0, y1, 0.0f, abgr});
+    verts.push_back({x1, y1, 0.0f, abgr});
+    verts.push_back({x1, y0, 0.0f, abgr});
+    verts.push_back({x0, y1, 0.0f, abgr});
+    verts.push_back({x1, y0, 0.0f, abgr});
+    verts.push_back({x0, y0, 0.0f, abgr});
 }
 
-// Append two triangles forming a rotated rect centred at (cx,cy).
+// Append two triangles forming a rotated rect: the AABB `rect` rotated by
+// `angle` around its centre.
 void pushRotatedRect(std::vector<PosColorVertex>& verts,
-                     float cx, float cy, float hw, float hh,
-                     float angle, uint32_t abgr) {
+                     ge::Rect rect, float angle, uint32_t abgr) {
     const float c = std::cos(angle);
     const float s = std::sin(angle);
+    const auto  centre = rect.center();
+    const float hw = rect.w * 0.5f;
+    const float hh = rect.h * 0.5f;
     // Four corners in local space: (±hw, ±hh)
-    float lx[4] = { -hw,  hw,  hw, -hw };
-    float ly[4] = { -hh, -hh,  hh,  hh };
+    const float lx[4] = { -hw,  hw,  hw, -hw };
+    const float ly[4] = { -hh, -hh,  hh,  hh };
     PosColorVertex v[4];
     for (int i = 0; i < 4; ++i) {
-        v[i].x    = cx + lx[i] * c - ly[i] * s;
-        v[i].y    = cy + lx[i] * s + ly[i] * c;
+        v[i].x    = centre.x + lx[i] * c - ly[i] * s;
+        v[i].y    = centre.y + lx[i] * s + ly[i] * c;
         v[i].z    = 0.0f;
         v[i].abgr = abgr;
     }
-    // Two triangles: 0-1-2, 0-2-3
     verts.push_back(v[0]); verts.push_back(v[1]); verts.push_back(v[2]);
     verts.push_back(v[0]); verts.push_back(v[2]); verts.push_back(v[3]);
 }
@@ -255,25 +259,25 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
     // Brown playfield placed at c.drawSafeRect() — tiltbuggy is touch-
     // free, so the maze can extend into gesture zones (the wider rect).
     // World maps [-orthoW, +orthoW] to [0, surf.w] in pixels.
-    auto rect = c.drawSafeRect();
+    auto safeRect = c.drawSafeRect();
     const float pxToWorldX = (surf.w > 0) ? (2.f * orthoW / float(surf.w)) : 0.f;
     const float pxToWorldY = (surf.h > 0) ? (2.f * orthoH / float(surf.h)) : 0.f;
-    const float bgL = -orthoW + rect.x            * pxToWorldX;
-    const float bgR = -orthoW + (rect.x + rect.w) * pxToWorldX;
-    const float bgT =  orthoH - rect.y            * pxToWorldY;
-    const float bgB =  orthoH - (rect.y + rect.h) * pxToWorldY;
-    pushRect(verts, bgL, bgB, bgR, bgT, rgb(0xAA, 0x66, 0x44));
+    const float bgL = -orthoW + safeRect.x                * pxToWorldX;
+    const float bgR = -orthoW + (safeRect.x + safeRect.w) * pxToWorldX;
+    const float bgB =  orthoH - (safeRect.y + safeRect.h) * pxToWorldY;
+    const float bgT =  orthoH - safeRect.y                * pxToWorldY;
+    pushRect(verts, ge::Rect{bgL, bgB, bgR - bgL, bgT - bgB}, rgb(0xAA, 0x66, 0x44));
 
     // 2. Surface rects (excluding ice — drawn as a textured sprite below).
-    for (const auto& surf : scene.surfaces()) {
+    for (const auto& s : scene.surfaces()) {
         uint32_t color;
-        switch (surf.type) {
+        switch (s.type) {
             case SurfaceType::Ice:     continue;  // see ice-sprite pass below
             case SurfaceType::Dirt:    color = rgb(0xAA, 0x66, 0x44); break;
             case SurfaceType::Asphalt: continue;
             default:                   continue;
         }
-        pushRect(verts, surf.l, surf.b, surf.r, surf.t, color);
+        pushRect(verts, s.rect, color);
     }
 
     // 3. Buggy — sized in proportion to the world (kept at 1/20 of the
@@ -283,8 +287,7 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
     const float hw = scene.halfExtent() * 0.05f;
     const float hh = hw * 0.5f;
     pushRotatedRect(verts,
-        pose.x, pose.y,
-        hw, hh,
+        ge::Rect{pose.x - hw, pose.y - hh, 2.f * hw, 2.f * hh},
         pose.angle,
         rgb(0xFF, 0xCC, 0x33));
 
@@ -312,15 +315,20 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
     // TOP (larger y) and `h` is NEGATIVE, flipping the y basis so the
     // sprite's source-image top lands at world top.
     if (!i_->pond.isNull()) {
-        for (const auto& surf : scene.surfaces()) {
-            if (surf.type != SurfaceType::Ice) continue;
-            const float pw = (surf.r - surf.l) * 0.125f;
-            const float ph = (surf.t - surf.b) * 0.125f;
+        for (const auto& s : scene.surfaces()) {
+            if (s.type != SurfaceType::Ice) continue;
+            // Inflate 25% so the irregular bezier border has visible overhang
+            // past the (rectangular) collision area.
+            const float pw = s.rect.w * 0.125f;
+            const float ph = s.rect.h * 0.125f;
+            // y-up: rect.y is the bottom edge in scene's y-up world. To put the
+            // sprite top-down upright on screen, frame() needs y at the TOP
+            // (larger world y) and h NEGATIVE (basis points toward smaller y).
             const auto m = ge::frame(ge::Rect{
-                surf.l - pw,
-                surf.t + ph,                          // y = TOP in y-up
-                (surf.r - surf.l) + 2.f * pw,
-                -((surf.t - surf.b) + 2.f * ph),      // h NEGATIVE for y-up
+                s.rect.x - pw,
+                s.rect.y + s.rect.h + ph,        // top in y-up = bottom + height
+                s.rect.w + 2.f * pw,
+                -(s.rect.h + 2.f * ph),           // negative for y-up
             });
             bgfx::setTransform(&m[0][0]);
             i_->pond.draw(0);

--- a/sample/tiltbuggy/src/Renderer.cpp
+++ b/sample/tiltbuggy/src/Renderer.cpp
@@ -215,7 +215,7 @@ void Renderer::init(const char* shaderDir) {
 
 void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
                          float /*tiltX*/, float /*tiltY*/) {
-    // The host's composite pass applies viewport tilt (when synthesised
+    // The host's composite pass applies viewport tilt (when synthesized
     // tilt is non-zero). The game just renders a flat top-down view.
     auto surf = c.fullRect();
     bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(surf.w),
@@ -305,7 +305,7 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
     bgfx::setState(BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A);
     bgfx::submit(0, i_->program);
 
-    // Ice-sprite pass — drawn after the colour batch so the pond sits on top
+    // Ice-sprite pass — drawn after the color batch so the pond sits on top
     // of the dirt/background. Each ice surface gets a copy of the same
     // SVG-rasterized texture, inflated 25% past the collision rect so the
     // irregular bezier border has visible overhang past where the friction

--- a/sample/tiltbuggy/src/Renderer.h
+++ b/sample/tiltbuggy/src/Renderer.h
@@ -17,7 +17,7 @@ public:
     Renderer(const Renderer&) = delete;
     Renderer& operator=(const Renderer&) = delete;
 
-    // Called once after bgfx is initialised. `shaderDir` is the directory
+    // Called once after bgfx is initialized. `shaderDir` is the directory
     // containing compiled `.bin` files (e.g. "build/shaders").
     void init(const char* shaderDir);
 
@@ -26,8 +26,8 @@ public:
     // `c.drawSafeRect()` (display-cutout-safe — visuals here aren't
     // physically obscured) and the renderer is free to draw anywhere
     // on `c.fullRect()` for effects that bleed past it.
-    // `tiltX` / `tiltY` are normalised (~[-1, +1]) device tilt; the
-    // host's composite pass applies viewport tilt when synthesised
+    // `tiltX` / `tiltY` are normalized (~[-1, +1]) device tilt; the
+    // host's composite pass applies viewport tilt when synthesized
     // tilt is non-zero. Pass (0, 0) for a flat top-down view.
     void drawFrame(const Scene& scene, const ge::Context& c,
                    float tiltX = 0.f, float tiltY = 0.f);

--- a/sample/tiltbuggy/src/Scene.cpp
+++ b/sample/tiltbuggy/src/Scene.cpp
@@ -32,8 +32,9 @@ struct Scene::Impl {
     b2ShapeId dirtShapeId;
 
     // Remembered surface bounds for surfaces()
-    float iceL, iceT, iceR, iceB;
-    float dirtL, dirtT, dirtR, dirtB;
+    // y-up world rects: x = left, y = bottom (smaller y), w/h positive.
+    ge::Rect iceRect;
+    ge::Rect dirtRect;
 
     explicit Impl(float halfExtent_) : halfExtent(halfExtent_) {
         // ------------------------------------------------------------------
@@ -101,27 +102,24 @@ struct Scene::Impl {
         // ------------------------------------------------------------------
 
         // Ice patch: upper-centre — sized at 1/16 of the original layout.
-        iceL = -0.1875f; iceB = 0.125f; iceR = 0.1875f; iceT = 0.375f;
+        iceRect = ge::Rect{-0.1875f, 0.125f, 0.375f, 0.25f};
         {
-            float hw = (iceR - iceL) * 0.5f;
-            float hh = (iceT - iceB) * 0.5f;
-            b2Vec2 centre = {(iceL + iceR) * 0.5f, (iceB + iceT) * 0.5f};
-            b2Polygon box = b2MakeOffsetBox(hw, hh, centre, b2Rot_identity);
+            const float hw = iceRect.w * 0.5f;
+            const float hh = iceRect.h * 0.5f;
+            const auto centre = iceRect.center();
+            b2Polygon box = b2MakeOffsetBox(hw, hh, b2Vec2{centre.x, centre.y}, b2Rot_identity);
             b2ShapeDef sdef = b2DefaultShapeDef();
             sdef.isSensor = true;
             iceShapeId = b2CreatePolygonShape(groundId, &sdef, &box);
         }
 
-        // Dirt patch: left strip, x∈[-halfExtent, -halfExtent/2], y∈[-halfExtent, halfExtent]
-        dirtL = -halfExtent;
-        dirtB = -halfExtent;
-        dirtR = -halfExtent * 0.5f;
-        dirtT =  halfExtent;
+        // Dirt patch: left strip, x ∈ [-halfExtent, -halfExtent/2], y ∈ [-halfExtent, halfExtent]
+        dirtRect = ge::Rect{-halfExtent, -halfExtent, halfExtent * 0.5f, 2.f * halfExtent};
         {
-            float hw = (dirtR - dirtL) * 0.5f;
-            float hh = (dirtT - dirtB) * 0.5f;
-            b2Vec2 centre = {(dirtL + dirtR) * 0.5f, (dirtB + dirtT) * 0.5f};
-            b2Polygon box = b2MakeOffsetBox(hw, hh, centre, b2Rot_identity);
+            const float hw = dirtRect.w * 0.5f;
+            const float hh = dirtRect.h * 0.5f;
+            const auto centre = dirtRect.center();
+            b2Polygon box = b2MakeOffsetBox(hw, hh, b2Vec2{centre.x, centre.y}, b2Rot_identity);
             b2ShapeDef sdef = b2DefaultShapeDef();
             sdef.isSensor = true;
             dirtShapeId = b2CreatePolygonShape(groundId, &sdef, &box);
@@ -160,8 +158,8 @@ float Scene::halfExtent() const {
 
 std::vector<Surface> Scene::surfaces() const {
     return {
-        { i_->iceL,  i_->iceT,  i_->iceR,  i_->iceB,  SurfaceType::Ice  },
-        { i_->dirtL, i_->dirtT, i_->dirtR, i_->dirtB, SurfaceType::Dirt },
+        { i_->iceRect,  SurfaceType::Ice  },
+        { i_->dirtRect, SurfaceType::Dirt },
     };
 }
 

--- a/sample/tiltbuggy/src/Scene.cpp
+++ b/sample/tiltbuggy/src/Scene.cpp
@@ -143,7 +143,7 @@ void Scene::step(float dt, b2Vec2 gravity) {
     b2World_Step(i_->worldId, dt, 4);
     // Arcade vehicle dynamics + surface effects temporarily disabled
     // so the buggy moves as a free-floating body — easier to diagnose
-    // tilt-input behaviour. Re-enable after viewport tilt is dialled in.
+    // tilt-input behavior. Re-enable after viewport tilt is dialled in.
 }
 
 Pose Scene::buggyPose() const {

--- a/sample/tiltbuggy/src/Scene.h
+++ b/sample/tiltbuggy/src/Scene.h
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <ge/SessionHost.h>  // ge::Rect
+
 #include <box2d/box2d.h>
 #include <memory>
 #include <vector>
@@ -13,7 +15,9 @@ struct Pose { float x, y, angle; };
 
 enum class SurfaceType { Asphalt, Ice, Dirt };
 struct Surface {
-    float l, t, r, b;   // AABB in world coords, y-up
+    // AABB in world coords (y-up): rect.x = left, rect.y = bottom (smaller y),
+    // rect.w / rect.h positive.
+    ge::Rect    rect;
     SurfaceType type;
 };
 

--- a/sample/tiltcal/Makefile
+++ b/sample/tiltcal/Makefile
@@ -1,7 +1,7 @@
 # TiltCal — accelerometer calibration sample.
 #
 # Quick & dirty: single-source app that reads SDL3's accelerometer and
-# logs each pose's reading. Used to characterise the SDL3 sensor
+# logs each pose's reading. Used to characterize the SDL3 sensor
 # contract on iOS / iPadOS / Android.
 
 ge := ../..

--- a/src/CutoutInsets_android.cpp
+++ b/src/CutoutInsets_android.cpp
@@ -5,7 +5,7 @@
 // Activity exposes `int[] getDisplayCutoutInsets()` returning
 // {left, right, top, bottom} populated from
 // WindowInsets.Type.displayCutout() in an OnApplyWindowInsetsListener.
-// If the activity doesn't define the method (apps that customise their
+// If the activity doesn't define the method (apps that customize their
 // activity from the ge template), we return zeros.
 
 #include "CutoutInsets.h"

--- a/src/Rect_test.cpp
+++ b/src/Rect_test.cpp
@@ -117,3 +117,88 @@ TEST_CASE("Rect equality is field-wise") {
     CHECK(a == b);
     CHECK(a != c);
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Enrichments — operator*/operator/, centered/between factories,
+// halfExtents, single-arg inset, outset.
+// ─────────────────────────────────────────────────────────────────────
+
+TEST_CASE("Rect halfExtents is half of size") {
+    Rect r{10, 20, 30, 40};
+    CHECK(r.halfExtents().x == 15.0f);
+    CHECK(r.halfExtents().y == 20.0f);
+}
+
+TEST_CASE("Rect operator*(float) scales all four fields uniformly") {
+    Rect r{2, 4, 6, 8};
+    Rect s = r * 0.5f;
+    CHECK(s.x == 1.0f);
+    CHECK(s.y == 2.0f);
+    CHECK(s.w == 3.0f);
+    CHECK(s.h == 4.0f);
+}
+
+TEST_CASE("Rect operator/(float) is the reciprocal of operator*") {
+    Rect r{16, 32, 64, 128};
+    Rect s = r / 16.0f;
+    CHECK(s.x == 1.0f);
+    CHECK(s.y == 2.0f);
+    CHECK(s.w == 4.0f);
+    CHECK(s.h == 8.0f);
+}
+
+TEST_CASE("Rect operator* and operator/ round-trip") {
+    Rect r{3, 7, 11, 13};
+    Rect roundtrip = (r * 4.5f) / 4.5f;
+    CHECK(roundtrip == r);
+}
+
+TEST_CASE("Rect::centered builds a rect of given size at given center") {
+    Rect r = Rect::centered({100, 50}, {40, 20});
+    CHECK(r.x == 80.0f);
+    CHECK(r.y == 40.0f);
+    CHECK(r.w == 40.0f);
+    CHECK(r.h == 20.0f);
+    // Round-trip: center() returns the original center.
+    CHECK(r.center().x == 100.0f);
+    CHECK(r.center().y == 50.0f);
+}
+
+TEST_CASE("Rect::between is order-independent and produces non-negative size") {
+    Rect r1 = Rect::between({10, 20}, {30, 50});
+    Rect r2 = Rect::between({30, 50}, {10, 20});
+    CHECK(r1 == r2);
+    CHECK(r1.x == 10.0f);
+    CHECK(r1.y == 20.0f);
+    CHECK(r1.w == 20.0f);
+    CHECK(r1.h == 30.0f);
+}
+
+TEST_CASE("Rect::between with diagonal points still yields positive w/h") {
+    Rect r = Rect::between({50, 10}, {10, 50});
+    CHECK(r.x == 10.0f);
+    CHECK(r.y == 10.0f);
+    CHECK(r.w == 40.0f);
+    CHECK(r.h == 40.0f);
+}
+
+TEST_CASE("Rect::inset(d) is symmetric inset(d, d)") {
+    Rect r{10, 20, 100, 80};
+    CHECK(r.inset(5.0f) == r.inset(5.0f, 5.0f));
+    Rect inner = r.inset(5.0f);
+    CHECK(inner.x == 15.0f);
+    CHECK(inner.y == 25.0f);
+    CHECK(inner.w == 90.0f);
+    CHECK(inner.h == 70.0f);
+}
+
+TEST_CASE("Rect::outset is the antonym of inset") {
+    Rect r{10, 20, 100, 80};
+    CHECK(r.outset(5.0f)        == r.inset(-5.0f));
+    CHECK(r.outset(3.0f, 7.0f)  == r.inset(-3.0f, -7.0f));
+    Rect bigger = r.outset(5.0f);
+    CHECK(bigger.x == 5.0f);
+    CHECK(bigger.y == 15.0f);
+    CHECK(bigger.w == 110.0f);
+    CHECK(bigger.h == 90.0f);
+}

--- a/src/bridge/ServerWireBridge.h
+++ b/src/bridge/ServerWireBridge.h
@@ -40,19 +40,19 @@ public:
     ServerWireBridge& operator=(const ServerWireBridge&) = delete;
 
     // Drain wire messages. On DeviceInfo arrival, dimensions become valid
-    // (caller should then call initialise()). On later SDL events, invokes
+    // (caller should then call initialize()). On later SDL events, invokes
     // the registered handler. Returns false if the wire is closed.
     bool pumpWire();
 
     // True after DeviceInfo arrives — width()/height() are valid; capture
-    // can be initialised. False before that.
+    // can be initialized. False before that.
     bool hasDimensions() const;
 
-    // Initialise capture framebuffer + encoder. Caller must have inited
+    // Initialize capture framebuffer + encoder. Caller must have inited
     // bgfx first. After this call, isReady() returns true.
-    void initialise();
+    void initialize();
 
-    // True after initialise() — ready to render.
+    // True after initialize() — ready to render.
     bool isReady() const;
 
     const std::string& id() const;

--- a/src/bridge/ServerWireBridge.mm
+++ b/src/bridge/ServerWireBridge.mm
@@ -46,7 +46,7 @@ struct ServerWireBridge::Impl {
     bool dimensionsKnown = false;
     bool ready = false;
 
-    // Session Context: built once dimensions arrive (in initialise),
+    // Session Context: built once dimensions arrive (in initialize),
     // refreshed each beginFrame. Brokered db is in-memory — persistence
     // is owned by the player and synced via sqlpipe.
     std::optional<Context> ctx;
@@ -193,7 +193,7 @@ void ServerWireBridge::pumpEvents() {
     pumpWire();
 }
 
-void ServerWireBridge::initialise() {
+void ServerWireBridge::initialize() {
     if (!i_->dimensionsKnown) return;
 
     i_->renderTex = bgfx::createTexture2D(

--- a/src/bridge/SessionHost_brokered.mm
+++ b/src/bridge/SessionHost_brokered.mm
@@ -169,7 +169,7 @@ void runBrokered(Factory factory, const SessionHostConfig& config) {
                     SPDLOG_INFO("bgfx initialized at {}x{}",
                                 bs.bridge->width(), bs.bridge->height());
                 }
-                bs.bridge->initialise();
+                bs.bridge->initialize();
                 bs.config = factory(bs.bridge->context());
                 bs.bridge->setEventHandler(bs.config.onEvent);
             }

--- a/src/bridge/VideoDecoder_android.cpp
+++ b/src/bridge/VideoDecoder_android.cpp
@@ -221,7 +221,7 @@ void VideoDecoder::M::deliverFrame(uint8_t* buf, size_t bufSize,
     // We always request NV12 at configure time. Some devices nonetheless
     // return BGRA; detect by buffer size and forward in either format
     // without conversion — the renderer (SDL_PIXELFORMAT_NV12 /
-    // SDL_PIXELFORMAT_BGRA32) handles colour-space conversion on the GPU.
+    // SDL_PIXELFORMAT_BGRA32) handles color-space conversion on the GPU.
     const size_t expectedBgra = static_cast<size_t>(width) * height * 4;
     const size_t expectedNv12 = static_cast<size_t>(width) * height * 3 / 2;
     const size_t frameBytes   = static_cast<size_t>(info.size);

--- a/src/bridge/WebSocketClient.cpp
+++ b/src/bridge/WebSocketClient.cpp
@@ -274,7 +274,7 @@ std::shared_ptr<WsConnection> connectWebSocket(
                 });
 
             timer.async_wait([&](const asio::error_code& ec) {
-                if (!ec) {  // timer expired (not cancelled)
+                if (!ec) {  // timer expired (not canceled)
                     timedOut = true;
                     socket.close();
                 }

--- a/src/png_test.cpp
+++ b/src/png_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE("loadImage premul: premultiplied invariant R <= A holds") {
 // ─────────────────────────────────────────────────────────────────────
 // SDL pixel round-trip: load a minimal in-memory PNG and verify that
 // SDL_ConvertSurface + premultiplication produces the expected bytes.
-// bgfx is NOT initialised in this test binary, so we test only the
+// bgfx is NOT initialized in this test binary, so we test only the
 // SDL/pixel layer — not the bgfx::createTexture2D call.
 // ─────────────────────────────────────────────────────────────────────
 

--- a/src/render/AccelSynth.h
+++ b/src/render/AccelSynth.h
@@ -1,7 +1,7 @@
 // Copyright 2026 Marcelo Cantos
 // SPDX-License-Identifier: Apache-2.0
 //
-// AccelSynth — synthesise SDL_EVENT_SENSOR_UPDATE events from Shift-gated
+// AccelSynth — synthesize SDL_EVENT_SENSOR_UPDATE events from Shift-gated
 // mouse motion when no real accelerometer is available (desktop, iOS
 // simulator, Android emulator).
 //
@@ -123,7 +123,7 @@ public:
     //
     // On TARGET_OS_SIMULATOR with GE_ACCELSYNTH_AUTODRIVE=1: drives a
     // synthetic 100-pixel X tilt for 2 s then triggers easing. The autodrive
-    // state is initialised on the first update() call (checked once via
+    // state is initialized on the first update() call (checked once via
     // autodriveChecked_).
     void update() {
 #if defined(__APPLE__) && TARGET_OS_SIMULATOR

--- a/src/render/DirectRenderHost.mm
+++ b/src/render/DirectRenderHost.mm
@@ -140,7 +140,7 @@ bgfx::VertexLayout composeLayout() {
 // The rotation is keyed on the LIVE display orientation reported by SDL
 // (SDL_GetCurrentDisplayOrientation) — not on SessionConfig.orientation,
 // which only records what the app *requested*. The live value reflects
-// what the OS actually rotated to (post-lock-if-honoured, or the live
+// what the OS actually rotated to (post-lock-if-honored, or the live
 // rotation when no lock was requested), so this stays correct in both
 // locked and free-orientation modes and across the brief window between
 // a lock request and the OS settling.
@@ -668,7 +668,7 @@ la::float2 DirectRenderHost::updateParallax() {
     }
     // Quaternion EMA: with α small the result stays close to a unit
     // quaternion, so plain componentwise lerp is fine — no slerp, no
-    // renormalisation needed (drift is self-correcting under
+    // renormalization needed (drift is self-correcting under
     // repeated blends toward unit-length samples).
     constexpr float kBaselineTau = 1.0f;  // seconds
     constexpr float kAssumedDt   = 1.0f / 60.0f;

--- a/src/render/PlayerRender.cpp
+++ b/src/render/PlayerRender.cpp
@@ -32,7 +32,7 @@ constexpr float kComposeCameraD = 2.0f;
 
 struct Mat3 { float m[9]; };  // row-major 3x3
 
-// Rodrigues' formula specialised for a rotation axis in the XY plane
+// Rodrigues' formula specialized for a rotation axis in the XY plane
 // (axZ = 0). Returns the 3x3 rotation matrix.
 Mat3 rotationXY(float axX, float axY, float angle) {
     const float c = std::cos(angle);

--- a/tools/android-template/app/build.gradle.in
+++ b/tools/android-template/app/build.gradle.in
@@ -45,7 +45,7 @@ android {
     // never copy the SDLActivity boilerplate) and the vendored SDL3
     // android-project. Drop 'src/main/java' from the list — the
     // template no longer scaffolds a per-app Activity.java; apps that
-    // genuinely need to customise behaviour subclass ge.GeActivity in
+    // genuinely need to customize behavior subclass ge.GeActivity in
     // their own java tree and add it back here.
     sourceSets {
         main {

--- a/tools/android/app/src/main/cpp/QRScanner_android.cpp
+++ b/tools/android/app/src/main/cpp/QRScanner_android.cpp
@@ -68,7 +68,7 @@ ScanResult scanQRCode() {
         env->ReleaseStringUTFChars(url, urlStr);
         SPDLOG_INFO("Scanned: {}:{}", result.host, result.port);
     } else {
-        SPDLOG_WARN("QR scan cancelled or failed");
+        SPDLOG_WARN("QR scan canceled or failed");
     }
 
     env->DeleteLocalRef(bridgeClass);

--- a/tools/icon-gen.cpp
+++ b/tools/icon-gen.cpp
@@ -19,9 +19,9 @@
 //   mipmap-{m,h,xh,xxh,xxxh}dpi/ic_launcher.png   legacy launcher (48..192 px)
 //   mipmap-{...}dpi/ic_launcher_round.png         round legacy variant (same content)
 //   drawable/ic_launcher_foreground.png           432×432 adaptive foreground
-//                                                  with master SVG centred in
+//                                                  with master SVG centered in
 //                                                  the 72dp safe zone (288 px)
-//   drawable/ic_launcher_background.xml           solid colour (--bg-color) or white
+//   drawable/ic_launcher_background.xml           solid color (--bg-color) or white
 //   mipmap-anydpi-v26/ic_launcher.xml             adaptive manifest
 //   mipmap-anydpi-v26/ic_launcher_round.xml       same, round variant
 //
@@ -130,7 +130,7 @@ bool rasterToPng(const std::string& svg, int size, const std::string& outPath) {
     return true;
 }
 
-// Render the master SVG centred in the 72dp safe zone of a 108dp canvas
+// Render the master SVG centered in the 72dp safe zone of a 108dp canvas
 // (canvasPx). Visible content occupies (72/108) × canvasPx ≈ 0.667 × canvasPx.
 bool rasterToAdaptiveForeground(const std::string& svg,
                                 int canvasPx,
@@ -145,7 +145,7 @@ bool rasterToAdaptiveForeground(const std::string& svg,
     unpremultiply(pixels.rgba);
 
     // Compose into a transparent canvasPx × canvasPx buffer with the inner
-    // image centred. Padding is fully transparent (rgba = 0,0,0,0).
+    // image centered. Padding is fully transparent (rgba = 0,0,0,0).
     std::vector<uint8_t> canvas(static_cast<size_t>(canvasPx) * canvasPx * 4, 0);
     const int offset = (canvasPx - innerPx) / 2;
     for (int y = 0; y < innerPx; ++y) {
@@ -180,7 +180,7 @@ const char* kAdaptiveIconXml = R"XML(<?xml version="1.0" encoding="utf-8"?>
 </adaptive-icon>
 )XML";
 
-// Normalise a colour string to '#RRGGBB' / '#AARRGGBB'. Empty input → white;
+// Normalize a color string to '#RRGGBB' / '#AARRGGBB'. Empty input → white;
 // missing leading '#' is added (Module.mk defaults strip it because Make
 // treats '#' as a comment).
 std::string normaliseColour(std::string in) {
@@ -238,7 +238,7 @@ bool generateAndroid(const std::string& svg,
         return false;
     }
 
-    // Adaptive background — solid colour drawable.
+    // Adaptive background — solid color drawable.
     if (!writeFile(resDir + "/drawable/ic_launcher_background.xml",
                    solidColourDrawableXml(bgHex))) {
         std::fprintf(stderr, "icon-gen: failed to write %s/drawable/ic_launcher_background.xml\n",

--- a/tools/init-android.sh
+++ b/tools/init-android.sh
@@ -31,7 +31,7 @@ CMAKE_PROJECT="$STRIPPED"
 # AndroidManifest.xml hardcodes android:name="ge.GeActivity" and
 # Gradle source-includes it from $GE_ROOT/android-shared. Apps no
 # longer scaffold a per-app Activity.java. Apps that need custom
-# behaviour subclass ge.GeActivity in their own java tree.
+# behavior subclass ge.GeActivity in their own java tree.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATE_DIR="$SCRIPT_DIR/android-template"

--- a/tools/ios/build-deps.sh
+++ b/tools/ios/build-deps.sh
@@ -55,7 +55,7 @@ build_sdl() {
     local DEST="$VENDOR/sdl3/lib/ios-arm64${SUFFIX}"
 
     if [ ! -e "$SDL_SRC/.git" ]; then
-        echo "ERROR: SDL submodule not initialised. Run:"
+        echo "ERROR: SDL submodule not initialized. Run:"
         echo "  cd ge && git submodule update --init vendor/github.com/libsdl-org/SDL"
         exit 1
     fi

--- a/tools/macos/build-deps.sh
+++ b/tools/macos/build-deps.sh
@@ -89,7 +89,7 @@ SDL_PREFIX="$BUILD/sdl3-prefix"
 SDL_DEST="$VENDOR/sdl3/lib/macos-arm64"
 
 if [ ! -e "$SDL_SRC/.git" ]; then
-    echo "ERROR: SDL submodule not initialised. Run:"
+    echo "ERROR: SDL submodule not initialized. Run:"
     echo "  cd sq && git submodule update --init vendor/github.com/libsdl-org/SDL"
     exit 1
 fi

--- a/tools/matrix-cell.sh
+++ b/tools/matrix-cell.sh
@@ -10,7 +10,7 @@
 # automatically acquires a spyder reservation before doing any device work
 # and releases it on exit. This makes concurrent cell execution safe: two
 # cells targeting different devices run in parallel; two cells racing for
-# the same device serialise via spyder's reservation queue.
+# the same device serialize via spyder's reservation queue.
 #
 # Usage:
 #   ge/tools/matrix-cell.sh <cell-name> [options]
@@ -50,7 +50,7 @@
 # Parallelism story (🎯T33.2):
 #   Cells that need a device are wrapped in `spyder run --device <alias>`.
 #   Two cells targeting different devices run concurrently. Two cells
-#   targeting the same device serialise — the second one retries up to 3×
+#   targeting the same device serialize — the second one retries up to 3×
 #   (10 s backoff) before failing (exit code 13 surfaced as a setup error).
 #   Desktop cells never need a reservation and always run concurrently.
 #
@@ -511,7 +511,7 @@ check_device_awake() {
             return "$DEVICE_ASLEEP_EXIT"
             ;;
         *)
-            warn_check "$subcheck" "unrecognised state='$state' — treating as no signal"
+            warn_check "$subcheck" "unrecognized state='$state' — treating as no signal"
             return 0
             ;;
     esac


### PR DESCRIPTION
## Summary

Release prep v0.16.0 — Rect enrichments + tiltbuggy rect refactor + British → US spelling sweep.

- 8 new `ge::Rect` inline helpers (operator* / operator/, centered, between factories, single-arg inset, outset, halfExtents) driven by audits across multimaze2 / esfera2 / yourworld2 / tiltbuggy.
- Tiltbuggy renderer + scene refactored to consume `ge::Rect` everywhere instead of l/t/r/b quartets.
- British → US spelling sweep across 33 source / doc files; NOTICES.md excluded.

## Test plan

- [x] `make unit-test` — 55 cases / 5791 assertions on macOS arm64 (was 46 before T51).
- [x] `make` — sample/tiltbuggy builds; pond + title + buggy still render correctly with the rect refactor (visually verified earlier in this session).
- [x] `make ge/icon-gen` — build-time tool still builds.
- [ ] Device test on Jevons / Minicades / Galaxy S21 Ultra / Galaxy Tab A9 — deferred; comment-only changes for most files, the only behavior-affecting code change is the rect-as-Rect refactor in tiltbuggy which does not alter runtime semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
