### PR TITLE
🎯T52: constexpr audit across ge's API surface; regression TU prevents drift

### DIFF
--- a/Module.mk
+++ b/Module.mk
@@ -259,6 +259,7 @@ ge/TEST_SRC = \
 	$(ge)/src/main_test.cpp \
 	$(ge)/src/DampedRotation_test.cpp \
 	$(ge)/src/Rect_test.cpp \
+	$(ge)/src/Rect_constexpr_test.cpp \
 	$(ge)/src/svg_test.cpp \
 	$(ge)/src/png_test.cpp \
 	$(ge)/src/text_test.cpp \

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1472,6 +1472,23 @@ targets:
     origin: discussed during T50 wrap-up; "would a new class add much value over lunasvg's API?" → "the whole concept bothers me — the matrix is the primitive" — 2026-05-10
     discovered: 2026-05-10
     achieved: 2026-05-10
+  T52:
+    name: All eligible ge API surface is constexpr, with regression tests preventing accidental loss
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - Every method, ctor, operator, and free function in ge's public API surface that can be constexpr is annotated constexpr.
+    - A regression test (Rect_constexpr_test.cpp + transform_constexpr_test.cpp or equivalent) exercises every constexpr API in a static_assert / consteval context, so removing constexpr from any of them breaks the build at the test TU.
+    - make unit-test passes (no runtime regressions).
+    - Sample app (sample/tiltbuggy) builds clean.
+    context: 'v0.19.0 reduced Rect to a small set of pure-arithmetic primitives — every Rect method is a candidate for constexpr. Same for ge::frame(Rect) in transform.h and any other math helpers. The regression test is the load-bearing piece: without it, future edits silently drop constexpr from individual methods and the property erodes.'
+    tags:
+    - api
+    - rect
+    - compile-time
+    origin: manual
+    discovered: 2026-05-10
   T6:
     name: Player can switch between active servers without QR
     status: identified

--- a/include/ge/DampedRotation.h
+++ b/include/ge/DampedRotation.h
@@ -11,14 +11,14 @@ using namespace linalg::aliases;
 // Stores orientation as a quaternion and angular velocity as a 3D vector.
 class DampedRotation {
 public:
-    DampedRotation(float damping = 0.90f) : damping_(damping) {}
+    constexpr DampedRotation(float damping = 0.90f) : damping_(damping) {}
 
-    const float4& orientation() const { return orientation_; }
-    const float3& angularVelocity() const { return angularVelocity_; }
+    constexpr const float4& orientation() const { return orientation_; }
+    constexpr const float3& angularVelocity() const { return angularVelocity_; }
 
-    void setOrientation(const float4& q) { orientation_ = q; }
-    void setAngularVelocity(const float3& v) { angularVelocity_ = v; }
-    void setDamping(float d) { damping_ = d; }
+    constexpr void setOrientation(const float4& q) { orientation_ = q; }
+    constexpr void setAngularVelocity(const float3& v) { angularVelocity_ = v; }
+    constexpr void setDamping(float d) { damping_ = d; }
 
     // Apply incremental rotation (during drag)
     void rotate(const float3& axis, float angle) {

--- a/include/ge/DampedValue.h
+++ b/include/ge/DampedValue.h
@@ -8,16 +8,16 @@
 // Used for smooth inertial motion with friction.
 class DampedValue {
 public:
-    DampedValue(float damping = 0.95f) : damping_(damping) {}
+    constexpr DampedValue(float damping = 0.95f) : damping_(damping) {}
 
-    float value() const { return value_; }
-    float velocity() const { return velocity_; }
+    constexpr float value() const { return value_; }
+    constexpr float velocity() const { return velocity_; }
 
-    void setValue(float v) { value_ = v; }
-    void setVelocity(float v) { velocity_ = v; }
+    constexpr void setValue(float v) { value_ = v; }
+    constexpr void setVelocity(float v) { velocity_ = v; }
 
     // Add to value directly (during drag)
-    void add(float delta) { value_ += delta; }
+    constexpr void add(float delta) { value_ += delta; }
 
     // Advance simulation by dt seconds (assumed 60fps for damping calc)
     void update(float dt) {
@@ -30,7 +30,7 @@ public:
         }
     }
 
-    bool isMoving() const { return velocity_ != 0.0f; }
+    constexpr bool isMoving() const { return velocity_ != 0.0f; }
 
 private:
     float value_ = 0.0f;

--- a/include/ge/SessionHost.h
+++ b/include/ge/SessionHost.h
@@ -71,13 +71,13 @@ struct Rect {
     struct Corners    { la::float2 a, b; };
     struct OriginSize { la::float2 origin, size; };
 
-    Rect() = default;
-    Rect(float x_, float y_, float w_, float h_)
+    constexpr Rect() = default;
+    constexpr Rect(float x_, float y_, float w_, float h_)
         : x(x_), y(y_), w(w_), h(h_) {}
-    Rect(Corners c)
+    constexpr Rect(Corners c)
         : x(c.a.x), y(c.a.y),
           w(c.b.x - c.a.x), h(c.b.y - c.a.y) {}
-    Rect(OriginSize os)
+    constexpr Rect(OriginSize os)
         : x(os.origin.x), y(os.origin.y),
           w(os.size.x),   h(os.size.y) {}
 
@@ -94,40 +94,40 @@ struct Rect {
     // a well-defined but non-conventional result that the caller may
     // or may not find useful. `normalized()` is a convenience for
     // callers who explicitly want positive-w/h form.
-    la::float2 x0y0() const { return {x,     y    }; }
-    la::float2 x1y0() const { return {x + w, y    }; }
-    la::float2 x0y1() const { return {x,     y + h}; }
-    la::float2 x1y1() const { return {x + w, y + h}; }
+    constexpr la::float2 x0y0() const { return {x,     y    }; }
+    constexpr la::float2 x1y0() const { return {x + w, y    }; }
+    constexpr la::float2 x0y1() const { return {x,     y + h}; }
+    constexpr la::float2 x1y1() const { return {x + w, y + h}; }
 
     // Size and center helpers.
-    la::float2 size()        const { return {w, h}; }
-    la::float2 halfExtents() const { return {w * 0.5f, h * 0.5f}; }
-    la::float2 center()      const { return {x + w * 0.5f, y + h * 0.5f}; }
+    constexpr la::float2 size()        const { return {w, h}; }
+    constexpr la::float2 halfExtents() const { return {w * 0.5f, h * 0.5f}; }
+    constexpr la::float2 center()      const { return {x + w * 0.5f, y + h * 0.5f}; }
 
     // Signed area: w * h. Sign reflects the winding implied by the field
     // signs (negative h or negative w produces negative area).
-    float area() const { return w * h; }
+    constexpr float area() const { return w * h; }
 
     // Aspect ratio (w / h). Caller's responsibility to handle h == 0.
-    float aspect() const { return w / h; }
+    constexpr float aspect() const { return w / h; }
 
     // True when w or h is exactly zero (`area() == 0`). Signed-area
     // rects (one negative dimension) are *not* empty — they cover a
     // region with negative winding, which `bbox`/`intersect` accept
     // and process via their min/max formulas without sign-judging.
-    bool empty() const { return w == 0 || h == 0; }
+    constexpr bool empty() const { return w == 0 || h == 0; }
 
     // Contextual-bool: true iff non-empty. Marked `explicit` so the
     // conversion only fires in boolean contexts (`if (r) ...`,
     // `while (r) ...`, `!r`) — no surprise int conversions.
-    explicit operator bool() const { return !empty(); }
-    bool operator!() const { return empty(); }
+    constexpr explicit operator bool() const { return !empty(); }
+    constexpr bool operator!() const { return empty(); }
 
     // Normalized form: positive w/h occupying the same region. Useful
     // when you've constructed a Rect via `Corners` from arbitrary-
     // order points and want the conventional form before passing to
     // `bbox`/`intersect`/`contains`.
-    Rect normalized() const {
+    constexpr Rect normalized() const {
         const float nx = w >= 0 ? x : x + w;
         const float ny = h >= 0 ? y : y + h;
         const float nw = w >= 0 ? w : -w;
@@ -137,11 +137,11 @@ struct Rect {
 
     // Half-open hit-test: includes [x, x+w) × [y, y+h). Matches SDL/bgfx
     // pixel coord convention so adjacent rects tile without overlap.
-    bool contains(la::float2 p) const {
+    constexpr bool contains(la::float2 p) const {
         return p.x >= x && p.x < x + w && p.y >= y && p.y < y + h;
     }
     // True when `other` is entirely inside this rect.
-    bool contains(const Rect& other) const {
+    constexpr bool contains(const Rect& other) const {
         return !other.empty() && !empty()
             && other.x >= x && other.y >= y
             && other.x + other.w <= x + w
@@ -149,27 +149,29 @@ struct Rect {
     }
     // True when this and `other` overlap on a positive-area region.
     // Boundary-touching does not count as overlap.
-    bool intersects(const Rect& other) const {
+    constexpr bool intersects(const Rect& other) const {
         return !empty() && !other.empty()
             && x < other.x + other.w && other.x < x + w
             && y < other.y + other.h && other.y < y + h;
     }
-    // Overlap rect, or an empty rect if there is no overlap.
-    Rect intersect(const Rect& other) const;
+    // Overlap rect, or an empty rect if there is no overlap. Defined
+    // out-of-class below so the impl can use ternary-min/max without
+    // pulling <algorithm> into this header's transitive closure.
+    constexpr Rect intersect(const Rect& other) const;
     // Bounding rect of the two. Treats empty rects as "nothing" — if
     // either is empty the other is returned unchanged.
-    Rect bbox(const Rect& other) const;
+    constexpr Rect bbox(const Rect& other) const;
 
     // Translated copy.
-    Rect translated(la::float2 d) const {
+    constexpr Rect translated(la::float2 d) const {
         return Rect{x + d.x, y + d.y, w, h};
     }
 
     // Copy-with-mutation accessors.
-    Rect withOrigin(la::float2 origin) const {
+    constexpr Rect withOrigin(la::float2 origin) const {
         return Rect{origin.x, origin.y, w, h};
     }
-    Rect withSize(la::float2 sz) const {
+    constexpr Rect withSize(la::float2 sz) const {
         return Rect{x, y, sz.x, sz.y};
     }
 
@@ -178,15 +180,15 @@ struct Rect {
     // Asymmetric edge-tweak: e.g. shrink top by 5 → `r.adjusted({0, 5, 0, -5})`.
     // Distinct from translated() / inset() / outset() because those bake
     // semantics in; adjusted() is the raw four-`+`s primitive.
-    Rect adjusted(Rect d) const {
+    constexpr Rect adjusted(Rect d) const {
         return Rect{x + d.x, y + d.y, w + d.w, h + d.h};
     }
 
     // Uniform scale of all four fields. Useful for converting between
     // coordinate systems related by a single scalar (e.g. pixel-rect to
     // normalized UV: `pixelRect / atlasSize`).
-    Rect operator*(float s) const { return Rect{x * s, y * s, w * s, h * s}; }
-    Rect operator/(float s) const { return *this * (1.0f / s); }
+    constexpr Rect operator*(float s) const { return Rect{x * s, y * s, w * s, h * s}; }
+    constexpr Rect operator/(float s) const { return *this * (1.0f / s); }
 
     // Parameters for `scaled`. `scale` is per-axis (or scalar — see the
     // companion overload below); `center` is the pivot expressed in
@@ -213,28 +215,48 @@ struct Rect {
         la::float2 center = {0.5f, 0.5f};
     };
 
-    Rect scaled(ScalingVec s) const {
+    constexpr Rect scaled(ScalingVec s) const {
         const float px = x + w * s.center.x;
         const float py = y + h * s.center.y;
         const float nw = w * s.scale.x;
         const float nh = h * s.scale.y;
         return Rect{px - s.center.x * nw, py - s.center.y * nh, nw, nh};
     }
-    Rect scaled(ScalingScalar s) const {
+    constexpr Rect scaled(ScalingScalar s) const {
         return scaled(ScalingVec{.scale = {s.scale, s.scale}, .center = s.center});
     }
 
     // Factory: rect of size `sz` whose center is at `c`. Kept as a
     // semantic factory — doesn't reduce cleanly to a ctor + transform.
-    static Rect centered(la::float2 c, la::float2 sz) {
+    static constexpr Rect centered(la::float2 c, la::float2 sz) {
         return Rect{c.x - sz.x * 0.5f, c.y - sz.y * 0.5f, sz.x, sz.y};
     }
 };
 
-inline bool operator==(const Rect& a, const Rect& b) {
+constexpr Rect Rect::intersect(const Rect& other) const {
+    if (empty() || other.empty()) return {};
+    const float l = (x          > other.x        ) ? x          : other.x;
+    const float t = (y          > other.y        ) ? y          : other.y;
+    const float r = (x + w      < other.x + other.w) ? x + w     : other.x + other.w;
+    const float b = (y + h      < other.y + other.h) ? y + h     : other.y + other.h;
+    if (r <= l || b <= t) return {};
+    return Rect{l, t, r - l, b - t};
+}
+
+constexpr Rect Rect::bbox(const Rect& other) const {
+    if (empty()) return other;
+    if (other.empty()) return *this;
+    const float l = (x          < other.x        ) ? x          : other.x;
+    const float t = (y          < other.y        ) ? y          : other.y;
+    const float r = (x + w      > other.x + other.w) ? x + w     : other.x + other.w;
+    const float b = (y + h      > other.y + other.h) ? y + h     : other.y + other.h;
+    return Rect{l, t, r - l, b - t};
+}
+
+constexpr bool operator==(const Rect& a, const Rect& b) {
     return a.x == b.x && a.y == b.y && a.w == b.w && a.h == b.h;
 }
-inline bool operator!=(const Rect& a, const Rect& b) { return !(a == b); }
+constexpr bool operator!=(const Rect& a, const Rect& b) { return !(a == b); }
 
 // Per-edge insets of a safe-area-style boundary within the render
 // surface. Direction-agnostic: `y0` is the inset on the smaller-y

--- a/include/ge/svg.h
+++ b/include/ge/svg.h
@@ -23,7 +23,7 @@ struct SvgPixels {
     int width  = 0;
     int height = 0;
 
-    bool isNull() const { return rgba.empty(); }
+    constexpr bool isNull() const { return rgba.empty(); }
 };
 
 // Rasterize an SVG document string to RGBA8 premultiplied pixels at the

--- a/include/ge/text.h
+++ b/include/ge/text.h
@@ -20,7 +20,7 @@ struct TextPixels {
     int width  = 0;
     int height = 0;
 
-    bool isNull() const { return rgba.empty(); }
+    constexpr bool isNull() const { return rgba.empty(); }
 };
 
 // Rasterize a UTF-8 string to RGBA8 premultiplied pixels using FreeType.

--- a/include/ge/transform.h
+++ b/include/ge/transform.h
@@ -31,7 +31,7 @@ namespace ge {
 // is recovered by the common case where local-space z = 0; the identity
 // z keeps the matrix invertible (det = w * h) so `la::inverse(frame(r))`
 // is well-defined for hit-testing.
-inline la::float4x4 frame(Rect r) {
+constexpr la::float4x4 frame(Rect r) {
     return {
         { r.w, 0.f, 0.f, 0.f },   // col 0: x basis
         { 0.f, r.h, 0.f, 0.f },   // col 1: y basis

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -3,29 +3,10 @@
 
 #include <ge/SessionHost.h>
 
-#include <algorithm>
-
 namespace ge {
 
-Rect Rect::intersect(const Rect& other) const {
-    if (empty() || other.empty()) return {};
-    const float l = std::max(x, other.x);
-    const float t = std::max(y, other.y);
-    const float r = std::min(x + w, other.x + other.w);
-    const float b = std::min(y + h, other.y + other.h);
-    if (r <= l || b <= t) return {};
-    return Rect{l, t, r - l, b - t};
-}
-
-Rect Rect::bbox(const Rect& other) const {
-    if (empty()) return other;
-    if (other.empty()) return *this;
-    const float l = std::min(x, other.x);
-    const float t = std::min(y, other.y);
-    const float r = std::max(x + w, other.x + other.w);
-    const float b = std::max(y + h, other.y + other.h);
-    return Rect{l, t, r - l, b - t};
-}
+// Rect::intersect / bbox are now defined inline as constexpr in
+// SessionHost.h (T52). Out-of-line definitions removed.
 
 struct Context::M {
     int surfaceWidth;

--- a/src/Rect_constexpr_test.cpp
+++ b/src/Rect_constexpr_test.cpp
@@ -1,0 +1,162 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression test for 🎯T52: every method, ctor, and operator on
+// `ge::Rect` and the `ge::frame(Rect)` transform must be `constexpr`.
+//
+// All exercise sites below are `static_assert`s — if anyone removes
+// `constexpr` from any of these APIs, this TU fails to compile. There
+// is no doctest TEST_CASE here because there are no runtime checks
+// to do; the load-bearing assertion is that the TU compiles at all.
+
+#include <ge/DampedRotation.h>
+#include <ge/DampedValue.h>
+#include <ge/SessionHost.h>
+#include <ge/svg.h>
+#include <ge/text.h>
+#include <ge/transform.h>
+
+namespace {
+
+using ge::Rect;
+
+// ── Constructors ─────────────────────────────────────────────────────
+constexpr Rect kDefault{};
+constexpr Rect k4Float{10, 20, 30, 40};
+constexpr Rect kFromOriginSize{{.origin = {1, 2}, .size = {3, 4}}};
+constexpr Rect kFromCorners{{.a = {0, 0}, .b = {10, 10}}};
+
+static_assert(kDefault.x == 0.f && kDefault.w == 0.f);
+static_assert(k4Float.x == 10.f && k4Float.h == 40.f);
+static_assert(kFromOriginSize == Rect{1, 2, 3, 4});
+static_assert(kFromCorners == Rect{0, 0, 10, 10});
+
+// Sign-preserving Corners (reverse order yields negative w/h):
+constexpr Rect kSigned{{.a = {40, 60}, .b = {10, 20}}};
+static_assert(kSigned == Rect{40, 60, -30, -40});
+
+// ── Direction-agnostic accessors ─────────────────────────────────────
+static_assert(k4Float.x0y0().x == 10.f && k4Float.x0y0().y == 20.f);
+static_assert(k4Float.x1y0().x == 40.f && k4Float.x1y0().y == 20.f);
+static_assert(k4Float.x0y1().x == 10.f && k4Float.x0y1().y == 60.f);
+static_assert(k4Float.x1y1().x == 40.f && k4Float.x1y1().y == 60.f);
+
+// ── Computed values ──────────────────────────────────────────────────
+static_assert(k4Float.size().x == 30.f && k4Float.size().y == 40.f);
+static_assert(k4Float.halfExtents().x == 15.f);
+static_assert(k4Float.center().x == 25.f && k4Float.center().y == 40.f);
+static_assert(k4Float.area() == 1200.f);
+static_assert(k4Float.aspect() == 30.f / 40.f);
+static_assert(!k4Float.empty());
+static_assert(kDefault.empty());
+// Signed-area is non-empty.
+static_assert(!kSigned.empty());
+static_assert(kSigned.area() == 1200.f);
+
+// ── Contextual-bool conversion ───────────────────────────────────────
+static_assert(static_cast<bool>(k4Float));
+static_assert(!static_cast<bool>(kDefault));
+static_assert(!kDefault);    // operator!
+static_assert(!!k4Float);    // operator! ∘ operator!
+
+// ── normalized() ─────────────────────────────────────────────────────
+constexpr Rect kNormalized = Rect{10, 20, -30, -40}.normalized();
+static_assert(kNormalized == Rect{-20, -20, 30, 40});
+
+// ── Containment / intersection / bbox ────────────────────────────────
+static_assert(k4Float.contains(ge::la::float2{15, 25}));
+static_assert(!k4Float.contains(ge::la::float2{50, 25}));
+static_assert(k4Float.contains(Rect{15, 25, 5, 5}));
+static_assert(!k4Float.contains(Rect{50, 50, 5, 5}));
+
+static_assert(k4Float.intersects(Rect{20, 30, 50, 50}));
+static_assert(!k4Float.intersects(Rect{200, 200, 5, 5}));
+
+constexpr Rect kI = k4Float.intersect(Rect{20, 30, 50, 50});
+static_assert(kI == Rect{20, 30, 20, 30});
+
+constexpr Rect kU = Rect{0, 0, 10, 10}.bbox(Rect{20, 20, 10, 10});
+static_assert(kU == Rect{0, 0, 30, 30});
+
+// Empty inputs are absorbed by bbox.
+static_assert(Rect{}.bbox(k4Float) == k4Float);
+static_assert(k4Float.bbox(Rect{}) == k4Float);
+
+// ── Mutations ────────────────────────────────────────────────────────
+static_assert(k4Float.translated({1, 2}) == Rect{11, 22, 30, 40});
+static_assert(k4Float.withOrigin({0, 0}) == Rect{0, 0, 30, 40});
+static_assert(k4Float.withSize({1, 1}) == Rect{10, 20, 1, 1});
+static_assert(k4Float.adjusted({1, 2, 3, 4}) == Rect{11, 22, 33, 44});
+
+// adjusted + Corners is the unified inset/outset/edge-mutate primitive.
+static_assert(Rect{0, 0, 100, 100}.adjusted({{.a = {5, 5}, .b = {-5, -5}}})
+              == Rect{5, 5, 90, 90});
+
+// ── Arithmetic operators ─────────────────────────────────────────────
+static_assert(k4Float * 2.f == Rect{20, 40, 60, 80});
+static_assert(k4Float / 2.f == Rect{5, 10, 15, 20});
+
+// ── scaled ───────────────────────────────────────────────────────────
+constexpr Rect kScaledVec    = k4Float.scaled({.scale = {2.f, 2.f}});
+constexpr Rect kScaledScalar = k4Float.scaled({.scale = 2.f});
+static_assert(kScaledVec == kScaledScalar);
+static_assert(kScaledVec.w == 60.f && kScaledVec.h == 80.f);
+// Default pivot is rect center, which therefore stays put.
+static_assert(kScaledVec.center().x == k4Float.center().x);
+static_assert(kScaledVec.center().y == k4Float.center().y);
+
+// Scale around the origin corner.
+constexpr Rect kScaledOrigin = k4Float.scaled({.scale = {2.f, 0.5f}, .center = {0.f, 0.f}});
+static_assert(kScaledOrigin == Rect{10, 20, 60, 20});
+
+// ── Static factories ─────────────────────────────────────────────────
+constexpr Rect kCentered = Rect::centered({100, 50}, {40, 20});
+static_assert(kCentered == Rect{80, 40, 40, 20});
+
+// ── Equality ─────────────────────────────────────────────────────────
+static_assert(Rect{1, 2, 3, 4} == Rect{1, 2, 3, 4});
+static_assert(Rect{1, 2, 3, 4} != Rect{1, 2, 3, 5});
+
+// ── ge::frame(Rect) — pure construction, constexpr ───────────────────
+constexpr ge::la::float4x4 kM = ge::frame(k4Float);
+static_assert(kM[0][0] == 30.f);   // x basis = w
+static_assert(kM[1][1] == 40.f);   // y basis = h
+static_assert(kM[2][2] == 1.f);    // z basis = identity
+static_assert(kM[3][0] == 10.f);   // origin x
+static_assert(kM[3][1] == 20.f);   // origin y
+
+// ── DampedValue — non-pow methods are constexpr ──────────────────────
+// Builds at compile time; getters / setters / add / isMoving evaluate
+// inside a consteval lambda so a single static_assert can drive the
+// state through the whole API.
+static_assert([] {
+    DampedValue v{0.9f};
+    if (v.value() != 0.f) return false;
+    if (v.velocity() != 0.f) return false;
+    if (v.isMoving()) return false;
+    v.setValue(3.5f);
+    v.setVelocity(2.0f);
+    if (v.value() != 3.5f) return false;
+    if (v.velocity() != 2.0f) return false;
+    if (!v.isMoving()) return false;
+    v.add(1.5f);
+    return v.value() == 5.0f;
+}());
+
+// ── DampedRotation — constexpr for ctor / getters / setters ──────────
+static_assert([] {
+    DampedRotation r{0.9f};
+    if (r.orientation().w != 1.0f) return false;
+    if (r.angularVelocity().x != 0.0f) return false;
+    r.setAngularVelocity(float3{1.f, 2.f, 3.f});
+    if (r.angularVelocity().z != 3.f) return false;
+    r.setOrientation(float4{0.f, 0.f, 0.f, 1.f});
+    r.setDamping(0.5f);
+    return true;
+}());
+
+// ── SvgPixels::isNull / TextPixels::isNull — vector::empty() is constexpr ──
+static_assert(ge::SvgPixels{}.isNull());
+static_assert(ge::TextPixels{}.isNull());
+
+}  // namespace


### PR DESCRIPTION
## Summary

Closes 🎯T52. Audits `constexpr` across ge's public API surface and adds a regression test TU that prevents drift.

## Changes

- **`ge::Rect`** (`SessionHost.h`) — every method, ctor, operator, and free function (`==`/`!=`) is `constexpr`.
- **`ge::Rect::intersect` / `bbox`** moved inline in the header (using ternary-min/max instead of `std::min`/`std::max` to keep `<algorithm>` out of `SessionHost.h`'s transitive closure); their out-of-line definitions in `src/Context.cpp` are removed.
- **`ge::frame(Rect)`** (`transform.h`) — `constexpr`.
- **`DampedValue`** (`DampedValue.h`) — `constexpr` on ctor, getters, setters, `add`, `isMoving`. `update` stays non-constexpr (`std::pow` / `std::abs` are constexpr only in C++26).
- **`DampedRotation`** (`DampedRotation.h`) — `constexpr` on ctor, getters, setters. Mutators / `matrix()` use linalg sin/cos/sqrt and stay non-constexpr.
- **`ge::SvgPixels::isNull`** (`svg.h`) and **`ge::TextPixels::isNull`** (`text.h`) — `constexpr` (`std::vector::empty()` is constexpr in C++20).

## Regression test

`src/Rect_constexpr_test.cpp` is a TU consisting entirely of `static_assert`s exercising every constexpr API. The file does its job by compiling — if any method loses `constexpr`, the TU fails with a clear diagnostic pointing at the offending method.

Verified by manually removing `constexpr` from `Rect::area()`:

```
src/Rect_constexpr_test.cpp:44:15: error: static assertion expression is not an integral constant expression
   44 | static_assert(k4Float.area() == 1200.f);
note: non-constexpr function 'area' cannot be used in a constant expression
```

## Out of scope (not constexpr-eligible)

Stateful types coupled to runtime libraries:
- `Sprite` (`bgfx::TextureHandle` / `bgfx::isValid`)
- `Tweak` (atomic shared_ptr + JSON)
- `Model` (bgfx textures)
- `DeltaTimer` (chrono)
- `GlobeController` (input + state)
- File I/O, SDL, WebSocket, video codecs
- JSON-based types (`ManifestDoc`, `ModelDef`) — `nlohmann::json` isn't constexpr

## Test plan

- [x] `make unit-test` — 64/64 pass
- [x] `cd sample/tiltbuggy && make` — sample app builds clean
- [x] Manually removed `constexpr` from `Rect::area()` to verify the regression test catches it (build fails with clear diagnostic)
