### PR TITLE
Release prep v0.20.0: constexpr audit (🎯T52)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1474,7 +1474,7 @@ targets:
     achieved: 2026-05-10
   T52:
     name: All eligible ge API surface is constexpr, with regression tests preventing accidental loss
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1489,6 +1489,7 @@ targets:
     - compile-time
     origin: manual
     discovered: 2026-05-10
+    achieved: 2026-05-10
   T6:
     name: Player can switch between active servers without QR
     status: identified


### PR DESCRIPTION
## Summary

Release prep for v0.20.0. Carries the `bullseye.yaml` retire of 🎯T52 into origin so the v0.20.0 tag includes it.

## Release content

The actual code change of v0.20.0 is the constexpr audit shipped in PR #74 (commit 5cc6e48). That PR added:

- `constexpr` to every `ge::Rect` method, ctor, operator, and the free `==`/`!=`
- `constexpr` to `ge::frame(Rect)` (transform.h)
- `constexpr` to `DampedValue` non-pow methods
- `constexpr` to `DampedRotation` non-trig methods
- `constexpr` to `SvgPixels::isNull` / `TextPixels::isNull`
- `src/Rect_constexpr_test.cpp` regression TU (compile-time enforcement)

## Test plan

- [x] `make unit-test` — 64/64 pass
- [x] `cd sample/tiltbuggy && make` — sample app builds clean
