### PR TITLE
CMakeLists: add button.cpp + sdl_input.cpp to GE_CORE_SOURCES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,8 @@ set(GE_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/svg.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/png.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/text.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/button.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sdl_input.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlift.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlpipe.cpp
 )

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1741,6 +1741,19 @@ targets:
     - ergonomics
     origin: manual
     discovered: 2026-05-11
+  T61:
+    name: ge CMake build includes button.cpp and sdl_input.cpp
+    status: identified
+    value: 0.0
+    cost: 0.0
+    showcase: true
+    acceptance:
+    - GE_CORE_SOURCES (or equivalent) in ge/CMakeLists.txt lists src/button.cpp and src/sdl_input.cpp alongside the other core sources (sprite.cpp, svg.cpp, png.cpp, text.cpp)
+    - iOS / Android CMake-built consumers link libge.a and successfully resolve ge::Button::handleEvent, ge::ButtonGroup::handleEvent, ge::Button::cancel, ge::input::fromSdl, and ge::input::sdlPointerEventConverter without 'Undefined symbols' errors
+    - ge's own ge/ios-init / ge/android-init scaffolding picks up the new sources automatically — no per-app patch required
+    context: Discovered while bumping multimaze2 to ge v0.24 to consume the new button + sdl_input APIs. The Makefile (ge/Module.mk) lists src/button.cpp and src/sdl_input.cpp under the engine sources, but ge/CMakeLists.txt does not — so the desktop / Module.mk build succeeds while every CMake-based consumer (iOS, Android) fails to link with Undefined symbols for ge::Button::handleEvent / ge::input::fromSdl. The two build systems should be source-equivalent; this is a missed addition when the new sources landed.
+    origin: manual
+    discovered: 2026-05-11
   T7:
     name: Audio pauses when the app is backgrounded
     status: identified


### PR DESCRIPTION
## Summary

v0.24.0 introduced two new source files (`src/button.cpp` from 🎯T56 in v0.23.0 and `src/sdl_input.cpp` from 🎯T59 in v0.24.0). Both were added to `Module.mk`'s `ge/SRC_DIRECT`, but `ge/CMakeLists.txt` keeps a parallel hand-listed source set (`GE_CORE_SOURCES`) that wasn't updated. Mac builds via Module.mk compile cleanly; iOS / Android builds via `add_subdirectory(ge)` fail to link because the new symbols aren't in `libge`.

Fix: append `src/button.cpp` and `src/sdl_input.cpp` to `GE_CORE_SOURCES`. Neither has platform-specific dependencies beyond SDL3, which is already linked into the cross-platform block.

This is a build break that broke multimaze's mobile build immediately after v0.24.0 landed.

## Test plan

- [x] `Module.mk`-based build still passes (already verified via `bin/ge-test` post-v0.24.0)
- [ ] CMake-based mobile build of a downstream consumer (multimaze) now links — to be verified by the user.