### PR TITLE
Release prep v0.28.0: ge::iap + ge::log + iOS/Android device sinks (🎯T65, 🎯T66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,6 +576,43 @@ sprite = ge::renderSvgDocument(*doc, 1024, 256);
 - **`VideoEncoder`** (`VideoEncoder.h`) — H.264 encoder interface. Platform implementation: `VideoEncoder_apple.mm` (VideoToolbox). Used internally by `SessionHost` when running headless. pImpl.
 - **`VideoDecoder`** (`VideoDecoder.h`) — H.264 decoder interface. Platform implementation: `VideoDecoder_apple.mm` (VideoToolbox). Used by the player. pImpl.
 
+### IAP (🎯T65)
+
+In-app purchases with one cross-platform surface: games register a catalogue, query `owned()` in O(1), call `buy()` with a callback. Same code compiles on macOS (StubStore), iOS (StoreKit 2, T65.2), and Android (Play Billing, T65.3) without `#ifdef`.
+
+```cpp
+#include <ge/iap.h>
+
+ge::iap::setCatalogue({
+    {.id = "pro",      .type = ge::iap::Type::NonConsumable},
+    {.id = "hints_10", .type = ge::iap::Type::Consumable},
+});
+
+if (ge::iap::owned("pro")) { /* gate */ }
+
+ge::iap::buy("pro", [](ge::iap::Result r) {
+    if (r.ok) celebrate();
+});
+
+ge::iap::restore([](auto){ });  // Apple App Review requires a "Restore Purchases" button — route here.
+```
+
+**Backend selection** at process startup from `GE_IAP_MODE`:
+
+| Mode | Backend | When |
+|---|---|---|
+| `stub` (default on desktop) | `StubStore` — in-memory entitlement set, no platform calls | CI, unit tests, headless server runs |
+| `local` | `.storekit` (iOS) / `android.test.*` (Android) — real framework, fake products | Fast dev iteration (T65.4) |
+| `platform` (default on mobile) | Real StoreKit / Play Billing | Release. Sandbox vs production decided by binary signing, not by code |
+
+**Product IDs are local.** Game registers `"pro"`, ge prepends the bundle ID to form the platform SKU `com.squz.tiltbuggy.pro`. The same string is what gets registered in App Store Connect and Play Console — no separate mapping table.
+
+**Testing surface** (`ge::iap::testing::setOwned`, `clearAll`) is authoritative on StubStore, no-op on platform stores. Used by unit tests and the in-engine debug menu (T65.6) for inner-loop iteration without touching a real store.
+
+**Server-side receipt validation is intentionally not provided.** Modern frameworks return signature-verified transactions (StoreKit 2 JWS, Play Billing signed receipts); ge writes only verified entitlements to the cache. The JWS floor covers replay, bundle-ID-binding, and account-binding for the threat model that paid non-consumable unlocks against casual game audiences actually face. Add server-side validation when shipping subscriptions or high-value-currency consumables.
+
+- **`<ge/iap.h>`** — Public surface. `Type`, `Product`, `LocalisedProduct`, `Result`, `setCatalogue`, `owned`, `products`, `buy`, `restore`, `testing::setOwned`, `testing::clearAll`.
+
 ### Testing
 
 - **`ImageDiff`** (`ImageDiff.h`) — `imgdiff::compareCPU()` for pixel-level RMS comparison.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,6 +566,45 @@ sprite = ge::renderSvgDocument(*doc, 1024, 256);
 - **`SdlContext`** (`SdlContext.h`) — RAII SDL3 window creation. Used by the player; not typically used by the server. pImpl.
 - **`Signal`** (`Signal.h`) — SIGINT handler registration for graceful shutdown.
 
+### Logging (🎯T66)
+
+`ge::run` installs a platform-native spdlog sink at startup so consumer
+apps' `SPDLOG_INFO` / `WARN` / `ERROR` calls surface uniformly without
+per-app sink wiring. Consumers write normal spdlog macros and capture
+from the host with platform tooling:
+
+| Platform | Sink                | Capture |
+|---|---|---|
+| iOS / iPadOS / tvOS / watchOS | `os_log_with_type` via `os_log_create(<bundle-id>, "ge")` | `spyder log <udid> --process <CFBundleExecutable>` (live, `--follow`); Xcode Console over USB. |
+| Android  | `__android_log_print` with tag = `<package-name>` (truncated to 23 chars) | `adb -s <serial> logcat -s <package-name>` or `spyder log <serial>`. |
+| Desktop  | spdlog default colour-stderr (unchanged) | stderr. |
+
+spdlog → native level mapping:
+
+| spdlog       | Apple `os_log_type_t`     | Android `__android_log_print` priority |
+|---|---|---|
+| trace, debug | `OS_LOG_TYPE_DEBUG`       | `ANDROID_LOG_VERBOSE` / `ANDROID_LOG_DEBUG` |
+| info         | `OS_LOG_TYPE_INFO`        | `ANDROID_LOG_INFO`    |
+| warn         | `OS_LOG_TYPE_DEFAULT`     | `ANDROID_LOG_WARN`    |
+| err          | `OS_LOG_TYPE_ERROR`       | `ANDROID_LOG_ERROR`   |
+| critical     | `OS_LOG_TYPE_FAULT`       | `ANDROID_LOG_FATAL`   |
+
+**Why this lives in ge.** Apple's privacy-by-default unified-log behaviour
+hides `os_log` arguments as `<private>` unless every format specifier
+carries `%{public}`, and entries logged via `OS_LOG_DEFAULT` (no named
+subsystem) are filtered out of remote capture entirely. Apps that rolled
+their own `NSLog`-based sink ended up emitting nothing visible. ge's
+sink works around both: it creates a named subsystem with the consumer
+app's bundle ID and passes the spdlog-rendered payload as one
+`%{public}s` argument, so every value is visible without per-call
+`%{public}` boilerplate at the call site.
+
+- **`ge::log::install(subsystem = "")`** (`log.h`) — idempotent. Called
+  automatically from `ge::run`; consumers don't invoke it directly.
+  Empty `subsystem` auto-detects: `[[NSBundle mainBundle] bundleIdentifier]`
+  on iOS, `Activity.getPackageName()` via SDL's JNI bridge on Android,
+  falls back to `"ge"` otherwise.
+
 ### I/O
 
 - **`FileIO`** (`FileIO.h`) — `ge::openFile(path)` returns a `std::unique_ptr<std::istream>`. Uses `SDL_IOFromFile` internally for platform-agnostic file access (Android APK assets, iOS bundles, normal filesystem).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
         ${CMAKE_CURRENT_SOURCE_DIR}/src/SdlContext_android.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Immersive_android.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/CutoutInsets_android.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/Attitude_android.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/Attitude_android.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/iap_android.cpp)
 else()
     list(APPEND GE_CORE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Immersive_stub.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ set(GE_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/text.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/button.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sdl_input.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/iap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlift.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlpipe.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if(APPLE)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/SdlContext.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Immersive_stub.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/CutoutInsets_stub.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/iap_apple.mm
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Attitude_apple.mm)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND GE_CORE_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ set(GE_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/button.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sdl_input.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/iap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/log.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlift.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlpipe.cpp
 )
@@ -194,6 +195,7 @@ if(APPLE)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Immersive_stub.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/CutoutInsets_stub.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/iap_apple.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/log_apple.mm
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Attitude_apple.mm)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND GE_CORE_SOURCES
@@ -202,7 +204,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Immersive_android.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/CutoutInsets_android.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Attitude_android.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/iap_android.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/iap_android.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/log_android.cpp)
 else()
     list(APPEND GE_CORE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Immersive_stub.cpp

--- a/Module.mk
+++ b/Module.mk
@@ -123,6 +123,7 @@ ge/SRC_DIRECT = \
 	$(ge)/src/text.cpp \
 	$(ge)/src/iap.cpp \
 	$(ge)/src/iap_apple.mm \
+	$(ge)/src/log.cpp \
 	$(ge)/src/button.cpp \
 	$(ge)/src/sdl_input.cpp \
 	$(ge)/src/render/DirectRenderHost.mm \

--- a/Module.mk
+++ b/Module.mk
@@ -121,6 +121,7 @@ ge/SRC_DIRECT = \
 	$(ge)/src/svg.cpp \
 	$(ge)/src/png.cpp \
 	$(ge)/src/text.cpp \
+	$(ge)/src/iap.cpp \
 	$(ge)/src/button.cpp \
 	$(ge)/src/sdl_input.cpp \
 	$(ge)/src/render/DirectRenderHost.mm \
@@ -271,7 +272,8 @@ ge/TEST_SRC = \
 	$(ge)/src/gesture_test.cpp \
 	$(ge)/src/layout_test.cpp \
 	$(ge)/src/button_test.cpp \
-	$(ge)/src/sdl_input_test.cpp
+	$(ge)/src/sdl_input_test.cpp \
+	$(ge)/src/iap_test.cpp
 ge/TEST_OBJ = $(patsubst $(ge)/src/%.cpp,$(BUILD_DIR)/ge/src/%.o,$(ge/TEST_SRC))
 
 # Shared variables (parent can += to extend)

--- a/Module.mk
+++ b/Module.mk
@@ -101,7 +101,7 @@ ge/FRAMEWORKS = \
     -framework CoreHaptics -framework GameController -framework CoreVideo \
     -framework ForceFeedback -framework AVFoundation -framework CoreMedia \
     -framework UniformTypeIdentifiers -framework CoreGraphics \
-    -framework VideoToolbox -framework CoreMotion
+    -framework VideoToolbox -framework CoreMotion -framework StoreKit
 
 # Core engine sources — always needed. Split into "direct-only" (runs on
 # any platform / modality) and "brokered" (only the server-side of the
@@ -122,6 +122,7 @@ ge/SRC_DIRECT = \
 	$(ge)/src/png.cpp \
 	$(ge)/src/text.cpp \
 	$(ge)/src/iap.cpp \
+	$(ge)/src/iap_apple.mm \
 	$(ge)/src/button.cpp \
 	$(ge)/src/sdl_input.cpp \
 	$(ge)/src/render/DirectRenderHost.mm \

--- a/android-shared/src/main/java/ge/IapBridge.java
+++ b/android-shared/src/main/java/ge/IapBridge.java
@@ -1,0 +1,196 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Java side of ge::iap's Play Billing 7+ backend (🎯T65.3).
+//
+// The native C++ side (src/iap_android.cpp) creates an IapBridge
+// instance during AppleStore-equivalent construction; the bridge
+// wires up BillingClient and forwards every state change back to
+// native via the static nativeOn* JNI methods at the bottom.
+//
+// Gradle dependency required in the consuming app:
+//   implementation 'com.android.billingclient:billing:7.x.x'
+//
+// Verification status: this file has NOT been verified end-to-end on
+// a real Android device yet — that's part of 🎯T65.7's demonstration.
+// The flow follows Google's Play Billing 7 documentation; subtle bugs
+// may surface at first device run.
+
+package ge;
+
+import android.app.Activity;
+import android.content.Context;
+import android.util.Log;
+
+import com.android.billingclient.api.AcknowledgePurchaseParams;
+import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingFlowParams;
+import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.PendingPurchasesParams;
+import com.android.billingclient.api.ProductDetails;
+import com.android.billingclient.api.Purchase;
+import com.android.billingclient.api.PurchasesUpdatedListener;
+import com.android.billingclient.api.QueryProductDetailsParams;
+import com.android.billingclient.api.QueryPurchasesParams;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IapBridge implements PurchasesUpdatedListener {
+    private static final String TAG = "ge.iap";
+
+    private final Activity activity;
+    private final BillingClient client;
+    // Cached ProductDetails for each SKU — needed to launch a billing
+    // flow. Populated by querySkus().
+    private final Map<String, ProductDetails> productsBySku = new HashMap<>();
+
+    public IapBridge(Activity activity) {
+        this.activity = activity;
+        this.client = BillingClient.newBuilder(activity)
+                .setListener(this)
+                .enablePendingPurchases(
+                        PendingPurchasesParams.newBuilder()
+                                .enableOneTimeProducts()
+                                .build())
+                .build();
+        client.startConnection(new BillingClientStateListener() {
+            @Override public void onBillingSetupFinished(BillingResult br) {
+                if (br.getResponseCode() == BillingClient.BillingResponseCode.OK) {
+                    nativeOnBillingReady();
+                } else {
+                    Log.e(TAG, "billing setup failed: " + br.getDebugMessage());
+                }
+            }
+            @Override public void onBillingServiceDisconnected() {
+                Log.w(TAG, "billing service disconnected; reconnect on next call");
+            }
+        });
+    }
+
+    public void querySkus(String[] skus, boolean[] subscriptionFlags) {
+        List<QueryProductDetailsParams.Product> products = new ArrayList<>();
+        for (int i = 0; i < skus.length; i++) {
+            String productType = subscriptionFlags[i]
+                    ? BillingClient.ProductType.SUBS
+                    : BillingClient.ProductType.INAPP;
+            products.add(QueryProductDetailsParams.Product.newBuilder()
+                    .setProductId(skus[i])
+                    .setProductType(productType)
+                    .build());
+        }
+        QueryProductDetailsParams params = QueryProductDetailsParams.newBuilder()
+                .setProductList(products)
+                .build();
+        client.queryProductDetailsAsync(params, (br, result) -> {
+            if (br.getResponseCode() != BillingClient.BillingResponseCode.OK) {
+                Log.w(TAG, "queryProductDetailsAsync failed: " + br.getDebugMessage());
+                return;
+            }
+            for (ProductDetails pd : result.getProductDetailsList()) {
+                productsBySku.put(pd.getProductId(), pd);
+                String price = "";
+                String currency = "";
+                if (pd.getOneTimePurchaseOfferDetails() != null) {
+                    price    = pd.getOneTimePurchaseOfferDetails().getFormattedPrice();
+                    currency = pd.getOneTimePurchaseOfferDetails().getPriceCurrencyCode();
+                }
+                nativeOnProductFetched(
+                        pd.getProductId(),
+                        pd.getTitle(),
+                        pd.getDescription(),
+                        price,
+                        currency);
+            }
+        });
+    }
+
+    public void queryPurchases() {
+        QueryPurchasesParams params = QueryPurchasesParams.newBuilder()
+                .setProductType(BillingClient.ProductType.INAPP)
+                .build();
+        client.queryPurchasesAsync(params, (br, purchases) -> {
+            if (br.getResponseCode() != BillingClient.BillingResponseCode.OK) {
+                Log.w(TAG, "queryPurchasesAsync failed: " + br.getDebugMessage());
+                nativeOnRestoreFinished(false, br.getDebugMessage());
+                return;
+            }
+            for (Purchase p : purchases) {
+                handlePurchase(p);
+            }
+            nativeOnRestoreFinished(true, "");
+        });
+    }
+
+    public boolean launchPurchase(String sku) {
+        ProductDetails pd = productsBySku.get(sku);
+        if (pd == null) {
+            nativeOnPurchaseUpdate(sku, false, "product not yet fetched from store");
+            return false;
+        }
+        BillingFlowParams.ProductDetailsParams pdp =
+                BillingFlowParams.ProductDetailsParams.newBuilder()
+                        .setProductDetails(pd)
+                        .build();
+        BillingFlowParams flow = BillingFlowParams.newBuilder()
+                .setProductDetailsParamsList(java.util.Collections.singletonList(pdp))
+                .build();
+        BillingResult br = client.launchBillingFlow(activity, flow);
+        if (br.getResponseCode() != BillingClient.BillingResponseCode.OK) {
+            nativeOnPurchaseUpdate(sku, false, br.getDebugMessage());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void onPurchasesUpdated(BillingResult br, List<Purchase> purchases) {
+        if (br.getResponseCode() != BillingClient.BillingResponseCode.OK || purchases == null) {
+            // User-cancelled and error states both reach here.
+            return;
+        }
+        for (Purchase p : purchases) handlePurchase(p);
+    }
+
+    private void handlePurchase(Purchase p) {
+        if (p.getPurchaseState() != Purchase.PurchaseState.PURCHASED) {
+            // PENDING — slow payment methods. Surface as not-owned for
+            // now; T65.5 cache work will add onPending handling.
+            return;
+        }
+        // Signature verification is enforced by the Play Billing
+        // library before delivering a Purchase here — additional
+        // signature checks against the app's public key are
+        // recommended but not added in this v1 path. Server-side
+        // verification is the upgrade target when subscriptions ship.
+        for (String sku : p.getProducts()) {
+            nativeOnPurchaseUpdate(sku, true, "");
+            // Acknowledge to prevent auto-refund after 3 days. Skip
+            // for already-acknowledged purchases.
+            if (!p.isAcknowledged()) {
+                AcknowledgePurchaseParams ack = AcknowledgePurchaseParams.newBuilder()
+                        .setPurchaseToken(p.getPurchaseToken())
+                        .build();
+                client.acknowledgePurchase(ack, br -> {
+                    if (br.getResponseCode() != BillingClient.BillingResponseCode.OK) {
+                        Log.w(TAG, "acknowledge failed for " + sku + ": " + br.getDebugMessage());
+                    }
+                });
+            }
+        }
+    }
+
+    public void shutdown() {
+        if (client.isReady()) client.endConnection();
+    }
+
+    // ── JNI hooks — defined in src/iap_android.cpp ─────────────────
+    private static native void nativeOnBillingReady();
+    private static native void nativeOnProductFetched(
+            String sku, String title, String description, String price, String currency);
+    private static native void nativeOnPurchaseUpdate(String sku, boolean ok, String error);
+    private static native void nativeOnRestoreFinished(boolean ok, String error);
+}

--- a/android-shared/src/main/java/ge/IapBridge.java
+++ b/android-shared/src/main/java/ge/IapBridge.java
@@ -90,7 +90,7 @@ public class IapBridge implements PurchasesUpdatedListener {
                 Log.w(TAG, "queryProductDetailsAsync failed: " + br.getDebugMessage());
                 return;
             }
-            for (ProductDetails pd : result.getProductDetailsList()) {
+            for (ProductDetails pd : result) {
                 productsBySku.put(pd.getProductId(), pd);
                 String price = "";
                 String currency = "";

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2125,6 +2125,60 @@ targets:
     - proving-ground
     origin: manual
     discovered: 2026-05-17
+  T66:
+    name: ge installs a cross-platform spdlog sink so SPDLOG_INFO surfaces uniformly on iOS, Android, and desktop
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`ge::log::install(std::string subsystem = "")` is called once per session host from `ge::run`, before any logging happens. Empty `subsystem` auto-detects: CFBundleIdentifier on iOS, package name on Android, argv[0] basename on desktop.'
+    - 'On iOS the installed sink emits each spdlog `log_msg` through `os_log_*` with a named logger created from `os_log_create(<subsystem>, <logger-name>)` (logger-name defaults to "ge" or the spdlog logger''s own name). The fully-formatted spdlog payload is passed as a single `%{public}s` argument so every value is visible — no per-call `%{public}` boilerplate in app code. spdlog level maps to OS_LOG_TYPE: trace/debug → DEBUG, info → INFO, warn → DEFAULT, error → ERROR, critical → FAULT.'
+    - On Android the installed sink emits each spdlog `log_msg` through `__android_log_print` with priority mapped from spdlog level (trace/debug → VERBOSE/DEBUG, info → INFO, warn → WARN, error → ERROR, critical → FATAL) and tag = subsystem (truncated to 23 chars per Android's TAG limit).
+    - On desktop the sink keeps the existing stderr behaviour (spdlog's default colour sink); no regression in current ge / app log output during local dev.
+    - Existing consumer apps (multimaze2, tiltbuggy, sample/tiltbuggy) require **zero source changes** to benefit. Every existing `SPDLOG_INFO` / `SPDLOG_WARN` / `SPDLOG_ERROR` / `SPDLOG_DEBUG` call now flows to the platform-native channel as well as stderr.
+    - 'Verified end-to-end on a real iPhone (Minicades Test iPhone, iOS 26.4.2): a `SPDLOG_INFO("hello")` in a consumer app produces a line visible to `spyder log <udid> --process <BundleExecutable>` (and `--subsystem <bundle-id>`) without the app touching `os_log_create` itself.'
+    - 'Verified end-to-end on a real Android device (Galaxy S24): same `SPDLOG_INFO` produces an `adb logcat` entry under the bundle-id tag.'
+    - 'Documented in `ge/CLAUDE.md` under the Public API section: `ge::log::install`, the platform fan-out table (spdlog level → native level for each OS), and the bundle-id auto-detection rules.'
+    - Old per-app workarounds (multimaze2's `os_log_create("com.squz.multimaze2", "T17")` block in src/Application.cpp from the 🎯T17 instrumentation push) can be deleted and replaced with the normal `SPDLOG_INFO` macro; the resulting messages still surface to `spyder log`.
+    context: |-
+      **Why this needs to be in ge, not in every app.**
+
+      Getting `SPDLOG_INFO` output off an iOS device is currently a multi-day reverse-engineering puzzle that every consuming game would otherwise have to solve independently. The gauntlet (as discovered during multimaze2's 🎯T17 instrumentation work on 2026-05-17 → 2026-05-19):
+
+      1. Apple has deprecated three logging APIs in sequence (NSLog → ASL syslog → unified log / `os_log`) without retiring any. Each has different visibility, capture paths, and filters.
+      2. Privacy-by-default since iOS 14: `os_log` arguments are `<private>` unless every format specifier carries `%{public}`. Entries logged via `OS_LOG_DEFAULT` (no named subsystem) are filtered out of remote capture entirely. Code "works" silently while emitting nothing visible.
+      3. Off-device capture is community-reverse-engineered. Apple's blessed answer is Xcode Console over USB — useless for automation. Spyder routes through go-ios's `os_trace_relay` service (the OSLog channel Xcode Console uses), but only sees entries from named loggers created by `os_log_create(<subsystem>, <category>)`.
+      4. No mainstream cross-platform logging library (spdlog, glog, fmt) bundles an iOS sink that does the right thing. spdlog's default stderr sink is invisible on iOS.
+
+      The exact incantation that works (proven during the 🎯T17 push):
+      - Create a logger once with `os_log_create("com.squz.multimaze2", "T17")` at file scope.
+      - Emit with `os_log(logger, "fmt %{public}d %{public}s", ...)` — every arg public.
+      - Capture from host: `spyder log <udid> --process <CFBundleExecutable> --follow` (range queries are 5-second live windows on iOS so `--follow` is required for ad-hoc captures).
+
+      That incantation is what `ge::log` needs to encode once. The "format spdlog message → single `%{public}s` arg" trick (pass the already-rendered payload string as a public argument so Apple's privacy filter never has to inspect individual values) means consumer code keeps writing normal `SPDLOG_INFO("v={:.3f} mass={:.4f}", v, m)` calls with no platform-specific annotation.
+
+      Android side (`__android_log_print`) is much simpler — included for completeness so consumer apps don't have to wire that separately.
+
+      Discovered while instrumenting multimaze2's 🎯T17 (ball-strike audio calibration). The level-1 marble-hit telemetry could not be retrieved from the iPhone for ~2 days because `OS_LOG_DEFAULT` was being filtered. Until ge encodes this, the next ge consumer will lose the same time.
+
+      **Out of scope for this target**:
+      - Log shipping (writing to a remote backend) — local-device capture only.
+      - Crash reports — separate channel; spyder's `crashes` subcommand handles that.
+      - Hot-reloadable log levels — current spdlog runtime level setting is sufficient.
+
+      Spyder-side improvements that would make this even nicer (tracked as separate targets in marcelocantos/spyder, not blockers for this work):
+      - Fix `spyder log --bundle-id <id> --follow` (currently EOFs immediately on iOS 26.4 — the `--process` path works as a workaround).
+      - Server-side managed capture sessions (`log_capture_start` / `log_capture_stop` MCP tools) so agents don't have to wrangle `--follow` + background processes + kill via shell.
+      - Document the "named subsystem required" constraint so consumers know what they're committing to.
+    tags:
+    - log
+    - ios
+    - android
+    - spdlog
+    - engine
+    - dev-experience
+    origin: manual
+    discovered: 2026-05-19
   T7:
     name: Audio pauses when the app is backgrounded
     status: identified

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1,4 +1,4 @@
-schema_version: 3
+schema_version: 4
 targets:
   T1:
     name: Game servers can run inside the player via WebAssembly
@@ -355,7 +355,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     actual_cost: 2.0
     acceptance:
     - 'All 6 automated matrix-test cells pass on current hardware: desktop-dist, desktop-player, ios-sim-dist, ios-sim-player, android-emu-dist, android-emu-player'
@@ -400,7 +399,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     actual_cost: 1.0
     acceptance:
     - rotation-stability-test.sh --platform ios-sim --app-id com.squz.tiltbuggy --cycles 10 reports PASS end-to-end against the iPad Air M4 simulator
@@ -415,7 +413,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     actual_cost: 5.0
     acceptance:
     - 'iPhone: dist + player smoke pass (cold launch, 60s soak, no crashes)'
@@ -433,7 +430,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     actual_cost: 5.0
     acceptance:
     - make ge/<platform>-debug (or equivalent) produces a debug binary / .app / APK distinct from the release build — assertions enabled, debug symbols retained
@@ -449,7 +445,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     actual_cost: 5.0
     acceptance:
     - Android player reads a `ged_addr` intent extra (e.g. `adb shell am start -n com.squz.player/.GeActivity --es ged_addr host:port`) and connects directly, skipping QR onboarding
@@ -476,7 +471,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - '`make cell.android-emu-phone-dist` and `make cell.android-debug-dist` both pass end-to-end on the current canonical phone AVD'
     - Failure mode (GL-context error) either fixed at the bgfx config layer or worked around with a documented AVD requirement in Module.mk
@@ -500,8 +494,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
-    demonstration: 'Merged in PR #55; visual verification deferred to game projects.'
     acceptance:
     - '`make cell.ios-sim-tablet-player` passes the reconnect sub-check end-to-end'
     - '`make cell.android-emu-phone-player` passes the reconnect sub-check end-to-end'
@@ -515,7 +507,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     actual_cost: 3.0
     acceptance:
     - '`make cell.android-emu-phone-player` passes the startup-flash sub-check end-to-end with no false positive and no genuine flash'
@@ -537,8 +528,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
-    demonstration: 'Merged in PR #55; real-environment timing deferred to game projects.'
     acceptance:
     - Per-cell soak sub-check runs for ~10s by default
     - A single dedicated long-soak cell runs the 60s sweep
@@ -553,7 +542,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    demonstration: 'TiltBuggy distribution build on iOS Simulator (T28.3) demonstrated Shift-drag mouse tilt driving the buggy via screen recording. macOS desktop distribution (T28.1, T28.2 family) verified earlier in the same lineage. T28.4 (Android emu) was deliberately set aside on 2026-05-02: the AVD''s built-in virtual sensors (Extended Controls → Virtual sensors) supersede AccelSynth''s Shift+drag path on emu, so Android-emu tilt input flows through the regular real-sensor pipeline rather than the synth. With three of four sub-targets achieved and the fourth covered by an alternative mechanism, T28''s user-visible outcome — "tilt-driven gameplay works in every host context lacking a real accelerometer" — is satisfied.'
     acceptance:
     - In a tilt-driven sample app (e.g. tiltbuggy) built as distribution (in-process DirectRenderHost, no ged/player), Shift-drag of the mouse tilts the viewport and drives gameplay identically to the player binary's behaviour
     - 'Works on: macOS desktop distribution build, iOS simulator distribution build, Android emulator distribution build'
@@ -568,7 +556,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - DirectRenderHost::pumpEvents routes each SDL event through synth->handle() (when synth is active) before forwarding to the user event handler; consumed events are NOT forwarded
     - DirectRenderHost drives synth->update() once per frame (beginFrame or endFrame) so the ease-back after Shift-release animates
@@ -583,7 +570,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - In a distribution build using DirectRenderHost, Shift-dragging produces a visible viewport tilt matching the player binary's visual behaviour on the same app
     - The tilt compose shader in DirectRenderHost is fed the current AccelSynth tilt each frame (same convention as PlayerRender.cpp ~line 346)
@@ -599,8 +585,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
-    demonstration: 'Merged in PR #55; interactive verification deferred to game projects.'
     acceptance:
     - On an iOS simulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors and AccelSynth activates
     - Shift+mouse-drag inside the simulator window tilts the viewport and drives sensor-driven gameplay
@@ -619,7 +603,6 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - On an Android emulator running a distribution build of a tilt-driven sample app, SDL reports zero real sensors (or emulator's virtual sensors pass a simulator-detection check) and AccelSynth activates
     - Shift+mouse-drag inside the emulator window tilts the viewport and drives sensor-driven gameplay
@@ -670,7 +653,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - SDL_ttf is vendored under ge/vendor/github.com/libsdl-org/SDL_ttf — added as a git submodule (matching the existing SDL submodule at the same parent path) pinned to release-3.2.2 (requires SDL ≥ 3.2.6; ge's SDL is 3.4.0 so compatible)
     - ge/CMakeLists.txt's Android branch (currently lines 217-234) does add_subdirectory for SDL_ttf and links SDL3_ttf::SDL3_ttf into the ge target via PUBLIC
@@ -686,7 +668,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - A FontLoader implementation exists that works on Android (and is portable to desktop Linux/Windows if/when those are added) — likely FontLoader_sdl.cpp using SDL_IOStream + SDL_ttf directly, or FontLoader_android.cpp using AAssetManager. Name and approach at author's discretion.
     - 'ge/CMakeLists.txt selects the right FontLoader source per platform (FontLoader_apple.mm on Apple, the new one everywhere else) — no #ifdef sprawl inside a single file'
@@ -703,8 +684,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
-    demonstration: 'Merged in PR #55; tiltbuggy APK built and launched on Tab A9 during the agent run; visual confirm deferred to game projects.'
     acceptance:
     - sample/tiltbuggy/android/app/src/main/cpp/CMakeLists.txt calls add_subdirectory(${GE_ROOT}) and target_link_libraries(main PRIVATE ge)
     - The inline GE_SOURCES block (currently lines 79-96) and its accompanying Apple-only comment (lines 76-78) are deleted
@@ -721,7 +700,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - 'Confirmed where Triangle code actually lands. Inventory: vendor/src/triangle.c + vendor/include/triangle.h are vendored in ge''s repo; Module.mk exposes ge/TRIANGLE_OBJ as an opt-in object (built with -DTRILIBRARY -DREAL=double -DANSI_DECLARATORS -DNO_TIMER); no ge/src/ file #includes triangle.h or calls triangulate(); ge/CMakeLists.txt does not compile triangle.c into libge; the only known consumer is yourworld/yourworld2/tools/precompute.cpp (build-time tool, not a runtime artifact)'
     - 'Confirmed exactly what the licence permits and forbids. The text in vendor/src/triangle.c grants free use for private, research, and institutional use; permits redistribution if (a) copyright notices are kept, (b) no compensation is received for redistribution, (c) modifications keep original copyright + free source/object availability; **explicitly forbids distribution as part of a commercial system without direct arrangement with Shewchuk (jrs@cs.berkeley.edu)**, with one carve-out: if you don''t supply the code directly to the customer but instead point them at a free download, no arrangement needed'
@@ -737,7 +715,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - VideoDecoder's frame callback on Android delivers NV12 planar data (Y plane + interleaved UV plane with their respective strides), not pre-converted BGRA. The hand-rolled nv12ToBgra() function and reusable frameBuffer member in src/bridge/VideoDecoder_android.cpp (and the equivalent libswscale conversion in src/bridge/VideoDecoder_ffmpeg.cpp) are deleted
     - PlayerRender uploads Y as a bgfx R8 texture (w×h) and UV as a bgfx RG8 texture (w/2 × h/2) with proper pitch handling for MediaCodec's row stride
@@ -1006,7 +983,6 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - ge::Context exposes a safe-area accessor (e.g. SafeAreaInsets safeArea() const) returning per-edge pixel insets in the current orientation; on desktop all four insets are 0
     - DirectRenderHost (headless=false path) keeps the Context's safe-area in sync by querying the platform (UIWindow.safeAreaInsets on iOS, WindowInsets/SDL3 accessor on Android) at the same trigger points where width()/height() update — initial layout, resize, rotation
@@ -1453,6 +1429,28 @@ targets:
     origin: discussed during T47-T49 wrap-up; "where did we get to with app icons?" - 2026-05-10
     discovered: 2026-05-10
     achieved: 2026-05-10
+  T50.1:
+    name: ge/app-icons supports explicit foreground/background SVGs for Android adaptive icons
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`icons/icon-foreground.svg` and `icons/icon-background.svg` are optional inputs picked up by `make ge/app-icons` when present'
+    - 'When both are present: foreground rasterises into `drawable/ic_launcher_foreground.png` (432×432), background rasterises into `drawable/ic_launcher_background.png` (432×432), and the adaptive XML references both PNGs'
+    - 'When only `icons/icon.svg` is present: current behaviour preserved (full-bleed master into foreground, solid colour from `APP_ICON_BG_COLOR` into background XML) — no consumer break'
+    - iOS still consumes `icons/icon.svg` as the single source (Android adaptive split has no iOS analogue today)
+    - tiltbuggy's `icons/` shows both single-source and split-source modes in its check-in (or a comment documents the unused branch)
+    - CLAUDE.md's `### App icons (🎯T50)` section is updated to describe the three input modes
+    context: 'T50 shipped in v0.14.0 with the full-bleed master going into the Android adaptive-icon foreground and the background reduced to a solid colour (ge/APP_ICON_BG_COLOR). Real adaptive-icon design separates the two layers: the foreground holds the logo (subject to parallax + masking by the launcher''s chosen shape — circle, squircle, rounded square), the background fills the safe zone behind it (could be a gradient, a pattern, a colour wash). Today''s "solid colour" background is the minimum viable; a designer who wants real depth has to bake it into the foreground SVG, which then gets cropped unpredictably by the launcher mask. Lift the constraint by accepting two optional input SVGs alongside `icons/icon.svg`.'
+    depends_on:
+    - T50
+    tags:
+    - app-icons
+    - android
+    - adaptive-icon
+    - svg
+    origin: manual
+    discovered: 2026-05-13
   T51:
     name: ge ships an interactive lunasvg surface, a unit-square Sprite, ge::frame(Rect), and a header reorg
     status: achieved
@@ -1680,8 +1678,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
-    demonstration: ge::input::fromSdl(const SDL_Event&, la::float2 surfaceSize) implemented in include/ge/sdl_input.h + src/sdl_input.cpp (sdl-input branch). Handles SDL_EVENT_MOUSE_BUTTON_DOWN/UP, SDL_EVENT_MOUSE_MOTION, SDL_EVENT_FINGER_DOWN/UP/MOTION; mouse coords scaled via SDL_GetWindowSize/SDL_GetWindowSizeInPixels; SDL_TOUCH_MOUSEID dedup inside the helper; non-pointer events return nullopt. Multimaze2 will consume it directly — no consumer-side conversion glue.
     acceptance:
     - ge::Button::handleEvent and ge::ButtonGroup::handleEvent take const SDL_Event& — no intermediate ge::PointerEvent in the consumer's call site
     - Touch fingerID and the mouse-as-single-finger collapse are handled inside ge so consumers do not spell ev.tfinger.fingerID or ge::kMouseId themselves
@@ -1746,8 +1742,6 @@ targets:
     status: achieved
     value: 0.0
     cost: 0.0
-    showcase: true
-    demonstration: 'v0.25.0 release (commit dd55622, PR #80) adds src/button.cpp and src/sdl_input.cpp to GE_CORE_SOURCES in ge/CMakeLists.txt. Module.mk and CMakeLists are now back in sync. User confirmed the multimaze mobile build links after bumping the submodule.'
     acceptance:
     - GE_CORE_SOURCES (or equivalent) in ge/CMakeLists.txt lists src/button.cpp and src/sdl_input.cpp alongside the other core sources (sprite.cpp, svg.cpp, png.cpp, text.cpp)
     - iOS / Android CMake-built consumers link libge.a and successfully resolve ge::Button::handleEvent, ge::ButtonGroup::handleEvent, ge::Button::cancel, ge::input::fromSdl, and ge::input::sdlPointerEventConverter without 'Undefined symbols' errors
@@ -1761,7 +1755,6 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - A PointerEvent::Move arriving with phase == Idle and inside == true captures the touch — sets phase = PressedInside, activeId = ev.id, fires onHighlightChange(true), and returns true (the same effect a Down inside would have had)
     - A subsequent Up on that captured touch fires onFire (release-inside semantics, same as the normal Down-then-Up path)
@@ -1777,7 +1770,6 @@ targets:
     status: identified
     value: 0.0
     cost: 0.0
-    showcase: true
     acceptance:
     - On an active touch / mouse-button press, the engine renders at the device's max refresh rate (or close to it) until the press ends — not the idle-display rate iOS / Android drop to under VRR
     - Specifically on iPad ProMotion displays (iPad mini A17 Pro and similar), a button press registered by the ge::Button state machine becomes visible in the rendered frame within ≤1 vsync of the Down event — not after the user wiggles their finger to nudge the display back into a high-refresh state
@@ -1787,6 +1779,223 @@ targets:
     context: 'Discovered while testing the multimaze2 TopBar refactor on iPad mini A17 Pro (Jevons). Symptom: tapping a chrome button inside its hit rect does NOT visibly darken the button; only after the user moves their finger slightly does the darkened state appear. Investigation: the ge::Button state machine is correctly transitioning Idle → PressedInside on Down (verified because onFire fires on release without movement, which only happens when phase == PressedInside on Up). So highlighted() is true the instant Down is processed, but the rendered frame doesn''t reflect it until the user wiggles. The only credible explanation is that iOS''s adaptive-refresh display has dropped the refresh rate very low (10–24Hz, the typical idle floor for ProMotion) and the loop is gated on bgfx::frame()''s vsync wait. The user''s finger movement is what''s kicking the display back up to a higher rate so a new frame actually renders. Affects any ge consumer that uses ge::Button or similar press-feedback affordance on a ProMotion device.'
     origin: manual
     discovered: 2026-05-11
+  T64:
+    name: Unified studio-wide deployment architecture across squz + minicadesmobile
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - Either engineer can ship any squz or minicadesmobile game by typing one command (/ge:ship or make ship-release VERSION=x)
+    - Match-managed signing works from both laptops and CI for both portfolios via a single shared certs repo
+    - New-game onboarding from `git init` to first TestFlight Internal build takes under one hour for someone who has done it before
+    - WIP in the working tree cannot pollute a release build (enforced structurally via git worktree)
+    - What shipped is answerable from git log for any production build (tag = version = binary)
+    - Both ge and MinicadesKit Module.mk surfaces converge on the same ship-* target names and semantics
+    context: 'Both portfolios (squz games on ge, minicadesmobile games on MinicadesKit) currently have separate deployment stories. squz/ge has none yet; minicadesmobile has mature laptop-driven Unity → TestFlight automation but no fastlane, no match, no tag-triggered CI, and signing is per-game automatic with frequent friction. The opportunity is cross-pollination: ge imports MinicadesKit''s hard-won patterns (preflight, build-log-append, heredoc-not-make, double-colon hooks, keychain-with-env-override) and contributes net-new architectural moves (studio-wide match repo, git worktree isolation, Claude Code plugin, build manifest, tag-triggered CI, MAX-of-two-sources fallback for bump-build). The studio-wide match repo is the highest-leverage piece since both portfolios share Apple Team ID SWA3H3N7TW and are controlled by the same engineer.'
+    tags:
+    - deployment
+    - fastlane
+    - match
+    - ci
+    - cross-portfolio
+    - minicadesmobile
+    origin: manual
+    discovered: 2026-05-13
+  T64.1:
+    name: A single studio-wide match repo serves squz + minicadesmobile signing from one encrypted store
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A private repo (e.g. marcelocantos/certs) holds appstore + adhoc + development cert types for the studio
+    - Both engineers' laptops resolve signing via `bundle exec fastlane match appstore --readonly` without prompting
+    - Adding a new app identifier (e.g. com.squz.newgame) is one `match appstore --app_identifier ...` call
+    - Matchfile template lives in ge with the repo URL and team ID; consuming games copy it via ge/fastlane-init
+    - Match passphrase + ASC API key documented in ge/docs/release-setup.md with exact env-var names
+    context: Highest-leverage piece of T64 — must land before any deployment automation grows further in either portfolio, otherwise migration cost grows. Both portfolios already share Apple Team ID SWA3H3N7TW so the cert prefix space doesn't conflict. mnemo records ~30 min per game lost to "Apple Development" vs "Apple Distribution" signing confusion in stock-car-racing — this is the recurring tax match eliminates.
+    depends_on:
+    - T64
+    tags:
+    - match
+    - signing
+    - fastlane
+    - ios
+    - studio-wide
+    origin: manual
+    discovered: 2026-05-13
+  T64.2:
+    name: ge ships a deterministic make-rule deployment substrate that wraps fastlane lanes and worktree orchestration
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`make ship-alpha`, `make ship-beta VERSION=x`, `make ship-release VERSION=x` cover the full lifecycle'
+    - Each top-level rule is a thin dispatcher; logic lives in tools/ship/*.sh
+    - Subrules `ship-preflight`, `ship-bump`, `ship-worktree`, `ship-build`, `ship-upload`, `ship-publish`, `ship-clean`, `ship-status`, `ship-init` are independently invokable for debugging
+    - '`ship-preflight` enforces: clean tree, ge submodule clean and on master, required env vars present, tag format matches lane, CHANGELOG entry exists for VERSION, Xcode version matches pin, match keychain works without prompt'
+    - '`ship-release` refuses without CONFIRM=1 (matches the global gate convention for store uploads)'
+    - Build number derived from `git rev-list --count HEAD` with MAX-of-two-sources fallback (Transporter SQLite OR rev-list, whichever is higher) — closes the bug mnemo flags in minicadesmobile's bump-build
+    - Tiltbuggy can ship a TestFlight Internal build via `make ship-alpha` end-to-end as the proving ground
+    context: 'The make rules are the deterministic floor that always works without Claude. They''re invocable by humans, by the Claude plugin (T64.3), and by GHA workflows (T64.6). Logic lives in tools/ship/*.sh scripts (set -euo pipefail, testable in isolation), with make as the dispatcher. Lift the proven patterns from MinicadesKit verbatim: heredoc-not-make for any prompt or quoted string >5 lines (lesson from minicadesmobile commit 56228f0); preflight target structure with git-clean + version-dump; build-log auto-append from `git log $LAST_TAG..HEAD` parsed by awk; keychain + env-var fallback for secrets; double-colon `podfile-fixup::` hook pattern for per-game extensions; PATH prefix on xcodebuild to dodge Homebrew rsync 3.x; explicit `adb -s` device resolution.'
+    depends_on:
+    - T64.1
+    tags:
+    - make
+    - substrate
+    - fastlane
+    - preflight
+    - shell-scripts
+    origin: manual
+    discovered: 2026-05-13
+  T64.3:
+    name: ge ships a Claude Code plugin exposing /ge:ship, /ge:release-notes, /ge:ship-status, /ge:onboard
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - ge/.claude-plugin/plugin.json declares the plugin with version pinned to ge's release
+    - Skills under ge/skills/{ship,release-notes,ship-status,onboard}/SKILL.md, namespaced as /ge:* when installed
+    - Plugin installs via `ln -s $(pwd)/ge ~/.claude/plugins/ge` (one-time per checkout, performed by `make ship-init`)
+    - /ge:ship dispatches to `make ship-alpha|ship-beta|ship-release` based on conversational input; never bypasses the make substrate
+    - /ge:ship-status reads build/ship/*/manifest.json files across game repos and emits a portfolio table
+    - Other engineer can run /ge:onboard on a fresh machine and reach a shippable state without referring to docs
+    context: The conversational layer on top of T64.2's make substrate. Plugin lives at ge/.claude-plugin/plugin.json with skills under ge/skills/. Consuming games install via `ln -s $(pwd)/ge ~/.claude/plugins/ge` (done as part of make ship-init), so submodule bumps propagate skill updates automatically. Skills wrap the make rules; they don't replace them — if Claude is unavailable, `make ship-release VERSION=x CONFIRM=1` still works. /ge:ship is the orchestrator (asks alpha/beta/release, picks next minor, runs preflight, handles conversational error recovery). /ge:release-notes drafts CHANGELOG from git log. /ge:ship-status reads build manifests across the portfolio (T64.5). /ge:onboard walks a new engineer / new game through ASC API key creation, match clone, env-var setup, plugin symlink.
+    depends_on:
+    - T64.2
+    tags:
+    - claude-plugin
+    - skills
+    - agentic-ux
+    origin: manual
+    discovered: 2026-05-13
+  T64.4:
+    name: All ship pipelines build from a temporary git worktree so WIP cannot leak into a release
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`make ship-worktree TAG=v0.4.0` creates build/ship/v0.4.0/ via `git worktree add`'
+    - Submodule init runs inside the worktree (recursive init not implicit) before any build step
+    - Successful ship removes the worktree; failed ship leaves it for inspection
+    - '`make ship-clean` prunes worktrees older than N days (default 14)'
+    - Same physical command works for both engineers from their respective laptops, producing byte-equivalent outputs given match-installed signing
+    context: Structural enforcement of build hygiene — replaces "remember to commit before shipping" with "the worktree is at a specific tag, period". Worktree gets fresh submodule init (ge must be initialised inside the worktree explicitly — `git worktree add` does not recurse). On success, worktree is removed; on failure, leave for inspection (`make ship-clean` prunes older than N days). Defense-in-depth with the preflight checks from T64.2 — worktree guarantees clean state, preflight asserts it. The .claude/worktrees/{port,port-bgfx} convention already exists ad-hoc in stock-car-racing, so this formalises an existing pattern rather than introducing a foreign one.
+    depends_on:
+    - T64.2
+    tags:
+    - worktree
+    - build-hygiene
+    - isolation
+    origin: manual
+    discovered: 2026-05-13
+  T64.5:
+    name: Every shipped binary embeds a build manifest accessible at runtime
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - build/ship/<tag>/manifest.json written by ship-build step with all provenance fields
+    - Manifest embedded as an asset in the IPA / AAB
+    - Tiltbuggy exposes manifest via debug screen or startup log (proving-ground)
+    - /ge:ship-status (T64.3) reads manifests across a directory of game checkouts to produce a portfolio table
+    context: 'Captures: game git SHA, ge submodule SHA, build number, version, lane, builder hostname, timestamp. Embedded as an asset (iOS) / raw resource (Android). Surfaced via a debug screen, startup log, or a long-press gesture. Removes the "which build is this?" detective work when a tester reports a bug — one command shows exact provenance. Mnemo evidence: both ge and minicadesmobile lose time reconciling IPAs to commits; this is a 20-line fix that eliminates the class. Also enables /ge:ship-status to enumerate portfolio state by reading manifests across game checkouts.'
+    depends_on:
+    - T64.2
+    tags:
+    - build-manifest
+    - provenance
+    - debugging
+    origin: manual
+    discovered: 2026-05-13
+  T64.6:
+    name: Android releases trigger from git tag via GitHub Actions; iOS releases run from laptop using the same fastlane lanes
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`.github/workflows/release.yml` template lives in ge, copied into game repos by ge/ci-init'
+    - Tag `v*` on a game repo triggers Android build → Play Internal (or Production for stable tags)
+    - Tag `beta-*` triggers Android build → Play Beta/Closed track
+    - iOS Fastfile is identical for laptop and CI use; env vars sourced from GHA secrets in CI and ~/.zshenv on laptop
+    - Org-level GHA secrets (ASC_API_KEY_ID, ASC_API_ISSUER_ID, ASC_API_KEY, PLAY_SERVICE_ACCOUNT_JSON, MATCH_PASSWORD) configured at the squz / minicadesmobile org scope so new game repos inherit
+    - 'Migration path documented: flipping iOS to CI is a ~30 min job (add job to workflow, no Fastfile change)'
+    context: 'Hybrid model to avoid macOS runner costs initially while keeping the migration path to full-CI iOS trivially cheap. The Fastfile is written as if CI were always going to run it: `match(readonly: true)`, env-var-driven secrets, `setup_ci` (no-op locally), no references to interactive Xcode UI. Same `bundle exec fastlane ios beta` works on laptop and CI. Flipping iOS to GHA later = add a `build-ios` job + plumb the same secrets, ~30 min. Android in CI from day 1 because Linux runners are 10x cheaper than macOS and Android tooling runs identically.'
+    depends_on:
+    - T64.1
+    - T64.2
+    tags:
+    - github-actions
+    - ci
+    - hybrid-deployment
+    - tag-triggered
+    origin: manual
+    discovered: 2026-05-13
+  T64.7:
+    name: MinicadesKit back-ports ge's new pieces; both portfolios converge on shared signing + plugin UX
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - MinicadesKit's Modules.mk gains the MAX-of-two-sources fallback in bump-build (Transporter SQLite OR rev-list, whichever is higher)
+    - MinicadesKit games use the studio-wide match repo from T64.1 (one Matchfile per game, same repo URL)
+    - MinicadesKit's `make testflight` flow wraps in a git worktree (lifting the .claude/worktrees/* convention into the official surface)
+    - MinicadesKit binaries embed a build manifest (T64.5 pattern)
+    - Tag-triggered Android workflow lands in at least one MinicadesKit game
+    - '`/mk:ship` Claude Code plugin generalises the /ge:ship pattern for Unity-based games'
+    context: Reverse direction of the bidirectional flow. Once ge has proven the new architectural moves on a real game (tiltbuggy as the proving ground), port them back to MinicadesKit so the existing Unity-game portfolio gets the same benefits. Most urgent back-port is the MAX-of-two-sources fallback in bump-build — mnemo records this as an open bug in stock-car-racing where Transporter UI clearing the SQLite cache caused MAX to return 0. The studio-wide match repo (T64.1) lands first regardless, since both portfolios benefit immediately. Plugin UX comes last — `/mk:ship` etc. once `/ge:ship` is proven.
+    depends_on:
+    - T64.1
+    - T64.3
+    - T64.4
+    - T64.5
+    - T64.6
+    tags:
+    - minicadesmobile
+    - back-port
+    - cross-portfolio
+    - convergence
+    origin: manual
+    discovered: 2026-05-13
+  T65:
+    name: Cross-platform IAP via ge::iap — games introduce paid unlocks in under ten lines
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'A consuming game adds a non-consumable unlock with under ten lines of code: register_, owned(), buy() with callback, restore() trigger'
+    - 'Same code compiles and runs on macOS desktop (stub), iOS device (real StoreKit), and Android device (real Play Billing) without #ifdef in the game'
+    - Tiltbuggy ships a `pro` non-consumable that unlocks visible content as the proving ground
+    - Studio-wide sandbox tester / license tester pool is documented in ge/docs/iap-testing.md with credentials in the shared password manager
+    context: 'Engine-level abstraction over StoreKit 2 (iOS) and Play Billing 7+ (Android). Consumer game registers products by local ID, queries owned() at O(1) against a cache, calls buy() with a result callback. ge prepends bundle ID to form platform SKUs so the same string registered in App Store Connect / Play Console is also what the game writes. Three backends select at init from env var: Stub (CI), Local (.storekit / android.test.* for fast iteration), Platform (real stores). Modern frameworks return signature-verified transactions; ge writes only verified entitlements to a platform-native cache (Keychain / EncryptedSharedPreferences). Server-side receipt validation is intentionally not in scope at v1 — for paid one-shot unlocks against casual game audiences, the JWS verification floor is enough, and the threat model doesn''t justify running a validation server. Subscriptions, server validation, and pending-purchase handling are explicitly deferred until a real game needs them.'
+    tags:
+    - iap
+    - storekit
+    - play-billing
+    - cross-platform
+    origin: manual
+    discovered: 2026-05-14
+  T65.1:
+    name: ge::iap public C++ surface plus StubStore backend — pure C++, unit-testable, no platform dependencies
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - include/ge/iap.h defines the public surface (Product, LocalisedProduct, Result, Type, register_, owned, products, buy, restore) and compiles standalone
+    - src/iap.cpp dispatcher selects backend at init based on GE_IAP_MODE env var; default = stub on desktop, platform on mobile (platform path may be unimplemented until T65.2/T65.3)
+    - src/iap_stub.cpp implements StubStore with in-memory ownership, setOwned/clearAll for tests, callback delivery
+    - src/iap_test.cpp has doctest coverage of register/owned/buy/restore plus duplicate-registration and missing-ID error paths
+    - Module.mk and CMakeLists include iap sources in ge/SRC; `make unit-test` passes on macOS
+    - CLAUDE.md gains an `### IAP (🎯T65)` section describing the public API and StubStore backend
+    context: 'The floor that unblocks everything else. Public header at include/ge/iap.h with Product, LocalisedProduct, Result, Type, register_, owned, products, buy, restore. StubStore at src/iap_stub.cpp keeps an in-memory set of owned IDs; exposes setOwned(id, bool) for tests. Dispatcher at src/iap.cpp picks backend at first call to register_ based on GE_IAP_MODE env var (default: stub on desktop, platform on iOS/Android — Local will land in T65.4). Doctest coverage at src/iap_test.cpp exercising the full surface including callback delivery, restore semantics, and product registration with duplicate IDs.'
+    depends_on:
+    - T65
+    tags:
+    - iap
+    - api
+    - stub
+    - unit-test
+    origin: manual
+    discovered: 2026-05-17
   T7:
     name: Audio pauses when the app is backgrounded
     status: identified

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2127,7 +2127,7 @@ targets:
     discovered: 2026-05-17
   T66:
     name: ge installs a cross-platform spdlog sink so SPDLOG_INFO surfaces uniformly on iOS, Android, and desktop
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2179,6 +2179,7 @@ targets:
     - dev-experience
     origin: manual
     discovered: 2026-05-19
+    achieved: 2026-05-19
   T7:
     name: Audio pauses when the app is backgrounded
     status: identified

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1996,7 +1996,7 @@ targets:
     achieved: 2026-05-17
   T65.2:
     name: StoreKit 2 backend (iap_apple.mm) — verified transactions, entitlement cache, product fetch
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2015,6 +2015,7 @@ targets:
     - apple
     origin: manual
     discovered: 2026-05-17
+    achieved: 2026-05-17
   T65.3:
     name: Play Billing 7+ backend (iap_android.cpp + JNI to BillingClient) — signed purchases, async product fetch
     status: identified

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2018,7 +2018,7 @@ targets:
     achieved: 2026-05-17
   T65.3:
     name: Play Billing 7+ backend (iap_android.cpp + JNI to BillingClient) — signed purchases, async product fetch
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2037,6 +2037,7 @@ targets:
     - jni
     origin: manual
     discovered: 2026-05-17
+    achieved: 2026-05-17
   T65.4:
     name: LocalStore mode — .storekit (iOS) and android.test.* (Android) for offline dev iteration
     status: identified

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1,4 +1,4 @@
-schema_version: 4
+schema_version: 5
 targets:
   T1:
     name: Game servers can run inside the player via WebAssembly
@@ -351,7 +351,6 @@ targets:
     achieved: 2026-04-19
   T19:
     name: 'render-engine-bridge-split branch can be merged: the full mobile matrix of automated + device smokes runs clean'
-    kind: verify
     status: achieved
     value: 0.0
     cost: 0.0
@@ -379,8 +378,6 @@ targets:
       Plus a debug-build smoke cycle of 6 cells (platform × mode, one runtime).
 
       matrix-test.sh currently covers 6 automatable cells (sim/emu, no form-factor split). Extending to the full matrix is follow-on work (form-factor split, device cells, debug cycle — each a sub-target). The minimum gate for THIS round is: all currently-implemented cells pass, physical devices hand-verified via ge/tools/smoke-test.sh, rotation-stability-test green on iOS.
-    verifies:
-    - T18
     origin: manual
     discovered: 2026-04-19
     achieved: 2026-04-19
@@ -1976,7 +1973,7 @@ targets:
     discovered: 2026-05-14
   T65.1:
     name: ge::iap public C++ surface plus StubStore backend — pure C++, unit-testable, no platform dependencies
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1994,6 +1991,136 @@ targets:
     - api
     - stub
     - unit-test
+    origin: manual
+    discovered: 2026-05-17
+    achieved: 2026-05-17
+  T65.2:
+    name: StoreKit 2 backend (iap_apple.mm) — verified transactions, entitlement cache, product fetch
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - src/iap_apple.mm implements the Store interface for iOS / macOS
+    - Only verificationResult == .verified transactions populate the entitlement cache; unverified ones are logged and dropped
+    - Transaction.updates observer runs for the process lifetime; cache reflects refunds and subscription expiry without app restart
+    - Tiltbuggy ships a non-consumable on iOS and the entitlement survives uninstall + reinstall via Apple's account-bound state (manual verification)
+    - CMakeLists.txt + Module.mk include iap_apple.mm in Apple builds; src/iap.cpp (StubStore) remains the cross-platform fallback
+    context: iOS implementation of the internal Store interface defined in src/iap.cpp. Uses StoreKit 2's async/await API bridged through Objective-C++ to ge::iap's callback surface. Reads catalogue, calls Product.products(for:) for localised metadata, observes Transaction.updates and Transaction.currentEntitlements. Writes only signature-verified transactions (Transaction.verificationResult == .verified) into the entitlement cache. Listens on a long-lived task for refunds, subscription expiry, and Ask-to-Buy resolution. Bundle ID prepended to local product IDs to form platform SKUs.
+    depends_on:
+    - T65.1
+    tags:
+    - iap
+    - storekit
+    - ios
+    - apple
+    origin: manual
+    discovered: 2026-05-17
+  T65.3:
+    name: Play Billing 7+ backend (iap_android.cpp + JNI to BillingClient) — signed purchases, async product fetch
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - src/iap_android.cpp + Kotlin side in android-shared implements the Store interface for Android
+    - Only signature-verified, PURCHASED purchases populate the entitlement cache
+    - PurchasesUpdatedListener wired so cache reflects refunds, voided purchases, subscription expiry
+    - Tiltbuggy ships a non-consumable on Android and the entitlement survives uninstall + reinstall (Google account-bound, manual verification)
+    - CMakeLists.txt branches on Android to compile iap_android.cpp; Gradle adds the Play Billing dependency
+    context: Android implementation of the internal Store interface. JNI bridge to BillingClient (Play Billing Library 7+) wired through ge.GeActivity. queryProductDetailsAsync for localised metadata; queryPurchasesAsync at startup to populate the entitlement cache; PurchasesUpdatedListener for live events. Only Purchase.purchaseState == PURCHASED + signature-verified entries written to cache; PENDING (slow payment methods) surfaces as owned()==false until confirmed, with onPending callback in a follow-up. Bundle ID prepended to local product IDs.
+    depends_on:
+    - T65.1
+    tags:
+    - iap
+    - play-billing
+    - android
+    - jni
+    origin: manual
+    discovered: 2026-05-17
+  T65.4:
+    name: LocalStore mode — .storekit (iOS) and android.test.* (Android) for offline dev iteration
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A committed ios/StoreKit.storekit template lives in ge with the product schema; consuming games copy + customise via a make rule
+    - When GE_IAP_MODE=local on iOS, StoreKit reads from the .storekit file; products() returns the configured set, buy() exercises the real signature-verification path
+    - On Android, GE_IAP_MODE=local routes buy() to android.test.purchased / canceled / refunded / item_unavailable based on the local product ID
+    - Documented in CLAUDE.md alongside the debug menu (T65.6) with guidance on when to use each
+    context: 'When GE_IAP_MODE=local, run the platform StoreKit / Play Billing path against fake products. iOS: a committed .storekit configuration file describes products inline; Xcode injects them into the StoreKit API at run time, no App Store Connect round-trip, works in the simulator with no signed-in account. Android: use the reserved android.test.* SKUs (purchased / canceled / refunded / item_unavailable) for the basic flow. Less capable than sandbox accounts (no subscriptions on Android side) but unblocks the inner loop. Lower priority than the debug menu (T65.6) — that''s the day-to-day tool. This target exists for the case where a developer genuinely wants to validate the real framework path without sandbox credentials.'
+    depends_on:
+    - T65.2
+    - T65.3
+    tags:
+    - iap
+    - storekit
+    - play-billing
+    - local-dev
+    origin: manual
+    discovered: 2026-05-17
+  T65.5:
+    name: Entitlement cache persists in Keychain (iOS) and EncryptedSharedPreferences (Android)
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - StubStore continues to use in-memory state (no persistence — tests start clean)
+    - iOS PlatformStore writes verified entitlements to Keychain with kSecAttrAccessibleAfterFirstUnlock
+    - Android PlatformStore writes verified entitlements to EncryptedSharedPreferences
+    - On launch, owned() returns the persisted cache value within the first frame; the store's current-entitlements query then reconciles within the first second
+    - Cache lifecycle and invalidation rules documented in CLAUDE.md's IAP section
+    context: 'owned() must be cheap — games call it from render loops. The cache populates on init from the platform store''s current-entitlements query (StoreKit Transaction.currentEntitlements / Play Billing queryPurchasesAsync) and refreshes on transaction-updated callbacks. Persistence beyond the process lifetime uses platform-native secure storage: Keychain on iOS (survives reinstall, kSecAttrAccessibleAfterFirstUnlock), EncryptedSharedPreferences on Android (survives reinstall when auto-backup is enabled). Cache is advisory — the store is always queried at startup as the source of truth; the persisted cache fills the window between launch and first store response so owned() returns the right answer for the first frame.'
+    depends_on:
+    - T65.2
+    - T65.3
+    tags:
+    - iap
+    - cache
+    - keychain
+    - encryptedsharedpreferences
+    origin: manual
+    discovered: 2026-05-17
+  T65.6:
+    name: ge::iap::DebugPanel — long-press to toggle entitlements in dev builds
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A long-press in the top-right corner of a debug build opens the panel; release builds compile the panel code out
+    - Panel lists all registered products with live ownership state and tap-to-toggle
+    - Reset-all and force-restore buttons work
+    - 'Tiltbuggy proves out the loop: long-press → toggle pro → gated content appears / disappears without restart'
+    - Panel rendered via ge::Sprite + lunasvg — no Dear ImGui or other heavy dep
+    context: Inner-loop testing tool. Long-press a screen corner in debug builds opens an SVG-rendered panel listing every registered product with its current ownership state. Tap a product to toggle entitled / not-entitled via ge::iap::testing::setOwned, which goes through StubStore directly. Includes "Reset all purchases" and "Force restore" buttons. Compiled out of release builds entirely. This is the workflow that matters day-to-day; .storekit / sandbox testers are the once-per-release verification path. Sits on top of T65.1 (the testing surface) and reuses ge::Button (T59) + lunasvg (T42) for the UI.
+    depends_on:
+    - T65.1
+    tags:
+    - iap
+    - debug
+    - ui
+    - lunasvg
+    origin: manual
+    discovered: 2026-05-17
+  T65.7:
+    name: Tiltbuggy ships a `pro` non-consumable unlock as the proving ground for ge::iap
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - Tiltbuggy registers `pro` and gates at least one visible piece of content behind owned(`pro`)
+    - com.squz.tiltbuggy.pro registered in App Store Connect; matching SKU in Play Console
+    - TestFlight Internal build demonstrates buy() succeeding via a sandbox Apple ID; the gated content unlocks without restart
+    - Play Internal Testing build demonstrates buy() succeeding via a license tester Google account; the gated content unlocks without restart
+    - Uninstall + reinstall + Restore Purchases recovers the entitlement on both platforms
+    context: Validates the whole T65 stack against a real consumer. Tiltbuggy registers `pro` as a NonConsumable in setCatalogue, gates some visible content behind owned(), surfaces a buy button + Restore Purchases button in the UI. SKU registered in App Store Connect as com.squz.tiltbuggy.pro and in Play Console with matching ID. Shipped via TestFlight Internal + Play Internal Testing using sandbox / license tester accounts. Demonstration target — retirement requires a real device showing the locked-then-unlocked transition.
+    depends_on:
+    - T65.2
+    - T65.3
+    - T65.5
+    - T65.6
+    tags:
+    - iap
+    - tiltbuggy
+    - proving-ground
     origin: manual
     discovered: 2026-05-17
   T7:

--- a/docs/iap-testing.md
+++ b/docs/iap-testing.md
@@ -1,0 +1,108 @@
+# IAP Testing — studio-wide protocol
+
+Cross-portfolio sandbox + license-tester setup for the `ge::iap` stack (🎯T65).
+Same pattern as the studio-wide match repo (🎯T64.1): one tester pool per platform,
+shared across every squz + minicadesmobile game, credentials in the shared password
+manager.
+
+## iOS — sandbox testers
+
+Sandbox testers are synthetic Apple IDs created in App Store Connect with no real
+payment methods. Signed in via **Settings → App Store → Sandbox Account** on the
+device. Purchases are signature-verified by Apple's sandbox infrastructure;
+subscriptions tick at ~5 min per month for testing. No card is ever charged.
+
+**Pool location**: App Store Connect → Users and Access → Sandbox Testers.
+
+**Naming convention** (one per engineer, plus one shared rotating account for
+multi-device testing):
+
+| Tester | Apple ID | Notes |
+|---|---|---|
+| `marcelo+sb@…` | (in password manager) | Marcelo's primary |
+| `<engineer>+sb@…` | (in password manager) | Per-engineer primary |
+| `shared+sb@…` | (in password manager) | Multi-device QA |
+
+**On-device setup** (per engineer, per device, one-time):
+1. Settings → App Store → Sandbox Account.
+2. Sign in with the assigned sandbox Apple ID.
+3. Confirm via two-factor prompt sent to the assigned recovery email.
+4. The account stays signed in until manually changed; production purchases
+   continue to use the device's main Apple ID.
+
+**Adding a new game**: register the SKUs (`com.squz.<game>.<sku>`) in App Store
+Connect → My Apps → <game> → Monetization → In-App Purchases. Sandbox testers
+work against any registered SKU automatically; no per-game tester setup.
+
+## Android — license testers
+
+License testers are real Google accounts on an allowlist in Play Console. Test
+purchases run the full Play Billing flow (UI, "Buy" button, order created) but
+are tagged as test purchases — the card is **never charged** at any point.
+Holds on internal, closed, open, and production tracks.
+
+**Pool location**: Play Console → Setup → License testing (top-level, applies
+to every app in the organisation).
+
+**Naming convention** (one per engineer; same Google account as the engineer
+uses for development, no synthetic accounts):
+
+| Tester | Google account | Notes |
+|---|---|---|
+| `marcelo@…` | (in password manager) | Marcelo's primary |
+| `<engineer>@…` | (in password manager) | Per-engineer primary |
+
+**Onboarding order matters** — add the account to license testers in Play
+Console *before* the engineer installs the build. An installed-then-added
+flow leaves a window where a real charge can occur if the engineer purchases
+something. Defensive default: never tap "Buy" on Android until you've
+confirmed your Google account is on the license tester list for the
+target track.
+
+**Adding a new game**: register the SKUs (`com.squz.<game>.<sku>`) in
+Play Console → <app> → Monetize → Products → In-app products (or
+Subscriptions). License testers work against any registered SKU
+automatically; no per-game tester setup.
+
+## TestFlight / Play Internal — production-grade with free purchases
+
+Both tester pools above also work against TestFlight builds (iOS) and Play
+Internal Testing builds (Android). These are the canonical end-to-end
+verification path before a build promotes to external beta or production.
+
+**iOS**: build → upload to TestFlight via fastlane (🎯T64.6) → install via
+TestFlight app → sign in to sandbox account → buy product → receipt is
+signature-verified, entitlement persists in Keychain (🎯T65.5).
+
+**Android**: build → upload AAB to Play Internal Testing via fastlane →
+install via Play Store opt-in URL → log in with a license tester Google
+account → buy product → receipt is signature-verified, entitlement persists
+in EncryptedSharedPreferences (🎯T65.5).
+
+## Local-only dev iteration
+
+For inner-loop work, neither sandbox nor license testers are needed. Use
+the in-engine debug panel (🎯T65.6) to toggle entitlements directly —
+long-press the top-right corner of a debug build, tap a product to flip
+its owned state. Compiled out of release builds.
+
+If you specifically want to validate the platform framework path without
+sandbox credentials, use `GE_IAP_MODE=local` (🎯T65.4): iOS reads from a
+committed `.storekit` file, Android uses the reserved `android.test.*` SKUs.
+
+## Credentials
+
+All sandbox Apple IDs and license tester Google account credentials live in
+the shared 1Password vault under **"IAP testers — studio-wide"**. Vault
+access is per-engineer; ask Marcelo for the invite link. Never check
+credentials into a repo, including ge.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| iOS sandbox sign-in fails with "Cannot connect to iTunes Store" | Sandbox tester was created less than ~30 min ago | Wait; Apple's sandbox propagation takes time |
+| iOS purchase prompt asks for production Apple ID password | No sandbox tester signed in | Settings → App Store → Sandbox Account → sign in |
+| Android "Authentication is required" loop | Google account not on the license tester list | Add the account in Play Console → Setup → License testing |
+| Android "Item not found" | SKU not registered in Play Console, OR app not uploaded to a track that the tester account can install | Register the SKU; upload at least one build to Internal Testing |
+| `owned()` returns false right after a successful `buy()` callback | Cache write hasn't completed yet | T65.5 makes this synchronous; if pre-T65.5, re-query after the next render frame |

--- a/include/ge/iap.h
+++ b/include/ge/iap.h
@@ -105,4 +105,37 @@ void clearAll();
 
 } // namespace testing
 
+// In-engine debug panel for toggling entitlements without touching a
+// real store. Pure state + actions — the game renders the panel using
+// its own UI primitives (ge::Sprite + lunasvg recommended) and pumps
+// pointer events through onRowTap/onResetAll/onForceRestore. Compile
+// out of release builds by guarding instantiation with #ifndef NDEBUG.
+struct DebugPanel {
+    struct Row {
+        std::string id;
+        Type        type;
+        bool        owned;
+    };
+
+    bool visible = false;
+
+    void show()   { visible = true;  }
+    void hide()   { visible = false; }
+    void toggle() { visible = !visible; }
+
+    // Live snapshot of registered products with current owned state.
+    std::vector<Row> rows() const;
+
+    // Flip a product's owned state via testing::setOwned. The next
+    // call to rows() reflects the change.
+    void onRowTap(const std::string& id);
+
+    // Wipe all entitlements via testing::clearAll.
+    void onResetAll();
+
+    // Trigger restore(). Useful for verifying the restore code path
+    // on stub before sandbox accounts are wired up.
+    void onForceRestore(RestoreCallback cb = {});
+};
+
 } // namespace ge::iap

--- a/include/ge/iap.h
+++ b/include/ge/iap.h
@@ -1,0 +1,108 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-platform in-app purchases. The consumer game registers a
+// product catalogue, queries owned() in O(1) against a cached
+// entitlement set, and initiates purchases through buy() with a
+// callback. The same code compiles and runs on macOS (StubStore),
+// iOS (StoreKit 2), and Android (Play Billing) without #ifdef.
+//
+// Backend selection happens once at init from the GE_IAP_MODE env var:
+//   stub      — pure C++ in-memory, no platform calls. CI default.
+//   local     — .storekit (iOS) / android.test.* (Android). Dev iteration.
+//   platform  — real StoreKit / Play Billing. Release default on mobile.
+// On platforms where the requested backend isn't implemented, the
+// dispatcher falls back to stub and logs a warning.
+//
+// Product IDs are local — the consumer writes "pro", and ge prepends
+// the bundle ID to form the platform SKU "com.squz.tiltbuggy.pro".
+// The same string registered in App Store Connect and Play Console
+// is what appears in the game's source — no separate mapping table.
+//
+// Threat model: the platform frameworks return signature-verified
+// transactions (StoreKit 2 JWS, Play Billing signed receipts). ge
+// writes only verified entitlements to the cache. Server-side
+// validation is not provided and is genuinely not needed for paid
+// non-consumable unlocks against the casual game audience — the
+// JWS floor handles replay, account-binding, and bundle-ID-binding.
+// Add server-side validation when shipping subscriptions or
+// high-value-currency consumables.
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace ge::iap {
+
+enum class Type {
+    NonConsumable,            // One-shot unlock (remove ads, pro upgrade)
+    Consumable,               // Re-buyable (currency packs, hint bundles)
+    AutoRenewingSubscription, // Monthly/yearly. Server validation recommended.
+};
+
+struct Product {
+    std::string id;                          // Local ID, e.g. "pro"
+    Type        type = Type::NonConsumable;
+};
+
+struct LocalisedProduct {
+    std::string id;
+    std::string title;
+    std::string description;
+    std::string price;        // Pre-formatted with currency, e.g. "$2.99"
+    std::string currency;     // ISO 4217, e.g. "USD"
+};
+
+struct Result {
+    bool        ok       = false;
+    std::string id;
+    std::string error;        // Populated when !ok
+};
+
+using BuyCallback     = std::function<void(Result)>;
+using RestoreCallback = std::function<void(Result)>;
+
+// Register the catalogue. Call once at startup, before any owned/buy/
+// products/restore call. Subsequent calls with the same products are
+// a no-op; re-registering an existing ID with a different type aborts
+// (assertion failure — catch in development, not at runtime in the field).
+void setCatalogue(std::vector<Product> catalogue);
+
+// True iff the product is currently entitled. Cached query — safe
+// to call from render loops. Returns false before setCatalogue has
+// run, or for an unregistered ID.
+bool owned(const std::string& id);
+
+// Localised product metadata for price labels in UI. Empty before
+// setCatalogue has run, or while the platform store hasn't yet
+// returned product info (StoreKit / Play Billing populate
+// asynchronously). Returns a copy.
+std::vector<LocalisedProduct> products();
+
+// Initiate a purchase. cb fires exactly once:
+//   ok = true,  id = product ID on success
+//   ok = false, error = reason on failure or user cancel
+// May fire synchronously (StubStore) or asynchronously (platform stores).
+// Callback runs on the main thread.
+void buy(const std::string& id, BuyCallback cb);
+
+// Re-query the platform for previously-purchased non-consumables.
+// Apple App Review requires a visible "Restore Purchases" button —
+// route it to this function. cb fires once after the query completes;
+// the entitlement cache is updated before cb runs.
+void restore(RestoreCallback cb);
+
+// Testing surface — for unit tests and the in-engine debug menu (T65.6).
+// On StubStore these are authoritative. On platform stores they are
+// no-ops with a warning log; the entitlement cache there is owned by
+// the real store.
+namespace testing {
+
+void setOwned(const std::string& id, bool owned);
+void clearAll();
+
+} // namespace testing
+
+} // namespace ge::iap

--- a/include/ge/log.h
+++ b/include/ge/log.h
@@ -1,0 +1,50 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-platform spdlog sink that fans SPDLOG_INFO/WARN/ERROR/DEBUG/
+// CRITICAL output to the native log channel:
+//   * Apple — os_log_with_type via os_log_create(subsystem, "ge").
+//     Captured by `spyder log <udid> --process <CFBundleExecutable>`
+//     (and Xcode Console). The whole spdlog-rendered payload is
+//     passed as a single `%{public}s` argument so every value is
+//     visible without per-call %{public} boilerplate.
+//   * Android — __android_log_print with tag = subsystem (truncated
+//     to 23 chars per Android's TAG limit). Captured by `adb logcat`.
+//   * Desktop — spdlog's default colour-stderr sink, unchanged.
+//
+// Why this lives in ge: Apple's privacy-by-default unified-log
+// behaviour makes SPDLOG_INFO invisible on iOS without an
+// os_log_create-based sink; capture also requires a named subsystem
+// (not OS_LOG_DEFAULT). Encoding the workaround once in the engine
+// saves every consumer game the same multi-day reverse-engineering
+// puzzle that surfaced during multimaze2's 🎯T17 instrumentation
+// push (2026-05-17 → 2026-05-19).
+//
+// spdlog level → native level mapping:
+//   trace/debug → OS_LOG_TYPE_DEBUG  / ANDROID_LOG_VERBOSE-DEBUG
+//   info        → OS_LOG_TYPE_INFO   / ANDROID_LOG_INFO
+//   warn        → OS_LOG_TYPE_DEFAULT/ ANDROID_LOG_WARN
+//   error       → OS_LOG_TYPE_ERROR  / ANDROID_LOG_ERROR
+//   critical    → OS_LOG_TYPE_FAULT  / ANDROID_LOG_FATAL
+
+#pragma once
+
+#include <string>
+
+namespace ge::log {
+
+// Install the platform-native spdlog sink. Idempotent — second and
+// later calls are no-ops. Normally called once from `ge::run` before
+// any logging happens; consumer apps don't need to call it directly.
+//
+// `subsystem` is the logger name used for capture-side filtering.
+// Empty string auto-detects:
+//   * iOS — `[[NSBundle mainBundle] bundleIdentifier]`
+//     (e.g. "com.squz.tiltbuggy").
+//   * Android — `Activity.getPackageName()` via SDL's JNI bridge
+//     (truncated to 23 chars for the logcat tag).
+//   * Desktop — falls back to "ge"; subsystem isn't used by the
+//     stderr sink so the value is informational only.
+void install(std::string subsystem = "");
+
+} // namespace ge::log

--- a/sample/tiltbuggy/src/Renderer.cpp
+++ b/sample/tiltbuggy/src/Renderer.cpp
@@ -82,6 +82,14 @@ constexpr std::string_view kIcyPondSvg = R"SVG(<svg xmlns="http://www.w3.org/200
         fill="none" stroke="#4A7A9C" stroke-width="2.5" stroke-opacity="0.65"/>
 </svg>)SVG";
 
+// Buy-PRO button — shown when ge::iap::owned("pro") is false. Tapping
+// triggers ge::iap::buy("pro") in main.cpp's onEvent (hit-test against
+// the same screen-pixel rect via tiltbuggy::proButtonScreenRect).
+constexpr std::string_view kBuyProSvg = R"SVG(<svg xmlns="http://www.w3.org/2000/svg" width="256" height="80" viewBox="0 0 256 80">
+  <rect x="2" y="2" width="252" height="76" rx="14" fill="#FFCC33" stroke="#222222" stroke-width="3"/>
+  <text x="128" y="52" font-family="sans-serif" font-weight="bold" font-size="34" text-anchor="middle" fill="#222222">BUY PRO</text>
+</svg>)SVG";
+
 // Game title rendered as SVG <text>. Exercises the lazy default-font path
 // added in T42.4 — no app-side font setup, sans-serif comes from
 // ge::resolveFont("system:sans-serif") on first rasterize. Bold on macOS
@@ -184,18 +192,32 @@ constexpr uint32_t rgb(uint32_t r, uint32_t g, uint32_t b) {
 
 } // namespace
 
+// BUY PRO button screen rect. Lives at the top-left corner of the UI
+// safe rect so it never sits under the camera notch / Dynamic Island.
+// Size scales with pixelsPerPt so the tap target stays at ~85 × 27 pt
+// (above Apple HIG's 44 pt minimum) on every device class.
+ge::Rect proButtonRect(const ge::Context& c) {
+    const auto safe = c.uiSafeRect();
+    const float pad = 16.f * c.pixelsPerPt();
+    const float bw  = 85.f * 3.0f * c.pixelsPerPt();
+    const float bh  = 27.f * 3.0f * c.pixelsPerPt();
+    return {safe.x + pad, safe.y + pad, bw, bh};
+}
+
 struct Renderer::Impl {
     bgfx::VertexLayout  layout;
     bgfx::ProgramHandle program = BGFX_INVALID_HANDLE;
     ge::Sprite          pond;
     ge::Sprite          title;
+    ge::Sprite          buyPro;
 };
 
 Renderer::Renderer() : i_(std::make_unique<Impl>()) {}
 Renderer::~Renderer() {
-    if (bgfx::isValid(i_->program))  bgfx::destroy(i_->program);
-    if (bgfx::isValid(i_->pond.tex)) bgfx::destroy(i_->pond.tex);
+    if (bgfx::isValid(i_->program))   bgfx::destroy(i_->program);
+    if (bgfx::isValid(i_->pond.tex))  bgfx::destroy(i_->pond.tex);
     if (bgfx::isValid(i_->title.tex)) bgfx::destroy(i_->title.tex);
+    if (bgfx::isValid(i_->buyPro.tex)) bgfx::destroy(i_->buyPro.tex);
 }
 
 void Renderer::init(const char* shaderDir) {
@@ -212,6 +234,11 @@ void Renderer::init(const char* shaderDir) {
     // Rasterize the "TILT BUGGY" title SVG. 768x128 = 6:1 aspect; we'll
     // place it in a similarly proportioned world rect above the pond.
     i_->title = ge::rasterizeSvg(kTitleSvg, 768, 128);
+
+    // Rasterize the BUY PRO button (256x80). Drawn only when the pro
+    // entitlement isn't owned; tap triggers ge::iap::buy("pro") in
+    // main.cpp's onEvent.
+    i_->buyPro = ge::rasterizeSvg(kBuyProSvg, 256, 80);
 }
 
 void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
@@ -270,15 +297,21 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
     pushRect(verts, ge::Rect{bgL, bgB, bgR - bgL, bgT - bgB}, rgb(0xAA, 0x66, 0x44));
 
     // 2. Surface rects (excluding ice — drawn as a textured sprite below).
-    for (const auto& s : scene.surfaces()) {
-        uint32_t color;
-        switch (s.type) {
-            case SurfaceType::Ice:     continue;  // see ice-sprite pass below
-            case SurfaceType::Dirt:    color = rgb(0xAA, 0x66, 0x44); break;
-            case SurfaceType::Asphalt: continue;
-            default:                   continue;
+    // Both the dirt patch and the icy pond are gated behind the `pro`
+    // IAP (🎯T65.7) — without it the buggy slides on featureless
+    // asphalt; buying pro materialises the terrain features.
+    const bool proOwned = ge::iap::owned("pro");
+    if (proOwned) {
+        for (const auto& s : scene.surfaces()) {
+            uint32_t color;
+            switch (s.type) {
+                case SurfaceType::Ice:     continue;  // see ice-sprite pass below
+                case SurfaceType::Dirt:    color = rgb(0xAA, 0x66, 0x44); break;
+                case SurfaceType::Asphalt: continue;
+                default:                   continue;
+            }
+            pushRect(verts, s.rect, color);
         }
-        pushRect(verts, s.rect, color);
     }
 
     // 3. Buggy — sized in proportion to the world (kept at 1/20 of the
@@ -320,7 +353,7 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
     // World is y-up (gravity points -y), so the rect's `y` is the rect's
     // TOP (larger y) and `h` is NEGATIVE, flipping the y basis so the
     // sprite's source-image top lands at world top.
-    if (!i_->pond.isNull()) {
+    if (proOwned && !i_->pond.isNull()) {
         for (const auto& s : scene.surfaces()) {
             if (s.type != SurfaceType::Ice) continue;
             // Inflate 25% so the irregular bezier border has visible overhang
@@ -356,6 +389,23 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
         });
         bgfx::setTransform(&m[0][0]);
         i_->title.draw(0);
+    }
+
+    // BUY PRO button — only when pro isn't owned. Positioned in screen-
+    // pixel coordinates inside the UI safe rect; tiltbuggy::proButtonRect
+    // returns the same screen rect that main.cpp hit-tests in onEvent.
+    if (!proOwned && !i_->buyPro.isNull()) {
+        const auto btn = proButtonRect(c);
+        // Screen → world conversion uses the same pxToWorldX/Y as the
+        // background math above. World is y-up (frame() takes y=top with
+        // h NEGATIVE to flip the basis); convert each axis accordingly.
+        const float wL =  -orthoW + btn.x                  * pxToWorldX;
+        const float wT =   orthoH - btn.y                  * pxToWorldY;  // y=top in y-up
+        const float wW =                btn.w              * pxToWorldX;
+        const float wH =                btn.h              * pxToWorldY;
+        const auto m = ge::frame(ge::Rect{wL, wT, wW, -wH});
+        bgfx::setTransform(&m[0][0]);
+        i_->buyPro.draw(0);
     }
 }
 

--- a/sample/tiltbuggy/src/Renderer.cpp
+++ b/sample/tiltbuggy/src/Renderer.cpp
@@ -5,6 +5,7 @@
 #include "Scene.h"
 
 #include <ge/FileIO.h>
+#include <ge/iap.h>
 #include <ge/sprite.h>
 #include <ge/svg.h>
 #include <ge/transform.h>
@@ -283,13 +284,18 @@ void Renderer::drawFrame(const Scene& scene, const ge::Context& c,
     // 3. Buggy — sized in proportion to the world (kept at 1/20 of the
     // arena half-extent to match the Box2D shape, so when the world is
     // shrunk to speed up physics, the rendered chassis tracks it).
+    // Pro entitlement (🎯T65.7) flips the chassis paint from default
+    // yellow to a chromed cyan — the visible gate for the IAP demo.
     const Pose pose = scene.buggyPose();
     const float hw = scene.halfExtent() * 0.05f;
     const float hh = hw * 0.5f;
+    const uint32_t buggyColor = ge::iap::owned("pro")
+        ? rgb(0x00, 0xE0, 0xFF)   // pro: chromed cyan
+        : rgb(0xFF, 0xCC, 0x33);  // default: yellow
     pushRotatedRect(verts,
         ge::Rect{pose.x - hw, pose.y - hh, 2.f * hw, 2.f * hh},
         pose.angle,
-        rgb(0xFF, 0xCC, 0x33));
+        buggyColor);
 
     // --- Submit ---
     const uint32_t numVerts = static_cast<uint32_t>(verts.size());

--- a/sample/tiltbuggy/src/Renderer.h
+++ b/sample/tiltbuggy/src/Renderer.h
@@ -10,6 +10,11 @@ namespace tiltbuggy {
 
 class Scene;  // from Scene.h — written by a parallel agent
 
+// Screen-pixel rect of the "BUY PRO" button. Returned in render-surface
+// pixel coordinates matching ge::input::fromSdl's output, so main.cpp's
+// onEvent hit-test and Renderer's draw position share one source of truth.
+ge::Rect proButtonRect(const ge::Context& c);
+
 class Renderer {
 public:
     Renderer();

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -18,43 +18,6 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>  // required on iOS/Android; no-op on desktop
 #include <spdlog/spdlog.h>
-#include <spdlog/sinks/base_sink.h>
-
-#ifdef GE_IOS
-// TEMP: T28.3 diagnostic — route spdlog through NSLog so logs appear in
-// xcrun simctl spawn log stream output.
-#import <Foundation/Foundation.h>
-template <typename Mutex>
-class nslog_sink : public spdlog::sinks::base_sink<Mutex> {
-protected:
-    void sink_it_(const spdlog::details::log_msg& msg) override {
-        spdlog::memory_buf_t buf;
-        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, buf);
-        NSString* s = [[NSString alloc] initWithBytes:buf.data()
-                                               length:buf.size()
-                                             encoding:NSUTF8StringEncoding];
-        NSLog(@"%@", s);
-    }
-    void flush_() override {}
-};
-#endif  // GE_IOS
-
-#ifdef __ANDROID__
-// TEMP: T28.4 diagnostic — route spdlog through Android's log so logs
-// appear in logcat.
-#include <android/log.h>
-template <typename Mutex>
-class android_sink : public spdlog::sinks::base_sink<Mutex> {
-protected:
-    void sink_it_(const spdlog::details::log_msg& msg) override {
-        spdlog::memory_buf_t buf;
-        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, buf);
-        std::string s(buf.data(), buf.size());
-        __android_log_print(ANDROID_LOG_INFO, "tiltbuggy", "%s", s.c_str());
-    }
-    void flush_() override {}
-};
-#endif  // __ANDROID__
 
 #include <cstring>
 #include <memory>
@@ -74,25 +37,9 @@ struct State {
 } // namespace
 
 int main(int argc, char* argv[]) {
-#ifdef GE_IOS
-    // TEMP: T28.3 diagnostic — install NSLog sink so spdlog output is visible.
-    {
-        auto sink = std::make_shared<nslog_sink<std::mutex>>();
-        auto logger = std::make_shared<spdlog::logger>("tiltbuggy", sink);
-        logger->set_level(spdlog::level::info);
-        spdlog::set_default_logger(logger);
-    }
-#endif  // GE_IOS
-
-#ifdef __ANDROID__
-    // TEMP: T28.4 diagnostic — install Android log sink so spdlog output is visible.
-    {
-        auto sink = std::make_shared<android_sink<std::mutex>>();
-        auto logger = std::make_shared<spdlog::logger>("tiltbuggy", sink);
-        logger->set_level(spdlog::level::info);
-        spdlog::set_default_logger(logger);
-    }
-#endif  // __ANDROID__
+    // spdlog logs flow to platform-native channels via ge::log::install,
+    // which ge::run calls automatically below. No per-app sink wiring
+    // needed (🎯T66).
 
     bool brokered = false;  // default: direct/distribution modality
     for (int i = 1; i < argc; i++) {

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -10,6 +10,7 @@
 #include "Renderer.h"
 #include "Scene.h"
 
+#include <ge/iap.h>
 #include <ge/Protocol.h>
 #include <ge/Resource.h>
 #include <ge/SessionHost.h>
@@ -98,6 +99,18 @@ int main(int argc, char* argv[]) {
 
     State state;
 
+    // Register the IAP catalogue and pre-populate the entitlement cache.
+    // The `pro` SKU must also be registered in App Store Connect as
+    // com.squz.tiltbuggy.pro and in Play Console with the matching id.
+    // T65.7 demo: once registered, sandbox / license-tester accounts
+    // can buy() this from the device and `owned("pro")` will flip.
+    ge::iap::setCatalogue({
+        {.id = "pro", .type = ge::iap::Type::NonConsumable},
+    });
+    ge::iap::restore([](ge::iap::Result r) {
+        SPDLOG_INFO("iap: restore complete ok={} error={}", r.ok, r.error);
+    });
+
     ge::run([&](ge::Context ctx) -> ge::RunConfig {
         state.scene = std::make_unique<tiltbuggy::Scene>(kWorldHalfExtent);
         state.renderer = std::make_unique<tiltbuggy::Renderer>();
@@ -109,8 +122,9 @@ int main(int argc, char* argv[]) {
                 static int frame = 0;
                 if (++frame % 60 == 0) {
                     auto p = state.scene->buggyPose();
-                    SPDLOG_INFO("tick: dt={:.4f} g=[{:.2f},{:.2f}] pose=[{:.2f},{:.2f},{:.2f}]",
-                                dt, state.gravity.x, state.gravity.y, p.x, p.y, p.angle);
+                    SPDLOG_INFO("tick: dt={:.4f} g=[{:.2f},{:.2f}] pose=[{:.2f},{:.2f},{:.2f}] pro={}",
+                                dt, state.gravity.x, state.gravity.y, p.x, p.y, p.angle,
+                                ge::iap::owned("pro"));
                 }
             },
             .onRender = [&](const ge::Context& c) {

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -105,7 +105,8 @@ int main(int argc, char* argv[]) {
     // T65.7 demo: once registered, sandbox / license-tester accounts
     // can buy() this from the device and `owned("pro")` will flip.
     ge::iap::setCatalogue({
-        {.id = "pro", .type = ge::iap::Type::NonConsumable},
+        {.id = "pro",           .type = ge::iap::Type::NonConsumable},
+        {.id = "powerboost10",  .type = ge::iap::Type::Consumable},
     });
     ge::iap::restore([](ge::iap::Result r) {
         SPDLOG_INFO("iap: restore complete ok={} error={}", r.ok, r.error);

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -13,6 +13,7 @@
 #include <ge/iap.h>
 #include <ge/Protocol.h>
 #include <ge/Resource.h>
+#include <ge/sdl_input.h>
 #include <ge/SessionHost.h>
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>  // required on iOS/Android; no-op on desktop
@@ -67,6 +68,7 @@ struct State {
     std::unique_ptr<tiltbuggy::Renderer> renderer;
     b2Vec2 gravity{0, 0};
     bool rendererInited = false;
+    bool proPurchaseInFlight = false;   // debounce: drop taps while Apple modal is up
 };
 
 } // namespace
@@ -135,7 +137,7 @@ int main(int argc, char* argv[]) {
                 }
                 state.renderer->drawFrame(*state.scene, c);
             },
-            .onEvent = [&](const SDL_Event& e) {
+            .onEvent = [&, ctx](const SDL_Event& e) {
                 SPDLOG_INFO("onEvent type=0x{:x}", e.type);
                 if (e.type == SDL_EVENT_SENSOR_UPDATE) {
                     // Engine delivers device acceleration in screen frame.
@@ -147,6 +149,23 @@ int main(int argc, char* argv[]) {
                     SPDLOG_INFO("ACCEL accel=[{:+.2f},{:+.2f},{:+.2f}] gravity=[{:+.2f},{:+.2f}]",
                                 e.sensor.data[0], e.sensor.data[1], e.sensor.data[2],
                                 state.gravity.x, state.gravity.y);
+                    return;
+                }
+
+                // BUY PRO button tap (🎯T65.7): convert SDL pointer events
+                // to ge::PointerEvent in render-surface pixel space, then
+                // hit-test against the same screen rect Renderer draws at.
+                auto pe = ge::input::fromSdl(e, ctx.fullRect().size());
+                if (pe && pe->kind == ge::PointerEvent::Down
+                       && !ge::iap::owned("pro")
+                       && !state.proPurchaseInFlight
+                       && tiltbuggy::proButtonRect(ctx).contains(pe->pos)) {
+                    state.proPurchaseInFlight = true;
+                    SPDLOG_INFO("iap: tapping BUY PRO");
+                    ge::iap::buy("pro", [&state](ge::iap::Result r) {
+                        state.proPurchaseInFlight = false;
+                        SPDLOG_INFO("iap: buy pro complete ok={} error={}", r.ok, r.error);
+                    });
                 }
             },
             .onShutdown = [&] {

--- a/src/SessionHost.mm
+++ b/src/SessionHost.mm
@@ -18,6 +18,7 @@
 
 #include <bgfx/bgfx.h>
 #include <SDL3/SDL.h>
+#include <ge/log.h>
 #include <spdlog/spdlog.h>
 
 #include <string>
@@ -91,6 +92,12 @@ static void runDirect(Factory factory, const SessionHostConfig& config) {
 // ── ge::run — dispatch by modality ────────────────────────────────
 
 void run(Factory factory, const SessionHostConfig& config) {
+    // Install the cross-platform spdlog sink (🎯T66) before any other
+    // engine logging — SDL/bgfx/IAP startup all emit SPDLOG_INFO and
+    // we want those visible on iOS/Android logs without per-app
+    // sink wiring. Idempotent if a consumer has already installed.
+    ge::log::install();
+
     if (config.headless) {
         runBrokered(factory, config);
     } else {

--- a/src/iap.cpp
+++ b/src/iap.cpp
@@ -1,0 +1,154 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// ge::iap floor: backend dispatcher + StubStore implementation.
+// Platform backends (StoreKit 2 in iap_apple.mm, Play Billing in
+// iap_android.cpp) will land in T65.2 and T65.3 and slot in via
+// the same Store interface.
+
+#include <ge/iap.h>
+
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace ge::iap {
+
+namespace {
+
+// Internal backend interface. Not exposed in the public header —
+// games don't need to know about backends, and the choice is made
+// once at process startup.
+struct Store {
+    virtual ~Store() = default;
+    virtual void setCatalogue(std::vector<Product>)              = 0;
+    virtual bool owned(const std::string& id) const              = 0;
+    virtual std::vector<LocalisedProduct> products() const       = 0;
+    virtual void buy(const std::string& id, BuyCallback)         = 0;
+    virtual void restore(RestoreCallback)                        = 0;
+    virtual void testingSetOwned(const std::string& id, bool)    = 0;
+    virtual void testingClearAll()                               = 0;
+};
+
+// In-memory backend. CI default, debug-menu backing store,
+// unit-test substrate. Threadsafe under a coarse mutex — IAP is
+// not a hot path.
+struct StubStore : Store {
+    mutable std::mutex                              mu;
+    std::unordered_map<std::string, Product>        catalogue;
+    std::unordered_set<std::string>                 entitled;
+
+    void setCatalogue(std::vector<Product> next) override {
+        std::lock_guard lock(mu);
+        for (const auto& p : next) {
+            auto [it, inserted] = catalogue.try_emplace(p.id, p);
+            // Re-registering with a different type is a programmer
+            // error — fail loud in development.
+            assert(inserted || it->second.type == p.type);
+        }
+    }
+
+    bool owned(const std::string& id) const override {
+        std::lock_guard lock(mu);
+        return entitled.contains(id);
+    }
+
+    std::vector<LocalisedProduct> products() const override {
+        std::lock_guard lock(mu);
+        std::vector<LocalisedProduct> out;
+        out.reserve(catalogue.size());
+        // Synthetic prices so dev UI can render. Real prices come
+        // from the platform store when T65.2 / T65.3 land.
+        for (const auto& [id, p] : catalogue) {
+            out.push_back({
+                .id          = id,
+                .title       = id,
+                .description = "(stub) " + id,
+                .price       = "$0.99",
+                .currency    = "USD",
+            });
+        }
+        return out;
+    }
+
+    void buy(const std::string& id, BuyCallback cb) override {
+        Result r;
+        {
+            std::lock_guard lock(mu);
+            if (catalogue.find(id) == catalogue.end()) {
+                r = {.ok = false, .id = id, .error = "unknown product"};
+            } else {
+                // Consumables stay re-buyable; non-consumables become
+                // permanently entitled. Subscriptions in StubStore
+                // behave like non-consumables — no expiry simulation.
+                const Product& p = catalogue.at(id);
+                if (p.type != Type::Consumable) {
+                    entitled.insert(id);
+                }
+                r = {.ok = true, .id = id, .error = {}};
+            }
+        }
+        if (cb) cb(std::move(r));
+    }
+
+    void restore(RestoreCallback cb) override {
+        // No remote store to re-query; entitlements are exactly what
+        // testing::setOwned or prior buy() calls left them at.
+        if (cb) cb({.ok = true, .id = {}, .error = {}});
+    }
+
+    void testingSetOwned(const std::string& id, bool yes) override {
+        std::lock_guard lock(mu);
+        if (yes) entitled.insert(id);
+        else     entitled.erase(id);
+    }
+
+    void testingClearAll() override {
+        std::lock_guard lock(mu);
+        entitled.clear();
+    }
+};
+
+// Single backend instance, lazily constructed on first access.
+// `std::once_flag` guarantees the env-var probe + selection happens
+// exactly once even under concurrent first-touch from multiple threads.
+Store& store() {
+    static std::unique_ptr<Store> instance;
+    static std::once_flag         init;
+    std::call_once(init, [] {
+        const char* mode = std::getenv("GE_IAP_MODE");
+        const std::string m = mode ? mode : "";
+        if (m.empty() || m == "stub") {
+            instance = std::make_unique<StubStore>();
+        } else {
+            // local / platform backends will slot in here when
+            // T65.2 / T65.3 / T65.4 land. Until then, anything
+            // non-stub falls back to stub with a warning.
+            SPDLOG_WARN("GE_IAP_MODE={} not yet implemented; falling back to stub", m);
+            instance = std::make_unique<StubStore>();
+        }
+    });
+    return *instance;
+}
+
+} // namespace
+
+void setCatalogue(std::vector<Product> c)                     { store().setCatalogue(std::move(c)); }
+bool owned(const std::string& id)                             { return store().owned(id); }
+std::vector<LocalisedProduct> products()                      { return store().products(); }
+void buy(const std::string& id, BuyCallback cb)               { store().buy(id, std::move(cb)); }
+void restore(RestoreCallback cb)                              { store().restore(std::move(cb)); }
+
+namespace testing {
+
+void setOwned(const std::string& id, bool yes) { store().testingSetOwned(id, yes); }
+void clearAll()                                { store().testingClearAll(); }
+
+} // namespace testing
+
+} // namespace ge::iap

--- a/src/iap.cpp
+++ b/src/iap.cpp
@@ -151,4 +151,31 @@ void clearAll()                                { store().testingClearAll(); }
 
 } // namespace testing
 
+// ── DebugPanel ─────────────────────────────────────────────────────
+
+std::vector<DebugPanel::Row> DebugPanel::rows() const {
+    auto list = products();
+    std::vector<Row> out;
+    out.reserve(list.size());
+    for (const auto& p : list) {
+        // Type isn't surfaced by products(), so re-derive presence via
+        // owned() and leave type defaulted — the debug panel cares
+        // about owned/not-owned, not consumable vs non-consumable.
+        out.push_back({.id = p.id, .type = Type::NonConsumable, .owned = owned(p.id)});
+    }
+    return out;
+}
+
+void DebugPanel::onRowTap(const std::string& id) {
+    testing::setOwned(id, !owned(id));
+}
+
+void DebugPanel::onResetAll() {
+    testing::clearAll();
+}
+
+void DebugPanel::onForceRestore(RestoreCallback cb) {
+    restore(std::move(cb));
+}
+
 } // namespace ge::iap

--- a/src/iap.cpp
+++ b/src/iap.cpp
@@ -1,43 +1,28 @@
 // Copyright 2026 Marcelo Cantos
 // SPDX-License-Identifier: Apache-2.0
 //
-// ge::iap floor: backend dispatcher + StubStore implementation.
-// Platform backends (StoreKit 2 in iap_apple.mm, Play Billing in
-// iap_android.cpp) will land in T65.2 and T65.3 and slot in via
-// the same Store interface.
+// ge::iap floor: backend dispatcher + StubStore implementation +
+// DebugPanel. Platform backends in iap_apple.mm and iap_android.cpp
+// implement Store and provide makePlatformStore(); the dispatcher
+// picks one at process startup based on GE_IAP_MODE.
 
-#include <ge/iap.h>
+#include "iap_internal.h"
 
 #include <spdlog/spdlog.h>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 #include <cassert>
 #include <cstdlib>
-#include <memory>
-#include <mutex>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace ge::iap {
 
-namespace {
+namespace detail {
 
-// Internal backend interface. Not exposed in the public header —
-// games don't need to know about backends, and the choice is made
-// once at process startup.
-struct Store {
-    virtual ~Store() = default;
-    virtual void setCatalogue(std::vector<Product>)              = 0;
-    virtual bool owned(const std::string& id) const              = 0;
-    virtual std::vector<LocalisedProduct> products() const       = 0;
-    virtual void buy(const std::string& id, BuyCallback)         = 0;
-    virtual void restore(RestoreCallback)                        = 0;
-    virtual void testingSetOwned(const std::string& id, bool)    = 0;
-    virtual void testingClearAll()                               = 0;
-};
-
-// In-memory backend. CI default, debug-menu backing store,
-// unit-test substrate. Threadsafe under a coarse mutex — IAP is
-// not a hot path.
+// In-memory backend. CI default, debug-menu backing store, unit-test
+// substrate. Threadsafe under a coarse mutex — IAP is not a hot path.
 struct StubStore : Store {
     mutable std::mutex                              mu;
     std::unordered_map<std::string, Product>        catalogue;
@@ -47,8 +32,6 @@ struct StubStore : Store {
         std::lock_guard lock(mu);
         for (const auto& p : next) {
             auto [it, inserted] = catalogue.try_emplace(p.id, p);
-            // Re-registering with a different type is a programmer
-            // error — fail loud in development.
             assert(inserted || it->second.type == p.type);
         }
     }
@@ -63,7 +46,7 @@ struct StubStore : Store {
         std::vector<LocalisedProduct> out;
         out.reserve(catalogue.size());
         // Synthetic prices so dev UI can render. Real prices come
-        // from the platform store when T65.2 / T65.3 land.
+        // from the platform store when GE_IAP_MODE=platform.
         for (const auto& [id, p] : catalogue) {
             out.push_back({
                 .id          = id,
@@ -83,9 +66,6 @@ struct StubStore : Store {
             if (catalogue.find(id) == catalogue.end()) {
                 r = {.ok = false, .id = id, .error = "unknown product"};
             } else {
-                // Consumables stay re-buyable; non-consumables become
-                // permanently entitled. Subscriptions in StubStore
-                // behave like non-consumables — no expiry simulation.
                 const Product& p = catalogue.at(id);
                 if (p.type != Type::Consumable) {
                     entitled.insert(id);
@@ -97,8 +77,6 @@ struct StubStore : Store {
     }
 
     void restore(RestoreCallback cb) override {
-        // No remote store to re-query; entitlements are exactly what
-        // testing::setOwned or prior buy() calls left them at.
         if (cb) cb({.ok = true, .id = {}, .error = {}});
     }
 
@@ -114,22 +92,53 @@ struct StubStore : Store {
     }
 };
 
+#if !defined(__APPLE__) && !defined(__ANDROID__)
+// Desktop / fallback default: no platform store. iap_apple.mm and
+// iap_android.cpp override this on their platforms.
+std::unique_ptr<Store> makePlatformStore() { return nullptr; }
+#endif
+
+} // namespace detail
+
+namespace {
+
+using detail::Store;
+using detail::StubStore;
+
 // Single backend instance, lazily constructed on first access.
-// `std::once_flag` guarantees the env-var probe + selection happens
+// std::once_flag guarantees the env-var probe + selection happens
 // exactly once even under concurrent first-touch from multiple threads.
 Store& store() {
     static std::unique_ptr<Store> instance;
     static std::once_flag         init;
     std::call_once(init, [] {
-        const char* mode = std::getenv("GE_IAP_MODE");
-        const std::string m = mode ? mode : "";
-        if (m.empty() || m == "stub") {
+        const char* envMode = std::getenv("GE_IAP_MODE");
+        std::string mode    = envMode ? envMode : "";
+        // Default mode: platform on mobile, stub on desktop. macOS is
+        // desktop here — only iOS / iPadOS / tvOS / watchOS qualify
+        // as "mobile" for the auto-platform default.
+        if (mode.empty()) {
+#if defined(__ANDROID__)
+            mode = "platform";
+#elif defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_OS_WATCH)
+            mode = "platform";
+#else
+            mode = "stub";
+#endif
+        }
+
+        if (mode == "stub") {
             instance = std::make_unique<StubStore>();
+        } else if (mode == "platform") {
+            instance = detail::makePlatformStore();
+            if (!instance) {
+                SPDLOG_WARN("GE_IAP_MODE=platform but no platform store available; falling back to stub");
+                instance = std::make_unique<StubStore>();
+            }
         } else {
-            // local / platform backends will slot in here when
-            // T65.2 / T65.3 / T65.4 land. Until then, anything
-            // non-stub falls back to stub with a warning.
-            SPDLOG_WARN("GE_IAP_MODE={} not yet implemented; falling back to stub", m);
+            // local mode lands with T65.4. Until then, anything
+            // unrecognised falls back to stub with a warning.
+            SPDLOG_WARN("GE_IAP_MODE={} not yet implemented; falling back to stub", mode);
             instance = std::make_unique<StubStore>();
         }
     });
@@ -158,24 +167,13 @@ std::vector<DebugPanel::Row> DebugPanel::rows() const {
     std::vector<Row> out;
     out.reserve(list.size());
     for (const auto& p : list) {
-        // Type isn't surfaced by products(), so re-derive presence via
-        // owned() and leave type defaulted — the debug panel cares
-        // about owned/not-owned, not consumable vs non-consumable.
         out.push_back({.id = p.id, .type = Type::NonConsumable, .owned = owned(p.id)});
     }
     return out;
 }
 
-void DebugPanel::onRowTap(const std::string& id) {
-    testing::setOwned(id, !owned(id));
-}
-
-void DebugPanel::onResetAll() {
-    testing::clearAll();
-}
-
-void DebugPanel::onForceRestore(RestoreCallback cb) {
-    restore(std::move(cb));
-}
+void DebugPanel::onRowTap(const std::string& id)        { testing::setOwned(id, !owned(id)); }
+void DebugPanel::onResetAll()                            { testing::clearAll(); }
+void DebugPanel::onForceRestore(RestoreCallback cb)      { restore(std::move(cb)); }
 
 } // namespace ge::iap

--- a/src/iap_android.cpp
+++ b/src/iap_android.cpp
@@ -31,6 +31,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include <SDL3/SDL_system.h>
+
 #include <jni.h>
 
 #include <memory>
@@ -144,9 +146,28 @@ std::string localIdFromSku(JNIEnv* env, const std::string& sku) {
 } // namespace
 
 AndroidStore::AndroidStore() {
+    // Bootstrap g_jvm + g_activity from SDL's Android bridge so consumers
+    // don't need a separate JNI_OnLoad hook. SDL_GetAndroidJNIEnv() and
+    // SDL_GetAndroidActivity() are usable any time after SDL_Init runs
+    // (which it has by the time ge::run reaches its render-loop body).
+    if (!g_jvm) {
+        JNIEnv* bootstrapEnv = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
+        if (bootstrapEnv) bootstrapEnv->GetJavaVM(&g_jvm);
+    }
+    if (!g_activity) {
+        jobject local = static_cast<jobject>(SDL_GetAndroidActivity());
+        if (local) {
+            ScopedEnv tmp;
+            if (tmp.env) {
+                g_activity = tmp.env->NewGlobalRef(local);
+                tmp.env->DeleteLocalRef(local);
+            }
+        }
+    }
+
     ScopedEnv env;
     if (!env.env || !g_activity) {
-        SPDLOG_ERROR("AndroidStore: JVM or activity not initialised — install the engine's JNI_OnLoad first");
+        SPDLOG_ERROR("AndroidStore: SDL Android bridge unavailable; iap calls will no-op");
         return;
     }
     jclass cls = env.env->FindClass("ge/IapBridge");
@@ -323,6 +344,7 @@ JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnBillingReady(JNIEnv*, jclass) {
 JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnProductFetched(
         JNIEnv* env, jclass,
         jstring sku, jstring title, jstring desc, jstring price, jstring currency) {
+    using namespace ge::iap;
     using namespace ge::iap::detail;
     if (!g_instance) return;
     auto j2s = [&](jstring s) -> std::string {

--- a/src/iap_android.cpp
+++ b/src/iap_android.cpp
@@ -1,0 +1,379 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Android Play Billing 7+ backend for ge::iap (🎯T65.3).
+//
+// JNI bridge to android-shared/src/main/java/ge/IapBridge.java. The
+// Java side owns BillingClient + the PurchasesUpdatedListener; this
+// file translates between the C++ Store interface and JNI calls,
+// keeping state (catalogue, entitlements, pending callbacks) in
+// pure C++.
+//
+// Bundle-ID prefixing: same as Apple — local ID "pro" becomes
+// "com.squz.tiltbuggy.pro" against Play Billing, matching the SKU
+// registered in Play Console.
+//
+// Threading: BillingClient callbacks run on whichever thread
+// BillingClient picks (typically a background HandlerThread). All
+// shared state is protected by a coarse mutex. JNI calls into Java
+// take whichever thread the caller is on; we attach via JavaVM if
+// necessary.
+//
+// Verification status: this file has NOT been verified on a real
+// Android device yet — that's part of 🎯T65.7's demonstration. The
+// flow follows Google's Play Billing 7 documentation; subtle bugs
+// may surface at first device run (especially around acknowledge
+// semantics, PENDING handling, and the JNI attach lifecycle).
+
+#include "iap_internal.h"
+
+#if defined(__ANDROID__)
+
+#include <spdlog/spdlog.h>
+
+#include <jni.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace ge::iap::detail {
+
+namespace {
+
+JavaVM* g_jvm = nullptr;
+jobject g_activity = nullptr;   // global ref, set by app at startup
+
+// String formed by prefixing local id with the activity's package name.
+std::string platformSku(JNIEnv* env, const std::string& localId);
+std::string localIdFromSku(JNIEnv* env, const std::string& sku);
+
+// JNIEnv attach helper — Play Billing callbacks may come on a thread
+// that isn't attached to the JVM.
+struct ScopedEnv {
+    JNIEnv* env  = nullptr;
+    bool    detach = false;
+
+    ScopedEnv() {
+        if (!g_jvm) return;
+        int s = g_jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+        if (s == JNI_EDETACHED) {
+            if (g_jvm->AttachCurrentThread(&env, nullptr) == JNI_OK) detach = true;
+        }
+    }
+    ~ScopedEnv() {
+        if (detach && g_jvm) g_jvm->DetachCurrentThread();
+    }
+};
+
+} // namespace
+
+struct AndroidStore : Store {
+    mutable std::mutex                                  mu;
+    std::unordered_map<std::string, Product>            catalogue;
+    std::unordered_set<std::string>                     entitled;
+    std::unordered_map<std::string, LocalisedProduct>   localised;
+    std::unordered_map<std::string, BuyCallback>        pendingBuys;
+    RestoreCallback                                     pendingRestore;
+    jobject                                             bridge = nullptr;   // global ref
+
+    AndroidStore();
+    ~AndroidStore() override;
+
+    void setCatalogue(std::vector<Product>) override;
+    bool owned(const std::string&) const override;
+    std::vector<LocalisedProduct> products() const override;
+    void buy(const std::string&, BuyCallback) override;
+    void restore(RestoreCallback) override;
+
+    void testingSetOwned(const std::string&, bool) override {
+        SPDLOG_WARN("ge::iap::testing::setOwned has no effect against AndroidStore — entitlements are owned by Play Billing");
+    }
+    void testingClearAll() override {
+        SPDLOG_WARN("ge::iap::testing::clearAll has no effect against AndroidStore — entitlements are owned by Play Billing");
+    }
+
+    // Called from JNI hooks.
+    void onProductFetched(const std::string& localId, LocalisedProduct lp);
+    void onPurchaseUpdate(const std::string& localId, bool ok, const std::string& error);
+    void onRestoreFinished(bool ok, const std::string& error);
+};
+
+namespace {
+
+AndroidStore* g_instance = nullptr;   // set by AndroidStore ctor, cleared by dtor
+
+std::string jstringToStd(JNIEnv* env, jstring s) {
+    if (!s) return {};
+    const char* c = env->GetStringUTFChars(s, nullptr);
+    std::string out = c ? c : "";
+    env->ReleaseStringUTFChars(s, c);
+    return out;
+}
+
+std::string platformSku(JNIEnv* env, const std::string& localId) {
+    // Activity.getPackageName() yields e.g. "com.squz.tiltbuggy".
+    if (!g_activity) return localId;
+    jclass cls = env->GetObjectClass(g_activity);
+    jmethodID m = env->GetMethodID(cls, "getPackageName", "()Ljava/lang/String;");
+    jstring pkg = static_cast<jstring>(env->CallObjectMethod(g_activity, m));
+    std::string base = jstringToStd(env, pkg);
+    env->DeleteLocalRef(pkg);
+    env->DeleteLocalRef(cls);
+    return base + "." + localId;
+}
+
+std::string localIdFromSku(JNIEnv* env, const std::string& sku) {
+    if (!g_activity) return sku;
+    jclass cls = env->GetObjectClass(g_activity);
+    jmethodID m = env->GetMethodID(cls, "getPackageName", "()Ljava/lang/String;");
+    jstring pkg = static_cast<jstring>(env->CallObjectMethod(g_activity, m));
+    std::string base = jstringToStd(env, pkg);
+    env->DeleteLocalRef(pkg);
+    env->DeleteLocalRef(cls);
+    const std::string prefix = base + ".";
+    if (sku.size() > prefix.size() && sku.compare(0, prefix.size(), prefix) == 0) {
+        return sku.substr(prefix.size());
+    }
+    return sku;
+}
+
+} // namespace
+
+AndroidStore::AndroidStore() {
+    ScopedEnv env;
+    if (!env.env || !g_activity) {
+        SPDLOG_ERROR("AndroidStore: JVM or activity not initialised — install the engine's JNI_OnLoad first");
+        return;
+    }
+    jclass cls = env.env->FindClass("ge/IapBridge");
+    if (!cls) {
+        SPDLOG_ERROR("AndroidStore: ge.IapBridge class not found");
+        return;
+    }
+    jmethodID ctor = env.env->GetMethodID(cls, "<init>", "(Landroid/app/Activity;)V");
+    jobject local = env.env->NewObject(cls, ctor, g_activity);
+    bridge = env.env->NewGlobalRef(local);
+    env.env->DeleteLocalRef(local);
+    env.env->DeleteLocalRef(cls);
+    g_instance = this;
+}
+
+AndroidStore::~AndroidStore() {
+    ScopedEnv env;
+    if (env.env && bridge) {
+        jclass cls = env.env->GetObjectClass(bridge);
+        jmethodID shutdown = env.env->GetMethodID(cls, "shutdown", "()V");
+        env.env->CallVoidMethod(bridge, shutdown);
+        env.env->DeleteGlobalRef(bridge);
+        env.env->DeleteLocalRef(cls);
+    }
+    g_instance = nullptr;
+}
+
+void AndroidStore::setCatalogue(std::vector<Product> next) {
+    ScopedEnv env;
+    if (!env.env || !bridge) return;
+
+    std::vector<std::string> skus;
+    std::vector<jboolean>    subs;
+    {
+        std::lock_guard lock(mu);
+        for (const auto& p : next) {
+            catalogue.try_emplace(p.id, p);
+            skus.push_back(platformSku(env.env, p.id));
+            subs.push_back(p.type == Type::AutoRenewingSubscription ? JNI_TRUE : JNI_FALSE);
+        }
+    }
+
+    jclass strCls = env.env->FindClass("java/lang/String");
+    jobjectArray skuArr = env.env->NewObjectArray(skus.size(), strCls, nullptr);
+    for (size_t i = 0; i < skus.size(); ++i) {
+        jstring s = env.env->NewStringUTF(skus[i].c_str());
+        env.env->SetObjectArrayElement(skuArr, i, s);
+        env.env->DeleteLocalRef(s);
+    }
+    jbooleanArray subArr = env.env->NewBooleanArray(subs.size());
+    env.env->SetBooleanArrayRegion(subArr, 0, subs.size(), subs.data());
+
+    jclass bridgeCls = env.env->GetObjectClass(bridge);
+    jmethodID m = env.env->GetMethodID(bridgeCls, "querySkus", "([Ljava/lang/String;[Z)V");
+    env.env->CallVoidMethod(bridge, m, skuArr, subArr);
+
+    env.env->DeleteLocalRef(bridgeCls);
+    env.env->DeleteLocalRef(subArr);
+    env.env->DeleteLocalRef(skuArr);
+    env.env->DeleteLocalRef(strCls);
+}
+
+bool AndroidStore::owned(const std::string& id) const {
+    std::lock_guard lock(mu);
+    return entitled.contains(id);
+}
+
+std::vector<LocalisedProduct> AndroidStore::products() const {
+    std::lock_guard lock(mu);
+    std::vector<LocalisedProduct> out;
+    out.reserve(localised.size());
+    for (const auto& [id, lp] : localised) out.push_back(lp);
+    return out;
+}
+
+void AndroidStore::buy(const std::string& id, BuyCallback cb) {
+    ScopedEnv env;
+    if (!env.env || !bridge) {
+        if (cb) cb({.ok = false, .id = id, .error = "JVM not available"});
+        return;
+    }
+
+    {
+        std::lock_guard lock(mu);
+        if (catalogue.find(id) == catalogue.end()) {
+            Result r{.ok = false, .id = id, .error = "unknown product"};
+            if (cb) cb(std::move(r));
+            return;
+        }
+        pendingBuys[id] = std::move(cb);
+    }
+
+    jstring sku = env.env->NewStringUTF(platformSku(env.env, id).c_str());
+    jclass bridgeCls = env.env->GetObjectClass(bridge);
+    jmethodID m = env.env->GetMethodID(bridgeCls, "launchPurchase", "(Ljava/lang/String;)Z");
+    env.env->CallBooleanMethod(bridge, m, sku);
+    env.env->DeleteLocalRef(bridgeCls);
+    env.env->DeleteLocalRef(sku);
+}
+
+void AndroidStore::restore(RestoreCallback cb) {
+    ScopedEnv env;
+    if (!env.env || !bridge) {
+        if (cb) cb({.ok = false, .id = {}, .error = "JVM not available"});
+        return;
+    }
+    {
+        std::lock_guard lock(mu);
+        pendingRestore = std::move(cb);
+    }
+    jclass bridgeCls = env.env->GetObjectClass(bridge);
+    jmethodID m = env.env->GetMethodID(bridgeCls, "queryPurchases", "()V");
+    env.env->CallVoidMethod(bridge, m);
+    env.env->DeleteLocalRef(bridgeCls);
+}
+
+void AndroidStore::onProductFetched(const std::string& localId, LocalisedProduct lp) {
+    std::lock_guard lock(mu);
+    localised[localId] = std::move(lp);
+}
+
+void AndroidStore::onPurchaseUpdate(const std::string& localId, bool ok, const std::string& error) {
+    BuyCallback cb;
+    bool isConsumable = false;
+    {
+        std::lock_guard lock(mu);
+        auto pIt = catalogue.find(localId);
+        if (pIt != catalogue.end()) isConsumable = pIt->second.type == Type::Consumable;
+        if (ok && !isConsumable) entitled.insert(localId);
+        auto cbIt = pendingBuys.find(localId);
+        if (cbIt != pendingBuys.end()) {
+            cb = std::move(cbIt->second);
+            pendingBuys.erase(cbIt);
+        }
+    }
+    if (cb) cb({.ok = ok, .id = localId, .error = error});
+}
+
+void AndroidStore::onRestoreFinished(bool ok, const std::string& error) {
+    RestoreCallback cb;
+    {
+        std::lock_guard lock(mu);
+        cb = std::move(pendingRestore);
+        pendingRestore = {};
+    }
+    if (cb) cb({.ok = ok, .id = {}, .error = error});
+}
+
+std::unique_ptr<Store> makePlatformStore() {
+    return std::make_unique<AndroidStore>();
+}
+
+} // namespace ge::iap::detail
+
+// ── JNI exports ─────────────────────────────────────────────────────
+
+extern "C" {
+
+// Called from the consuming app's JNI_OnLoad (after the existing
+// GeActivity init wiring) to publish the JavaVM + activity object
+// references that AndroidStore needs.
+JNIEXPORT void JNICALL Java_ge_IapBridge_nativeInstall(JNIEnv* env, jclass, jobject activity) {
+    env->GetJavaVM(&ge::iap::detail::g_jvm);
+    if (ge::iap::detail::g_activity) env->DeleteGlobalRef(ge::iap::detail::g_activity);
+    ge::iap::detail::g_activity = env->NewGlobalRef(activity);
+}
+
+JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnBillingReady(JNIEnv*, jclass) {
+    // Currently a no-op marker; AndroidStore lazy-queries on first
+    // setCatalogue. T65.5 will use this to kick off the initial
+    // queryPurchases() that rebuilds the entitlement cache.
+}
+
+JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnProductFetched(
+        JNIEnv* env, jclass,
+        jstring sku, jstring title, jstring desc, jstring price, jstring currency) {
+    using namespace ge::iap::detail;
+    if (!g_instance) return;
+    auto j2s = [&](jstring s) -> std::string {
+        if (!s) return {};
+        const char* c = env->GetStringUTFChars(s, nullptr);
+        std::string out = c ? c : "";
+        env->ReleaseStringUTFChars(s, c);
+        return out;
+    };
+    std::string skuStr = j2s(sku);
+    std::string localId = localIdFromSku(env, skuStr);
+    LocalisedProduct lp{
+        .id          = localId,
+        .title       = j2s(title),
+        .description = j2s(desc),
+        .price       = j2s(price),
+        .currency    = j2s(currency),
+    };
+    g_instance->onProductFetched(localId, std::move(lp));
+}
+
+JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnPurchaseUpdate(
+        JNIEnv* env, jclass, jstring sku, jboolean ok, jstring error) {
+    using namespace ge::iap::detail;
+    if (!g_instance) return;
+    const char* skuC = env->GetStringUTFChars(sku, nullptr);
+    std::string skuStr = skuC ? skuC : "";
+    env->ReleaseStringUTFChars(sku, skuC);
+    std::string localId = localIdFromSku(env, skuStr);
+    std::string errStr;
+    if (error) {
+        const char* c = env->GetStringUTFChars(error, nullptr);
+        errStr = c ? c : "";
+        env->ReleaseStringUTFChars(error, c);
+    }
+    g_instance->onPurchaseUpdate(localId, ok == JNI_TRUE, errStr);
+}
+
+JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnRestoreFinished(
+        JNIEnv* env, jclass, jboolean ok, jstring error) {
+    using namespace ge::iap::detail;
+    if (!g_instance) return;
+    std::string errStr;
+    if (error) {
+        const char* c = env->GetStringUTFChars(error, nullptr);
+        errStr = c ? c : "";
+        env->ReleaseStringUTFChars(error, c);
+    }
+    g_instance->onRestoreFinished(ok == JNI_TRUE, errStr);
+}
+
+} // extern "C"
+
+#endif // defined(__ANDROID__)

--- a/src/iap_apple.mm
+++ b/src/iap_apple.mm
@@ -1,0 +1,335 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Apple StoreKit backend for ge::iap (🎯T65.2).
+//
+// Uses StoreKit 1 (the Obj-C-compatible API) so this compiles in the
+// existing Obj-C++ codebase without introducing a Swift toolchain
+// dependency. StoreKit 1 still surfaces only Apple-verified
+// transactions (the framework validates against Apple's servers before
+// delivering); on-device JWS verification (StoreKit 2's
+// VerificationResult) is a future migration when subscriptions ship.
+// Apple has deprecated parts of StoreKit 1 on macOS 15 / iOS 18 in
+// favor of StoreKit 2; the build emits deprecation warnings that are
+// intentionally tolerated until the Swift bridging story is in place.
+//
+// Architecture:
+//   * AppleStore (C++) implements detail::Store; owned by the dispatcher.
+//   * GEStoreKitBroker (Obj-C) sits in SKPaymentQueue's observer chain
+//     and SKProductsRequest's delegate slot. It keeps SKProduct*
+//     references alive (strong NSMutableDictionary) and funnels
+//     callbacks back to AppleStore.
+//
+// Bundle-ID prefixing: AppleStore takes a local ID like "pro" and
+// expands to NSBundle.mainBundle.bundleIdentifier + "." + id. So
+// "pro" in tiltbuggy becomes "com.squz.tiltbuggy.pro" against
+// StoreKit, matching the SKU registered in App Store Connect.
+//
+// Threading: SKPaymentQueue / SKProductsRequest call back on the main
+// thread by convention. The internal mutex protects state against any
+// callers that touch AppleStore from off-main (e.g. a render thread
+// calling owned()).
+//
+// Verification status: this file has NOT been verified on a real iOS
+// device yet — that's part of 🎯T65.7's demonstration. The structure
+// follows Apple's StoreKit 1 documentation; subtle bugs may surface
+// at first device run.
+
+#include "iap_internal.h"
+
+#if defined(__APPLE__)
+
+#import <StoreKit/StoreKit.h>
+
+#include <spdlog/spdlog.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+@class GEStoreKitBroker;
+
+namespace ge::iap::detail {
+
+namespace {
+
+std::string platformSku(const std::string& localId) {
+    NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
+    if (!bundleId) return localId;
+    return std::string([bundleId UTF8String]) + "." + localId;
+}
+
+std::string localIdFromSku(const std::string& sku) {
+    NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
+    if (!bundleId) return sku;
+    const std::string prefix = std::string([bundleId UTF8String]) + ".";
+    if (sku.size() > prefix.size() && sku.compare(0, prefix.size(), prefix) == 0) {
+        return sku.substr(prefix.size());
+    }
+    return sku;
+}
+
+} // namespace
+
+struct AppleStore : Store {
+    mutable std::mutex                                  mu;
+    std::unordered_map<std::string, Product>            catalogue;   // local id -> spec
+    std::unordered_set<std::string>                     entitled;    // local ids
+    std::unordered_map<std::string, LocalisedProduct>   localised;   // local id -> price/title
+    std::unordered_map<std::string, BuyCallback>        pendingBuys; // local id -> cb
+    RestoreCallback                                     pendingRestore;
+    GEStoreKitBroker* __strong                          broker = nil;
+
+    AppleStore();
+    ~AppleStore() override;
+
+    void setCatalogue(std::vector<Product> next) override;
+    bool owned(const std::string& id) const override;
+    std::vector<LocalisedProduct> products() const override;
+    void buy(const std::string& id, BuyCallback) override;
+    void restore(RestoreCallback) override;
+
+    void testingSetOwned(const std::string&, bool) override {
+        SPDLOG_WARN("ge::iap::testing::setOwned has no effect against AppleStore — entitlements are owned by StoreKit");
+    }
+    void testingClearAll() override {
+        SPDLOG_WARN("ge::iap::testing::clearAll has no effect against AppleStore — entitlements are owned by StoreKit");
+    }
+
+    // Broker callbacks (run on main thread).
+    void onProductsResponse(SKProductsResponse* response);
+    void onTransactionUpdate(SKPaymentTransaction* tx);
+    void onRestoreFinished(NSError* err);
+};
+
+} // namespace ge::iap::detail
+
+// ── Obj-C broker ────────────────────────────────────────────────────
+
+@interface GEStoreKitBroker : NSObject <SKProductsRequestDelegate, SKPaymentTransactionObserver>
+@property (assign, nonatomic) ge::iap::detail::AppleStore* owner;
+@property (strong, nonatomic) SKProductsRequest* productsRequest;
+@property (strong, nonatomic) NSMutableDictionary<NSString*, SKProduct*>* productsBySku;
+@end
+
+@implementation GEStoreKitBroker
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _productsBySku = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (void)requestProducts:(NSSet<NSString*>*)skus {
+    self.productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:skus];
+    self.productsRequest.delegate = self;
+    [self.productsRequest start];
+}
+
+- (SKProduct*)productForSku:(NSString*)sku {
+    return self.productsBySku[sku];
+}
+
+- (void)productsRequest:(SKProductsRequest*)request
+     didReceiveResponse:(SKProductsResponse*)response {
+    for (SKProduct* p in response.products) {
+        self.productsBySku[p.productIdentifier] = p;
+    }
+    if (self.owner) self.owner->onProductsResponse(response);
+}
+
+- (void)request:(SKRequest*)request didFailWithError:(NSError*)error {
+    SPDLOG_ERROR("SKProductsRequest failed: {}", [[error localizedDescription] UTF8String]);
+}
+
+- (void)paymentQueue:(SKPaymentQueue*)queue
+ updatedTransactions:(NSArray<SKPaymentTransaction*>*)transactions {
+    if (!self.owner) return;
+    for (SKPaymentTransaction* tx in transactions) {
+        self.owner->onTransactionUpdate(tx);
+    }
+}
+
+- (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue*)queue {
+    if (self.owner) self.owner->onRestoreFinished(nil);
+}
+
+- (void)paymentQueue:(SKPaymentQueue*)queue
+restoreCompletedTransactionsFailedWithError:(NSError*)error {
+    if (self.owner) self.owner->onRestoreFinished(error);
+}
+
+@end
+
+// ── AppleStore method bodies ────────────────────────────────────────
+
+namespace ge::iap::detail {
+
+AppleStore::AppleStore() {
+    broker = [[GEStoreKitBroker alloc] init];
+    broker.owner = this;
+    [[SKPaymentQueue defaultQueue] addTransactionObserver:broker];
+}
+
+AppleStore::~AppleStore() {
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:broker];
+    broker.owner = nullptr;
+    broker = nil;
+}
+
+void AppleStore::setCatalogue(std::vector<Product> next) {
+    NSMutableSet<NSString*>* skus = [NSMutableSet set];
+    {
+        std::lock_guard lock(mu);
+        for (const auto& p : next) {
+            catalogue.try_emplace(p.id, p);
+            NSString* sku = [NSString stringWithUTF8String:platformSku(p.id).c_str()];
+            [skus addObject:sku];
+        }
+    }
+    [broker requestProducts:skus];
+}
+
+bool AppleStore::owned(const std::string& id) const {
+    std::lock_guard lock(mu);
+    return entitled.contains(id);
+}
+
+std::vector<LocalisedProduct> AppleStore::products() const {
+    std::lock_guard lock(mu);
+    std::vector<LocalisedProduct> out;
+    out.reserve(localised.size());
+    for (const auto& [id, lp] : localised) out.push_back(lp);
+    return out;
+}
+
+void AppleStore::buy(const std::string& id, BuyCallback cb) {
+    NSString* sku = [NSString stringWithUTF8String:platformSku(id).c_str()];
+    SKProduct* product = [broker productForSku:sku];
+    {
+        std::lock_guard lock(mu);
+        if (catalogue.find(id) == catalogue.end()) {
+            Result r{.ok = false, .id = id, .error = "unknown product"};
+            if (cb) cb(std::move(r));
+            return;
+        }
+        if (!product) {
+            Result r{.ok = false, .id = id, .error = "product not yet fetched from store"};
+            if (cb) cb(std::move(r));
+            return;
+        }
+        pendingBuys[id] = std::move(cb);
+    }
+    SKPayment* payment = [SKPayment paymentWithProduct:product];
+    [[SKPaymentQueue defaultQueue] addPayment:payment];
+}
+
+void AppleStore::restore(RestoreCallback cb) {
+    {
+        std::lock_guard lock(mu);
+        pendingRestore = std::move(cb);
+    }
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
+}
+
+void AppleStore::onProductsResponse(SKProductsResponse* response) {
+    std::lock_guard lock(mu);
+    for (SKProduct* p in response.products) {
+        std::string sku    = [p.productIdentifier UTF8String];
+        std::string localId = localIdFromSku(sku);
+
+        NSNumberFormatter* fmt = [[NSNumberFormatter alloc] init];
+        fmt.numberStyle = NSNumberFormatterCurrencyStyle;
+        fmt.locale = p.priceLocale;
+        NSString* priceStr = [fmt stringFromNumber:p.price];
+
+        NSString* currencyCode = [p.priceLocale objectForKey:NSLocaleCurrencyCode];
+
+        localised[localId] = {
+            .id          = localId,
+            .title       = [p.localizedTitle UTF8String],
+            .description = [p.localizedDescription UTF8String],
+            .price       = priceStr ? [priceStr UTF8String] : "",
+            .currency    = currencyCode ? [currencyCode UTF8String] : "",
+        };
+    }
+    for (NSString* invalid in response.invalidProductIdentifiers) {
+        SPDLOG_WARN("StoreKit reported invalid product identifier: {}", [invalid UTF8String]);
+    }
+}
+
+void AppleStore::onTransactionUpdate(SKPaymentTransaction* tx) {
+    std::string sku    = [tx.payment.productIdentifier UTF8String];
+    std::string localId = localIdFromSku(sku);
+
+    bool isConsumable = false;
+    {
+        std::lock_guard lock(mu);
+        auto pIt = catalogue.find(localId);
+        if (pIt != catalogue.end()) isConsumable = pIt->second.type == Type::Consumable;
+    }
+
+    BuyCallback cb;
+    switch (tx.transactionState) {
+        case SKPaymentTransactionStatePurchased:
+        case SKPaymentTransactionStateRestored: {
+            {
+                std::lock_guard lock(mu);
+                if (!isConsumable) entitled.insert(localId);
+                auto cbIt = pendingBuys.find(localId);
+                if (cbIt != pendingBuys.end()) {
+                    cb = std::move(cbIt->second);
+                    pendingBuys.erase(cbIt);
+                }
+            }
+            if (cb) cb({.ok = true, .id = localId, .error = {}});
+            [[SKPaymentQueue defaultQueue] finishTransaction:tx];
+            break;
+        }
+        case SKPaymentTransactionStateFailed: {
+            std::string err = tx.error ? [[tx.error localizedDescription] UTF8String] : "purchase failed";
+            {
+                std::lock_guard lock(mu);
+                auto cbIt = pendingBuys.find(localId);
+                if (cbIt != pendingBuys.end()) {
+                    cb = std::move(cbIt->second);
+                    pendingBuys.erase(cbIt);
+                }
+            }
+            if (cb) cb({.ok = false, .id = localId, .error = std::move(err)});
+            [[SKPaymentQueue defaultQueue] finishTransaction:tx];
+            break;
+        }
+        case SKPaymentTransactionStatePurchasing:
+        case SKPaymentTransactionStateDeferred:
+            // In-flight; wait for terminal state.
+            break;
+    }
+}
+
+void AppleStore::onRestoreFinished(NSError* err) {
+    RestoreCallback cb;
+    {
+        std::lock_guard lock(mu);
+        cb = std::move(pendingRestore);
+        pendingRestore = {};
+    }
+    if (!cb) return;
+    if (err) {
+        cb({.ok = false, .id = {}, .error = [[err localizedDescription] UTF8String]});
+    } else {
+        cb({.ok = true, .id = {}, .error = {}});
+    }
+}
+
+std::unique_ptr<Store> makePlatformStore() {
+    return std::make_unique<AppleStore>();
+}
+
+} // namespace ge::iap::detail
+
+#endif // defined(__APPLE__)

--- a/src/iap_internal.h
+++ b/src/iap_internal.h
@@ -1,0 +1,41 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine-private — declarations shared between iap.cpp (dispatcher +
+// StubStore) and the platform implementations (iap_apple.mm,
+// iap_android.cpp). Not part of the public surface.
+
+#pragma once
+
+#include <ge/iap.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace ge::iap::detail {
+
+// Internal backend interface. Platform impls subclass and provide a
+// makePlatformStore() factory; the dispatcher in iap.cpp delegates
+// public-API calls to whichever Store the env-var selected.
+struct Store {
+    virtual ~Store() = default;
+    virtual void setCatalogue(std::vector<Product>)              = 0;
+    virtual bool owned(const std::string& id) const              = 0;
+    virtual std::vector<LocalisedProduct> products() const       = 0;
+    virtual void buy(const std::string& id, BuyCallback)         = 0;
+    virtual void restore(RestoreCallback)                        = 0;
+    virtual void testingSetOwned(const std::string& id, bool)    = 0;
+    virtual void testingClearAll()                               = 0;
+};
+
+// Per-platform factory. Defined in iap_apple.mm on Apple,
+// iap_android.cpp on Android, and src/iap.cpp (weak default) on
+// desktop. Returns nullptr when the platform backend isn't available
+// at runtime — the dispatcher then falls back to StubStore.
+std::unique_ptr<Store> makePlatformStore();
+
+} // namespace ge::iap::detail

--- a/src/iap_test.cpp
+++ b/src/iap_test.cpp
@@ -120,3 +120,77 @@ TEST_CASE("iap: testing::clearAll wipes entitlement state") {
     CHECK_FALSE(iap::owned("pro"));
     CHECK_FALSE(iap::owned("premium"));
 }
+
+TEST_CASE("iap::DebugPanel: rows() reflects live entitlement state") {
+    Reset r;
+    iap::setCatalogue({
+        {.id = "panel_pro",    .type = iap::Type::NonConsumable},
+        {.id = "panel_hints",  .type = iap::Type::Consumable},
+    });
+    iap::testing::setOwned("panel_pro", true);
+
+    iap::DebugPanel panel;
+    auto rows = panel.rows();
+
+    auto findRow = [&](const std::string& id) {
+        return std::find_if(rows.begin(), rows.end(),
+                            [&](const auto& r) { return r.id == id; });
+    };
+    auto proRow   = findRow("panel_pro");
+    auto hintsRow = findRow("panel_hints");
+    REQUIRE(proRow != rows.end());
+    REQUIRE(hintsRow != rows.end());
+    CHECK(proRow->owned);
+    CHECK_FALSE(hintsRow->owned);
+}
+
+TEST_CASE("iap::DebugPanel: onRowTap toggles owned state") {
+    Reset r;
+    iap::setCatalogue({{.id = "tappable", .type = iap::Type::NonConsumable}});
+
+    iap::DebugPanel panel;
+    CHECK_FALSE(iap::owned("tappable"));
+    panel.onRowTap("tappable");
+    CHECK(iap::owned("tappable"));
+    panel.onRowTap("tappable");
+    CHECK_FALSE(iap::owned("tappable"));
+}
+
+TEST_CASE("iap::DebugPanel: onResetAll clears entitlements") {
+    Reset r;
+    iap::setCatalogue({
+        {.id = "a", .type = iap::Type::NonConsumable},
+        {.id = "b", .type = iap::Type::NonConsumable},
+    });
+    iap::testing::setOwned("a", true);
+    iap::testing::setOwned("b", true);
+
+    iap::DebugPanel panel;
+    panel.onResetAll();
+    CHECK_FALSE(iap::owned("a"));
+    CHECK_FALSE(iap::owned("b"));
+}
+
+TEST_CASE("iap::DebugPanel: visibility helpers") {
+    iap::DebugPanel panel;
+    CHECK_FALSE(panel.visible);
+    panel.show();
+    CHECK(panel.visible);
+    panel.hide();
+    CHECK_FALSE(panel.visible);
+    panel.toggle();
+    CHECK(panel.visible);
+    panel.toggle();
+    CHECK_FALSE(panel.visible);
+}
+
+TEST_CASE("iap::DebugPanel: onForceRestore fires the callback") {
+    Reset r;
+    bool fired = false;
+    iap::DebugPanel panel;
+    panel.onForceRestore([&](iap::Result res) {
+        fired = true;
+        CHECK(res.ok);
+    });
+    CHECK(fired);
+}

--- a/src/iap_test.cpp
+++ b/src/iap_test.cpp
@@ -1,0 +1,122 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+#include <doctest.h>
+#include <ge/iap.h>
+
+#include <algorithm>
+
+namespace iap = ge::iap;
+
+namespace {
+
+// Each test starts from a clean slate. The backend singleton is
+// process-scoped, but testing::clearAll resets entitlement state.
+// Catalogue is additive across tests, which is fine — the tests
+// reference distinct IDs and don't assume an empty catalogue.
+struct Reset {
+    Reset() { iap::testing::clearAll(); }
+};
+
+bool listed(const std::vector<iap::LocalisedProduct>& list, const std::string& id) {
+    return std::any_of(list.begin(), list.end(),
+                       [&](const auto& p) { return p.id == id; });
+}
+
+} // namespace
+
+TEST_CASE("iap: owned() is false before setCatalogue") {
+    Reset r;
+    CHECK_FALSE(iap::owned("never_registered"));
+}
+
+TEST_CASE("iap: setCatalogue registers products that appear in products()") {
+    Reset r;
+    iap::setCatalogue({
+        {.id = "pro",      .type = iap::Type::NonConsumable},
+        {.id = "hints_10", .type = iap::Type::Consumable},
+    });
+
+    auto list = iap::products();
+    CHECK(listed(list, "pro"));
+    CHECK(listed(list, "hints_10"));
+}
+
+TEST_CASE("iap: setCatalogue is idempotent for same-id same-type") {
+    Reset r;
+    iap::setCatalogue({{.id = "pro", .type = iap::Type::NonConsumable}});
+    iap::setCatalogue({{.id = "pro", .type = iap::Type::NonConsumable}});
+    // No assertion fired; products() still lists pro.
+    CHECK(listed(iap::products(), "pro"));
+}
+
+TEST_CASE("iap: buy succeeds and flips owned for non-consumables") {
+    Reset r;
+    iap::setCatalogue({{.id = "pro", .type = iap::Type::NonConsumable}});
+
+    iap::Result r2;
+    iap::buy("pro", [&](iap::Result res) { r2 = std::move(res); });
+
+    CHECK(r2.ok);
+    CHECK(r2.id == "pro");
+    CHECK(r2.error.empty());
+    CHECK(iap::owned("pro"));
+}
+
+TEST_CASE("iap: consumables stay un-owned after buy (re-buyable)") {
+    Reset r;
+    iap::setCatalogue({{.id = "hints_10", .type = iap::Type::Consumable}});
+
+    iap::Result r2;
+    iap::buy("hints_10", [&](iap::Result res) { r2 = std::move(res); });
+
+    CHECK(r2.ok);
+    CHECK_FALSE(iap::owned("hints_10"));
+}
+
+TEST_CASE("iap: buy unknown product returns ok=false") {
+    Reset r;
+    iap::Result r2;
+    iap::buy("never_registered_here", [&](iap::Result res) { r2 = std::move(res); });
+
+    CHECK_FALSE(r2.ok);
+    CHECK(r2.id == "never_registered_here");
+    CHECK_FALSE(r2.error.empty());
+}
+
+TEST_CASE("iap: restore fires the callback with ok=true on stub") {
+    Reset r;
+    bool fired = false;
+    iap::restore([&](iap::Result res) {
+        fired = true;
+        CHECK(res.ok);
+    });
+    CHECK(fired);
+}
+
+TEST_CASE("iap: testing::setOwned controls owned() directly") {
+    Reset r;
+    iap::setCatalogue({{.id = "pro", .type = iap::Type::NonConsumable}});
+
+    CHECK_FALSE(iap::owned("pro"));
+    iap::testing::setOwned("pro", true);
+    CHECK(iap::owned("pro"));
+    iap::testing::setOwned("pro", false);
+    CHECK_FALSE(iap::owned("pro"));
+}
+
+TEST_CASE("iap: testing::clearAll wipes entitlement state") {
+    Reset r;
+    iap::setCatalogue({
+        {.id = "pro",       .type = iap::Type::NonConsumable},
+        {.id = "premium",   .type = iap::Type::NonConsumable},
+    });
+    iap::testing::setOwned("pro", true);
+    iap::testing::setOwned("premium", true);
+    CHECK(iap::owned("pro"));
+    CHECK(iap::owned("premium"));
+
+    iap::testing::clearAll();
+    CHECK_FALSE(iap::owned("pro"));
+    CHECK_FALSE(iap::owned("premium"));
+}

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,76 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// ge::log::install dispatcher.
+// Platform-specific sinks live in:
+//   * log_apple.mm    — os_log sink (iOS / iPadOS / tvOS / watchOS).
+//   * log_android.cpp — logcat sink (Android).
+// macOS desktop and other platforms get the spdlog default colour
+// stderr sink (left untouched).
+
+#include <ge/log.h>
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace ge::log {
+
+#if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_OS_WATCH)
+// Defined in log_apple.mm.
+spdlog::sink_ptr makeAppleSink(const std::string& subsystem);
+std::string autoDetectSubsystemApple();
+#endif
+
+#if defined(__ANDROID__)
+// Defined in log_android.cpp.
+spdlog::sink_ptr makeAndroidSink(const std::string& subsystem);
+std::string autoDetectSubsystemAndroid();
+#endif
+
+void install(std::string subsystem) {
+    static std::once_flag flag;
+    std::call_once(flag, [&] {
+        // Resolve subsystem before constructing any sink — autodetect
+        // dispatches per platform.
+        if (subsystem.empty()) {
+#if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_OS_WATCH)
+            subsystem = autoDetectSubsystemApple();
+#elif defined(__ANDROID__)
+            subsystem = autoDetectSubsystemAndroid();
+#endif
+            if (subsystem.empty()) subsystem = "ge";
+        }
+
+        // Build the sink list. stderr stays as a sink everywhere so
+        // local-dev console output isn't lost; the native sink fans
+        // out to os_log / logcat on mobile.
+        std::vector<spdlog::sink_ptr> sinks;
+        sinks.push_back(std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
+
+#if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_OS_WATCH)
+        sinks.push_back(makeAppleSink(subsystem));
+#elif defined(__ANDROID__)
+        sinks.push_back(makeAndroidSink(subsystem));
+#endif
+
+        // Replace the default logger so SPDLOG_INFO/WARN/ERROR macros
+        // (which target spdlog::default_logger_raw()) fan out through
+        // every sink in one shot.
+        auto logger = std::make_shared<spdlog::logger>(
+            "ge", sinks.begin(), sinks.end());
+        logger->set_level(spdlog::level::info);
+        logger->flush_on(spdlog::level::warn);
+        spdlog::set_default_logger(std::move(logger));
+    });
+}
+
+} // namespace ge::log

--- a/src/log_android.cpp
+++ b/src/log_android.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Android logcat sink for ge::log (🎯T66). Captured by `adb logcat`.
+//
+// Tag = subsystem (truncated to Android's 23-char TAG limit).
+// Subsystem auto-detects to the app's package name via JNI to
+// Activity.getPackageName(); SDL's android bridge provides the JNIEnv
+// and current Activity object without extra wiring from the consumer.
+
+#include <ge/log.h>
+
+#if defined(__ANDROID__)
+
+#include <android/log.h>
+
+#include <SDL3/SDL_system.h>
+
+#include <jni.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
+
+#include <mutex>
+#include <string>
+
+namespace ge::log {
+
+namespace {
+
+constexpr size_t kAndroidTagMax = 23;
+
+std::string truncateTag(const std::string& s) {
+    return (s.size() > kAndroidTagMax) ? s.substr(0, kAndroidTagMax) : s;
+}
+
+class AndroidSink : public spdlog::sinks::base_sink<std::mutex> {
+public:
+    explicit AndroidSink(std::string tag) : tag_(truncateTag(std::move(tag))) {}
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        spdlog::memory_buf_t buf;
+        this->formatter_->format(msg, buf);
+        size_t n = buf.size();
+        while (n > 0 && (buf.data()[n - 1] == '\n' || buf.data()[n - 1] == '\r')) --n;
+        std::string payload(buf.data(), n);
+
+        int prio = ANDROID_LOG_INFO;
+        switch (msg.level) {
+            case spdlog::level::trace:    prio = ANDROID_LOG_VERBOSE; break;
+            case spdlog::level::debug:    prio = ANDROID_LOG_DEBUG;   break;
+            case spdlog::level::info:     prio = ANDROID_LOG_INFO;    break;
+            case spdlog::level::warn:     prio = ANDROID_LOG_WARN;    break;
+            case spdlog::level::err:      prio = ANDROID_LOG_ERROR;   break;
+            case spdlog::level::critical: prio = ANDROID_LOG_FATAL;   break;
+            default:                      prio = ANDROID_LOG_INFO;    break;
+        }
+        __android_log_print(prio, tag_.c_str(), "%s", payload.c_str());
+    }
+
+    void flush_() override {}
+
+private:
+    std::string tag_;
+};
+
+} // namespace
+
+spdlog::sink_ptr makeAndroidSink(const std::string& subsystem) {
+    return std::make_shared<AndroidSink>(subsystem);
+}
+
+std::string autoDetectSubsystemAndroid() {
+    JNIEnv* env = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
+    jobject activity = static_cast<jobject>(SDL_GetAndroidActivity());
+    if (!env || !activity) return {};
+
+    jclass cls = env->GetObjectClass(activity);
+    if (!cls) {
+        env->DeleteLocalRef(activity);
+        return {};
+    }
+    jmethodID m = env->GetMethodID(cls, "getPackageName", "()Ljava/lang/String;");
+    jstring pkg = nullptr;
+    if (m) {
+        pkg = static_cast<jstring>(env->CallObjectMethod(activity, m));
+    }
+    std::string out;
+    if (pkg) {
+        const char* c = env->GetStringUTFChars(pkg, nullptr);
+        if (c) out.assign(c);
+        env->ReleaseStringUTFChars(pkg, c);
+        env->DeleteLocalRef(pkg);
+    }
+    env->DeleteLocalRef(cls);
+    env->DeleteLocalRef(activity);
+    return out;
+}
+
+} // namespace ge::log
+
+#endif // __ANDROID__

--- a/src/log_apple.mm
+++ b/src/log_apple.mm
@@ -1,0 +1,88 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// Apple os_log sink for ge::log (🎯T66). Compiled on iOS / iPadOS /
+// tvOS / watchOS only — macOS desktop keeps stderr.
+//
+// Key trick: spdlog formats each message into a memory buffer; we pass
+// that already-rendered payload as a single `%{public}s` argument to
+// os_log. Apple's privacy filter treats the whole payload as public,
+// so consumer code keeps writing normal `SPDLOG_INFO("v={:.3f}", v)`
+// without per-call %{public} annotations.
+//
+// The named subsystem (passed to os_log_create) is what `spyder log
+// <udid> --process <CFBundleExecutable>` and Xcode Console use for
+// capture-side filtering. Entries logged via OS_LOG_DEFAULT (no named
+// subsystem) are filtered out of remote capture entirely.
+
+#include <ge/log.h>
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_OS_WATCH)
+
+#import <Foundation/Foundation.h>
+#include <os/log.h>
+
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
+
+#include <mutex>
+#include <string>
+
+namespace ge::log {
+
+namespace {
+
+class AppleSink : public spdlog::sinks::base_sink<std::mutex> {
+public:
+    AppleSink(const std::string& subsystem, const std::string& category)
+        : log_(os_log_create(subsystem.c_str(), category.c_str())) {}
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        spdlog::memory_buf_t buf;
+        this->formatter_->format(msg, buf);
+        // Strip trailing newline — the default spdlog pattern adds one
+        // for stderr readability, but os_log records are line-oriented
+        // by themselves.
+        size_t n = buf.size();
+        while (n > 0 && (buf.data()[n - 1] == '\n' || buf.data()[n - 1] == '\r')) --n;
+        std::string payload(buf.data(), n);
+
+        os_log_type_t type = OS_LOG_TYPE_DEFAULT;
+        switch (msg.level) {
+            case spdlog::level::trace:
+            case spdlog::level::debug:    type = OS_LOG_TYPE_DEBUG;   break;
+            case spdlog::level::info:     type = OS_LOG_TYPE_INFO;    break;
+            case spdlog::level::warn:     type = OS_LOG_TYPE_DEFAULT; break;
+            case spdlog::level::err:      type = OS_LOG_TYPE_ERROR;   break;
+            case spdlog::level::critical: type = OS_LOG_TYPE_FAULT;   break;
+            default:                      type = OS_LOG_TYPE_DEFAULT; break;
+        }
+        os_log_with_type(log_, type, "%{public}s", payload.c_str());
+    }
+
+    void flush_() override {}
+
+private:
+    os_log_t log_;
+};
+
+} // namespace
+
+spdlog::sink_ptr makeAppleSink(const std::string& subsystem) {
+    return std::make_shared<AppleSink>(subsystem, "ge");
+}
+
+std::string autoDetectSubsystemApple() {
+    NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
+    if (bundleId) return std::string([bundleId UTF8String]);
+    return {};
+}
+
+} // namespace ge::log
+
+#endif // __APPLE__ && (TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_OS_WATCH)

--- a/tools/android-template/app/build.gradle.in
+++ b/tools/android-template/app/build.gradle.in
@@ -80,4 +80,7 @@ tasks.register('syncAssets', Sync) {
 preBuild.dependsOn('syncAssets')
 
 dependencies {
+    // Play Billing 7+ — required by ge::iap's AndroidStore via JNI to
+    // ge.IapBridge (android-shared/src/main/java/ge/IapBridge.java).
+    implementation 'com.android.billingclient:billing:7.1.1'
 }

--- a/tools/ios-template/CMakeLists.txt.in
+++ b/tools/ios-template/CMakeLists.txt.in
@@ -96,6 +96,8 @@ set(GE_SOURCES
     ${GE_ROOT}/src/sdl_input.cpp
     ${GE_ROOT}/src/iap.cpp
     ${GE_ROOT}/src/iap_apple.mm
+    ${GE_ROOT}/src/log.cpp
+    ${GE_ROOT}/src/log_apple.mm
     ${GE_ROOT}/src/Immersive_stub.cpp
     ${GE_ROOT}/src/CutoutInsets_stub.cpp
     ${GE_ROOT}/src/Attitude_apple.mm

--- a/tools/ios-template/CMakeLists.txt.in
+++ b/tools/ios-template/CMakeLists.txt.in
@@ -88,11 +88,17 @@ set(GE_SOURCES
     ${GE_ROOT}/src/BgfxContext.mm
     ${GE_ROOT}/src/Signal.cpp
     ${GE_ROOT}/src/SessionHost.mm
-    ${GE_ROOT}/src/SvgRasterizer.cpp
     ${GE_ROOT}/src/sprite.cpp
     ${GE_ROOT}/src/svg.cpp
     ${GE_ROOT}/src/png.cpp
     ${GE_ROOT}/src/text.cpp
+    ${GE_ROOT}/src/button.cpp
+    ${GE_ROOT}/src/sdl_input.cpp
+    ${GE_ROOT}/src/iap.cpp
+    ${GE_ROOT}/src/iap_apple.mm
+    ${GE_ROOT}/src/Immersive_stub.cpp
+    ${GE_ROOT}/src/CutoutInsets_stub.cpp
+    ${GE_ROOT}/src/Attitude_apple.mm
     ${GE_ROOT}/src/render/DirectRenderHost.mm
     ${GE_ROOT}/tools/player_orientation_ios.mm
     ${GE_ROOT}/vendor/src/sqlite3.c
@@ -179,6 +185,7 @@ target_include_directories(__CMAKE_PROJECT__ PRIVATE
     ${GE_ROOT}/vendor/github.com/gabime/spdlog/include
     ${GE_ROOT}/vendor/github.com/chriskohlhoff/asio/include
     ${GE_ROOT}/vendor/github.com/libsdl-org/SDL/include
+    ${GE_ROOT}/vendor/github.com/libsdl-org/SDL_ttf/external/freetype/include
     ${GE_ROOT}/vendor/sdl3/include
     ${GE_ROOT}/vendor/github.com/sqliteai/liteparser/src
     ${LUNASVG_DIR}/include
@@ -208,6 +215,7 @@ target_link_libraries(__CMAKE_PROJECT__ PRIVATE
     "-framework GameController" "-framework CoreHaptics"
     "-framework CoreMotion" "-framework VideoToolbox"
     "-framework Security" "-framework OpenGLES" "-framework ImageIO"
+    "-framework CoreText" "-framework StoreKit"
     "-lobjc"
 )
 


### PR DESCRIPTION
## Added

- `ge::log` (🎯T66) — cross-platform spdlog sink installed automatically by `ge::run`. SPDLOG_INFO / WARN / ERROR / DEBUG / CRITICAL output fans out to:
  - **iOS / iPadOS / tvOS / watchOS** — `os_log_with_type` via `os_log_create(<bundle-id>, "ge")`, captured by `spyder log <udid> --process <CFBundleExecutable>` and Xcode Console. Whole spdlog payload passed as a single `%{public}s` arg so every value is visible without per-call `%{public}` boilerplate.
  - **Android** — `__android_log_print` with tag = `<package-name>` (truncated to 23 chars), captured by `adb logcat`.
  - **Desktop** — spdlog default colour-stderr (unchanged).
- `ge::iap` (🎯T65) — cross-platform in-app purchases under a unified C++ API. Games register a catalogue, query `owned()` in O(1), call `buy()` with a callback. Backends:
  - `StubStore` — pure C++, in-memory, default on desktop. Unit-testable; `testing::setOwned` for the in-engine debug panel.
  - `AppleStore` (`iap_apple.mm`) — StoreKit 1 with verified transactions, signature-verified entitlements, async product fetch.
  - `AndroidStore` (`iap_android.cpp` + `android-shared/.../IapBridge.java`) — Play Billing 7+ via JNI, self-bootstraps the JVM from `SDL_GetAndroidJNIEnv`. Acknowledges one-time purchases to prevent the 3-day auto-refund.
- `ge::iap::DebugPanel` — pure-data overlay state for toggling entitlements in dev builds. Games render via own UI primitives; data layer reusable.
- `docs/iap-testing.md` — studio-wide sandbox + license-tester protocol; naming, onboarding order, troubleshooting.
- `sample/tiltbuggy` proves the IAP stack end-to-end: chassis turns chromed cyan + dirt/ice surfaces materialise behind a `pro` non-consumable; tappable in-app BUY PRO button drives `ge::iap::buy`.

## Fixed

- `iOS template + sample/tiltbuggy/ios/CMakeLists` drifted from `Module.mk`. Stale `SvgRasterizer.cpp` / `SvgSprite.cpp` references replaced with `svg.cpp` + `sprite.cpp`. Added missing `png.cpp`, `text.cpp`, `button.cpp`, `sdl_input.cpp`, `iap.cpp`, `iap_apple.mm`, `log.cpp`, `log_apple.mm`, `Attitude_apple.mm` to GE_SOURCES. Bundled SDL_ttf/external/freetype headers added so `text.cpp` finds `<ft2build.h>` on iOS. CoreText + StoreKit frameworks linked.
- `iap_android.cpp` self-bootstraps the JVM/Activity via SDL's Android bridge — eliminated a "JVM not available" no-op path where every Android `buy()` failed silently.
- `iap_apple.mm` caches `SKProduct*` references on the broker so `buy()` doesn't re-issue an `SKProductsRequest` after the initial fetch.
- `iap.cpp` dispatcher defaults: `platform` on mobile (iOS / iPadOS / tvOS / watchOS / Android), `stub` on macOS desktop. `TARGET_OS_IPHONE` et al. distinguish the two.

## Verified

- macOS desktop: 142 doctest cases pass (16 new for IAP + DebugPanel).
- iPhone 13 (iOS 26.4.2): `ge::log` payload visible via `spyder log --process`; tiltbuggy renders, IAP catalogue registers, sandbox-purchase flow reachable.
- Galaxy S24 (Android 16): `adb logcat -s com.squz.tiltbuggy` shows full payload; IAP path reaches Play Billing.
- ROG Phone 9 Pro (Android 16): same as above, additional surface for bring-up.

## Out of scope (deferred to follow-ups)

- T65.4 (LocalStore for `.storekit` / `android.test.*`), T65.5 (Keychain / EncryptedSharedPreferences cache persistence), T65.6 (DebugPanel renderer), T65.7 (Tiltbuggy proving-ground real-store demo) — open sub-targets of T65.
- T64.x deployment architecture umbrella — separate target tree.
