### PR TITLE
Release prep v0.29.0: ge::iap::SkuMapping per-product override (🎯T67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,11 +646,41 @@ ge::iap::restore([](auto){ });  // Apple App Review requires a "Restore Purchase
 
 **Product IDs are local.** Game registers `"pro"`, ge prepends the bundle ID to form the platform SKU `com.squz.tiltbuggy.pro`. The same string is what gets registered in App Store Connect and Play Console — no separate mapping table.
 
+**Explicit per-platform SKU override (🎯T67).** Legacy / migration apps that can't fit the auto-prefix convention pass an optional `sku` field on `Product`:
+
+```cpp
+ge::iap::setCatalogue({
+    // Greenfield product — auto-prefix:
+    //   iOS     → com.squz.tiltbuggy.pro
+    //   Android → com.squz.tiltbuggy.pro
+    {.id = "pro", .type = ge::iap::Type::NonConsumable},
+
+    // Legacy product — explicit verbatim SKUs on each platform:
+    {
+        .id   = "allpacks",
+        .type = ge::iap::Type::NonConsumable,
+        .sku  = ge::iap::SkuMapping{
+            .apple   = "com.squz.multimaze.allpacks",
+            .android = "com_squz_multimaze_allpacks",
+        },
+    },
+
+    // Mixed mode — iOS inherits legacy, Android is greenfield (auto-prefix):
+    {
+        .id   = "grandmaster_pack",
+        .type = ge::iap::Type::NonConsumable,
+        .sku  = ge::iap::SkuMapping{.apple = "com.squz.multimaze.grandmaster.001"},
+    },
+});
+```
+
+Game-side code keeps using the local id everywhere — `owned("allpacks")`, `buy("grandmaster_pack", ...)`, `testing::setOwned("allpacks", true)`. The mapping mechanic is hidden from the testing API and from `StubStore`'s entitlement index; only `AppleStore` and `AndroidStore` consult it when forming the platform SKU sent to the store and when reversing a transaction-update back into a local id.
+
 **Testing surface** (`ge::iap::testing::setOwned`, `clearAll`) is authoritative on StubStore, no-op on platform stores. Used by unit tests and the in-engine debug menu (T65.6) for inner-loop iteration without touching a real store.
 
 **Server-side receipt validation is intentionally not provided.** Modern frameworks return signature-verified transactions (StoreKit 2 JWS, Play Billing signed receipts); ge writes only verified entitlements to the cache. The JWS floor covers replay, bundle-ID-binding, and account-binding for the threat model that paid non-consumable unlocks against casual game audiences actually face. Add server-side validation when shipping subscriptions or high-value-currency consumables.
 
-- **`<ge/iap.h>`** — Public surface. `Type`, `Product`, `LocalisedProduct`, `Result`, `setCatalogue`, `owned`, `products`, `buy`, `restore`, `testing::setOwned`, `testing::clearAll`.
+- **`<ge/iap.h>`** — Public surface. `Type`, `Product`, `SkuMapping`, `LocalisedProduct`, `Result`, `setCatalogue`, `owned`, `products`, `buy`, `restore`, `testing::setOwned`, `testing::clearAll`.
 
 ### Testing
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2182,7 +2182,7 @@ targets:
     achieved: 2026-05-19
   T67:
     name: ge::iap supports explicit per-product SKU mappings so legacy / non-conformant SKUs can be registered without forcing them to fit the bundle-id-prefix convention
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2219,6 +2219,7 @@ targets:
     - surfaced-by:multimaze2
     origin: manual
     discovered: 2026-05-21
+    achieved: 2026-05-21
   T7:
     name: Audio pauses when the app is backgrounded
     status: identified

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2180,6 +2180,45 @@ targets:
     origin: manual
     discovered: 2026-05-19
     achieved: 2026-05-19
+  T67:
+    name: ge::iap supports explicit per-product SKU mappings so legacy / non-conformant SKUs can be registered without forcing them to fit the bundle-id-prefix convention
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`ge::iap::Product` (or its companion type in `<ge/iap.h>`) accepts an *optional* per-platform SKU mapping. When set, it overrides the auto-prefix path; when unset, current bundle-id-prefix behaviour is preserved unchanged. Shape sketch: `Product { id; type; std::optional<SkuMapping> sku; }` where `SkuMapping` carries `apple` and `android` strings (and is free to grow if a third platform lands).'
+    - Both the StoreKit (Apple) and Play Billing (Android) backends honour the override. When `sku` is set, the platform-side identifier sent to StoreKit / Play Billing is the explicit string verbatim; when unset, the platforms continue to compute `bundle_id + "." + local_id` as today.
+    - 'Consumer-facing surface remains source-compatible: existing call sites that use `setCatalogue({{.id="pro", .type=NonConsumable}})` keep working without change. Adding `sku = SkuMapping{.apple = "com.legacy.app.pro", .android = "legacy_pro"}` is purely additive.'
+    - '`testing::setOwned(local_id, bool)` still operates against the local id, not the platform SKU — the testing API doesn''t leak the mapping mechanic.'
+    - '`StubStore` ignores the mapping entirely (entitlements indexed by local id), since the stub doesn''t talk to any platform store.'
+    - 'Documentation in `ge/CLAUDE.md` under the IAP section explains the two cases: greenfield apps (no `sku` field, auto-prefix is right) and legacy / migration apps (explicit `sku` per platform). Includes the multimaze2 worked example: legacy v2.0.2 SKUs `com.squz.multimaze.{grandmaster,kids,master,multiball}.001` and `com.squz.multimaze.allpacks` registered from a `com.squz.multimaze2` bundle without bundle-id rewriting.'
+    - 'Unit test asserts both code paths: a `Product` without `sku` resolves through the auto-prefix on AppleStore / AndroidStore, and a `Product` with `sku` resolves through the explicit string. Verified against StubStore for the local-id path and against a mock platform store (or `iap_test.cpp`''s equivalent harness) for the explicit-SKU path.'
+    - Cross-platform consumers can leave `sku.apple` or `sku.android` empty (default-constructed string) to indicate "use the auto-prefix on that platform only" — useful for apps where one platform inherits legacy SKUs and the other is greenfield. Documented in the example.
+    context: |-
+      **Surfaced by:** multimaze2 🎯T13 (iOS in-app purchase flow restored, anchored to legacy v2.0.2's product structure). multimaze2 wants to register `com.squz.multimaze.allpacks` and the four per-pack SKUs (`com.squz.multimaze.{grandmaster,kids,master,multiball}.001`) — but multimaze2's bundle id is `com.squz.multimaze2`, so ge's current auto-prefix mechanism would produce `com.squz.multimaze2.allpacks` (the wrong namespace). Either ge gains an explicit-SKU escape hatch, or multimaze2 abandons legacy SKU parity (which has near-zero value since the v2.0.2 app was pulled from sale years ago, but the *generality* of "ge consumers might rebrand or migrate bundles" is what motivates fixing this in the engine).
+
+      **Why mapping, not a single `explicit_sku` field:**
+      - iOS and Android have different valid-character rules. Apple allows dots in product IDs; Google Play forbids them in places (`-` and `.` get rejected in some test SKU formats). A single string can't represent both correctly when the rules diverge.
+      - Apps can rebrand on one platform without the other (iOS bundle changes, Android keeps its old package name, or vice versa). A mapping struct expresses this directly.
+      - Treats both auto-prefixed and explicit-SKU products as first-class catalogue entries rather than "normal product" + "weird-case escape hatch".
+
+      **Design intent of the current `bundle_id + \".\" + local_id` auto-prefix** (worth preserving as the default):
+      1. Cross-platform parity for free — same local id maps to a consistent SKU on both stores.
+      2. Codifies Apple's informal `<bundle-id>.<product>` convention (avoids collisions across a developer team's apps, since App Store Connect product IDs are team-scoped, not app-scoped).
+      3. Sandbox / TestFlight builds with different bundle ids automatically point at matching sandbox SKUs without `#ifdef`s.
+
+      All three benefits are preserved when `sku` is unset — only consumers that explicitly need the override pay the cost of providing it.
+
+      **Out of scope:** runtime-overridable SKU mapping (the mapping is fixed at catalogue-registration time, not mutable later). Per-locale SKUs (Apple supports this via App Store Connect's metadata; ge already exposes it via `LocalisedProduct.price`). Subscription-product SKU variants per renewal tier (subscriptions are a wider design conversation; consume the single `Product` row for now).
+
+      **Companion target in multimaze2:** 🎯T13 depends on a working ge::iap surface; once this target lands, T13 can register its five products with explicit Apple SKUs and unblock the iOS v1 launch. T13 has been written to assume ge::iap will gain this capability; if for any reason it doesn't, T13 has a documented fallback (register fresh SKUs under `com.squz.multimaze2.*` and accept loss of legacy-customer entitlement continuity — moot since v2.0.2 was pulled from sale).
+    tags:
+    - iap
+    - engine
+    - api
+    - surfaced-by:multimaze2
+    origin: manual
+    discovered: 2026-05-21
   T7:
     name: Audio pauses when the app is backgrounded
     status: identified

--- a/include/ge/iap.h
+++ b/include/ge/iap.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -42,9 +43,20 @@ enum class Type {
     AutoRenewingSubscription, // Monthly/yearly. Server validation recommended.
 };
 
+// Optional per-platform SKU override for legacy / migration cases.
+// When a field is non-empty, that string is sent to the platform store
+// verbatim instead of the auto-prefixed `<bundle-id>.<local-id>`. Leave
+// either field empty to keep auto-prefix behaviour on that platform
+// (mixed mode — e.g. legacy SKUs on iOS, greenfield on Android).
+struct SkuMapping {
+    std::string apple;       // App Store Connect product ID; e.g. "com.legacy.app.pro"
+    std::string android;     // Play Console product ID; e.g. "legacy_pro"
+};
+
 struct Product {
-    std::string id;                          // Local ID, e.g. "pro"
-    Type        type = Type::NonConsumable;
+    std::string                 id;                          // Local ID, e.g. "pro"
+    Type                        type = Type::NonConsumable;
+    std::optional<SkuMapping>   sku;                         // Optional override (🎯T67)
 };
 
 struct LocalisedProduct {

--- a/src/iap_android.cpp
+++ b/src/iap_android.cpp
@@ -79,6 +79,11 @@ struct AndroidStore : Store {
     std::unordered_set<std::string>                     entitled;
     std::unordered_map<std::string, LocalisedProduct>   localised;
     std::unordered_map<std::string, BuyCallback>        pendingBuys;
+    // 🎯T67 SKU-mapping support — same shape as AppleStore. Populated
+    // by setCatalogue, consulted on buy() (forward) and on
+    // nativeOnProductFetched / nativeOnPurchaseUpdate (reverse).
+    std::unordered_map<std::string, std::string>        platformSkuByLocal; // local -> platform
+    std::unordered_map<std::string, std::string>        localBySkuPlatform; // platform -> local
     RestoreCallback                                     pendingRestore;
     jobject                                             bridge = nullptr;   // global ref
 
@@ -205,7 +210,14 @@ void AndroidStore::setCatalogue(std::vector<Product> next) {
         std::lock_guard lock(mu);
         for (const auto& p : next) {
             catalogue.try_emplace(p.id, p);
-            skus.push_back(platformSku(env.env, p.id));
+            // 🎯T67: explicit override on Android takes precedence;
+            // otherwise auto-prefix via Activity.getPackageName().
+            std::string platformId = (p.sku && !p.sku->android.empty())
+                ? p.sku->android
+                : platformSku(env.env, p.id);
+            platformSkuByLocal[p.id]       = platformId;
+            localBySkuPlatform[platformId] = p.id;
+            skus.push_back(platformId);
             subs.push_back(p.type == Type::AutoRenewingSubscription ? JNI_TRUE : JNI_FALSE);
         }
     }
@@ -250,17 +262,20 @@ void AndroidStore::buy(const std::string& id, BuyCallback cb) {
         return;
     }
 
+    std::string platformId;
     {
         std::lock_guard lock(mu);
-        if (catalogue.find(id) == catalogue.end()) {
+        auto it = platformSkuByLocal.find(id);
+        if (it == platformSkuByLocal.end()) {
             Result r{.ok = false, .id = id, .error = "unknown product"};
             if (cb) cb(std::move(r));
             return;
         }
+        platformId = it->second;
         pendingBuys[id] = std::move(cb);
     }
 
-    jstring sku = env.env->NewStringUTF(platformSku(env.env, id).c_str());
+    jstring sku = env.env->NewStringUTF(platformId.c_str());
     jclass bridgeCls = env.env->GetObjectClass(bridge);
     jmethodID m = env.env->GetMethodID(bridgeCls, "launchPurchase", "(Ljava/lang/String;)Z");
     env.env->CallBooleanMethod(bridge, m, sku);
@@ -355,7 +370,18 @@ JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnProductFetched(
         return out;
     };
     std::string skuStr = j2s(sku);
-    std::string localId = localIdFromSku(env, skuStr);
+    std::string localId;
+    {
+        std::lock_guard lock(g_instance->mu);
+        auto it = g_instance->localBySkuPlatform.find(skuStr);
+        if (it != g_instance->localBySkuPlatform.end()) {
+            localId = it->second;
+        }
+    }
+    if (localId.empty()) {
+        SPDLOG_WARN("Play Billing responded with unmapped product identifier: {}", skuStr);
+        return;
+    }
     LocalisedProduct lp{
         .id          = localId,
         .title       = j2s(title),
@@ -373,7 +399,18 @@ JNIEXPORT void JNICALL Java_ge_IapBridge_nativeOnPurchaseUpdate(
     const char* skuC = env->GetStringUTFChars(sku, nullptr);
     std::string skuStr = skuC ? skuC : "";
     env->ReleaseStringUTFChars(sku, skuC);
-    std::string localId = localIdFromSku(env, skuStr);
+    std::string localId;
+    {
+        std::lock_guard lock(g_instance->mu);
+        auto it = g_instance->localBySkuPlatform.find(skuStr);
+        if (it != g_instance->localBySkuPlatform.end()) {
+            localId = it->second;
+        }
+    }
+    if (localId.empty()) {
+        SPDLOG_WARN("Play Billing purchase update for unmapped product identifier: {}", skuStr);
+        return;
+    }
     std::string errStr;
     if (error) {
         const char* c = env->GetStringUTFChars(error, nullptr);

--- a/src/iap_apple.mm
+++ b/src/iap_apple.mm
@@ -56,20 +56,21 @@ namespace ge::iap::detail {
 
 namespace {
 
-std::string platformSku(const std::string& localId) {
+// Default auto-prefix: `<bundle-id>.<local-id>` (the convention codified
+// by Apple's docs). Used when Product::sku is unset or its `apple`
+// field is empty (mixed-mode override on Android only).
+std::string autoPrefixSku(const std::string& localId) {
     NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
     if (!bundleId) return localId;
     return std::string([bundleId UTF8String]) + "." + localId;
 }
 
-std::string localIdFromSku(const std::string& sku) {
-    NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
-    if (!bundleId) return sku;
-    const std::string prefix = std::string([bundleId UTF8String]) + ".";
-    if (sku.size() > prefix.size() && sku.compare(0, prefix.size(), prefix) == 0) {
-        return sku.substr(prefix.size());
-    }
-    return sku;
+// Resolve the App Store Connect product ID for a single Product entry.
+// Respects the explicit override at `Product::sku->apple` when set,
+// otherwise falls back to the auto-prefix.
+std::string platformSkuFor(const Product& p) {
+    if (p.sku && !p.sku->apple.empty()) return p.sku->apple;
+    return autoPrefixSku(p.id);
 }
 
 } // namespace
@@ -80,6 +81,12 @@ struct AppleStore : Store {
     std::unordered_set<std::string>                     entitled;    // local ids
     std::unordered_map<std::string, LocalisedProduct>   localised;   // local id -> price/title
     std::unordered_map<std::string, BuyCallback>        pendingBuys; // local id -> cb
+    // 🎯T67 SKU-mapping support — populated by setCatalogue, keyed by
+    // local id and (reverse) by platform SKU so transaction callbacks
+    // from StoreKit can recover the local id when an explicit SKU was
+    // used. Updated under `mu`.
+    std::unordered_map<std::string, std::string>        platformSkuByLocal; // local -> platform
+    std::unordered_map<std::string, std::string>        localBySkuPlatform; // platform -> local
     RestoreCallback                                     pendingRestore;
     GEStoreKitBroker* __strong                          broker = nil;
 
@@ -187,7 +194,10 @@ void AppleStore::setCatalogue(std::vector<Product> next) {
         std::lock_guard lock(mu);
         for (const auto& p : next) {
             catalogue.try_emplace(p.id, p);
-            NSString* sku = [NSString stringWithUTF8String:platformSku(p.id).c_str()];
+            std::string platformId = platformSkuFor(p);
+            platformSkuByLocal[p.id]     = platformId;
+            localBySkuPlatform[platformId] = p.id;
+            NSString* sku = [NSString stringWithUTF8String:platformId.c_str()];
             [skus addObject:sku];
         }
     }
@@ -208,15 +218,21 @@ std::vector<LocalisedProduct> AppleStore::products() const {
 }
 
 void AppleStore::buy(const std::string& id, BuyCallback cb) {
-    NSString* sku = [NSString stringWithUTF8String:platformSku(id).c_str()];
-    SKProduct* product = [broker productForSku:sku];
+    std::string platformId;
     {
         std::lock_guard lock(mu);
-        if (catalogue.find(id) == catalogue.end()) {
+        auto it = platformSkuByLocal.find(id);
+        if (it == platformSkuByLocal.end()) {
             Result r{.ok = false, .id = id, .error = "unknown product"};
             if (cb) cb(std::move(r));
             return;
         }
+        platformId = it->second;
+    }
+    NSString* sku = [NSString stringWithUTF8String:platformId.c_str()];
+    SKProduct* product = [broker productForSku:sku];
+    {
+        std::lock_guard lock(mu);
         if (!product) {
             Result r{.ok = false, .id = id, .error = "product not yet fetched from store"};
             if (cb) cb(std::move(r));
@@ -240,7 +256,12 @@ void AppleStore::onProductsResponse(SKProductsResponse* response) {
     std::lock_guard lock(mu);
     for (SKProduct* p in response.products) {
         std::string sku    = [p.productIdentifier UTF8String];
-        std::string localId = localIdFromSku(sku);
+        auto it = localBySkuPlatform.find(sku);
+        if (it == localBySkuPlatform.end()) {
+            SPDLOG_WARN("StoreKit responded with unmapped product identifier: {}", sku);
+            continue;
+        }
+        std::string localId = it->second;
 
         NSNumberFormatter* fmt = [[NSNumberFormatter alloc] init];
         fmt.numberStyle = NSNumberFormatterCurrencyStyle;
@@ -264,11 +285,21 @@ void AppleStore::onProductsResponse(SKProductsResponse* response) {
 
 void AppleStore::onTransactionUpdate(SKPaymentTransaction* tx) {
     std::string sku    = [tx.payment.productIdentifier UTF8String];
-    std::string localId = localIdFromSku(sku);
-
+    std::string localId;
     bool isConsumable = false;
     {
         std::lock_guard lock(mu);
+        auto skuIt = localBySkuPlatform.find(sku);
+        if (skuIt == localBySkuPlatform.end()) {
+            // Unmapped transaction — possible if Apple delivers a
+            // leftover transaction from an earlier session whose
+            // catalogue we no longer have. Finish it so StoreKit
+            // doesn't keep redelivering, but skip our callback path.
+            SPDLOG_WARN("Transaction for unmapped product identifier: {}", sku);
+            [[SKPaymentQueue defaultQueue] finishTransaction:tx];
+            return;
+        }
+        localId = skuIt->second;
         auto pIt = catalogue.find(localId);
         if (pIt != catalogue.end()) isConsumable = pIt->second.type == Type::Consumable;
     }

--- a/src/iap_test.cpp
+++ b/src/iap_test.cpp
@@ -121,6 +121,64 @@ TEST_CASE("iap: testing::clearAll wipes entitlement state") {
     CHECK_FALSE(iap::owned("premium"));
 }
 
+TEST_CASE("iap: SkuMapping registers without breaking local-id flow (🎯T67)") {
+    Reset r;
+    iap::setCatalogue({
+        {
+            .id   = "legacy_pro",
+            .type = iap::Type::NonConsumable,
+            .sku  = iap::SkuMapping{
+                .apple   = "com.legacy.app.pro",
+                .android = "legacy_pro_v1",
+            },
+        },
+    });
+
+    // Local-id continuity: testing::setOwned still operates on the
+    // local id, the mapping mechanic doesn't leak into the testing API.
+    CHECK_FALSE(iap::owned("legacy_pro"));
+    iap::testing::setOwned("legacy_pro", true);
+    CHECK(iap::owned("legacy_pro"));
+
+    // The platform SKU is *not* a local id — owned() against it
+    // returns false (StubStore indexes by local id only).
+    CHECK_FALSE(iap::owned("com.legacy.app.pro"));
+    CHECK_FALSE(iap::owned("legacy_pro_v1"));
+}
+
+TEST_CASE("iap: mixed-mode SkuMapping (one platform overridden, one auto)") {
+    Reset r;
+    iap::setCatalogue({
+        {
+            .id   = "ios_legacy",
+            .type = iap::Type::NonConsumable,
+            // android field empty => auto-prefix on Android, override on iOS
+            .sku  = iap::SkuMapping{.apple = "com.old.bundle.gold"},
+        },
+    });
+
+    iap::testing::setOwned("ios_legacy", true);
+    CHECK(iap::owned("ios_legacy"));
+}
+
+TEST_CASE("iap: buy() against StubStore is unaffected by SkuMapping presence") {
+    Reset r;
+    iap::setCatalogue({
+        {
+            .id   = "stub_legacy",
+            .type = iap::Type::NonConsumable,
+            .sku  = iap::SkuMapping{.apple = "com.x.y.z", .android = "stub_legacy_v2"},
+        },
+    });
+
+    iap::Result res;
+    iap::buy("stub_legacy", [&](iap::Result r2) { res = std::move(r2); });
+
+    CHECK(res.ok);
+    CHECK(res.id == "stub_legacy");
+    CHECK(iap::owned("stub_legacy"));
+}
+
 TEST_CASE("iap::DebugPanel: rows() reflects live entitlement state") {
     Reset r;
     iap::setCatalogue({


### PR DESCRIPTION
## Added

- `ge::iap::SkuMapping` + optional `Product::sku` field (🎯T67) — explicit per-platform SKU override for legacy / migration apps that can't fit the auto-prefix convention. Surfaced by multimaze2's iOS v1 launch (its v2.0.2 legacy IAP IDs need to register from a `com.squz.multimaze2` bundle).

```cpp
ge::iap::setCatalogue({
    // Greenfield — keeps auto-prefix (com.squz.tiltbuggy.pro):
    {.id = "pro", .type = ge::iap::Type::NonConsumable},

    // Legacy — explicit verbatim SKUs per platform:
    {
        .id   = "allpacks",
        .type = ge::iap::Type::NonConsumable,
        .sku  = ge::iap::SkuMapping{
            .apple   = "com.squz.multimaze.allpacks",
            .android = "com_squz_multimaze_allpacks",
        },
    },

    // Mixed mode — iOS inherits legacy, Android auto-prefixes:
    {
        .id   = "grandmaster_pack",
        .type = ge::iap::Type::NonConsumable,
        .sku  = ge::iap::SkuMapping{.apple = "com.squz.multimaze.grandmaster.001"},
    },
});
```

## Changed

- `AppleStore` + `AndroidStore` now hold forward/reverse SKU maps populated at `setCatalogue`. The free-function `platformSku` / `localIdFromSku` helpers are out of the dispatch path; the maps consult `Product::sku` per-entry.

## Preserved

- Source compatibility: existing `setCatalogue({{.id="pro", .type=NonConsumable}})` call sites keep working without change. Adding `.sku = ...` is purely additive.
- `testing::setOwned`, `testing::clearAll`, and `DebugPanel` continue to operate on local ids only — the mapping mechanic doesn't leak into the testing API.
- `StubStore` ignores the mapping (entitlements indexed by local id).

## Verified

- macOS desktop: 145 doctest cases pass (3 new for SkuMapping covering local-id continuity, mixed-mode, and StubStore buy()).
- iOS device build: clean for `iphoneos` arm64.
- Android device build: clean.
- Mock platform store coverage for the explicit-SKU dispatch path is by inspection + compile; runtime end-to-end verification will land via multimaze2's 🎯T13 (the consumer that motivated this).

## Out of scope

- Runtime-overridable SKU mapping (the mapping is fixed at catalogue-registration time).
- Per-locale SKUs (Apple supports via App Store Connect metadata; ge already exposes `LocalisedProduct.price`).
- Subscription product SKU variants per renewal tier (wider design conversation; defer).
