### PR TITLE
ge: SessionConfig.orientation honors specific kOrientation* constants (🎯T36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,12 +400,22 @@ This was the takeaway of a long debugging session in v0.1.0 (see commit `e0da016
 
 **How games request the lock:**
 
-- **Direct-render apps** (`DirectRenderHost`-mode, e.g. TiltBuggy): set `SessionHostConfig.orientation = wire::kOrientationLandscape` (or any non-zero `wire::kOrientation*` constant). The engine calls `playerForceOrientation` from `DirectRenderHost::send` automatically. The orientation stub/swizzle is now linked into `libge` (v0.3.0+), so apps don't need to add anything to their build.
+- **Direct-render apps** (`DirectRenderHost`-mode, e.g. TiltBuggy): set `SessionHostConfig.orientation = wire::kOrientationPortrait` (or whichever `wire::kOrientation*` constant matches the game's intent). The engine calls `playerForceOrientation` from `DirectRenderHost::send` automatically. The orientation stub/swizzle is linked into `libge` (v0.3.0+), so apps don't need to add anything to their build.
 - **Player apps** get this for free — `wire::SessionConfig.orientation` from the server triggers `playerForceOrientation()` over the wire.
 
-**API caveat (v0.3.0):** the `wire::kOrientation*` enum has four constants (Landscape, LandscapeFlipped, Portrait, PortraitFlipped) but `playerForceOrientation` currently treats the field as a **boolean** — any non-zero value enables the lock; the *specific* value is not honored. The orientation that gets locked is whichever one iOS picked at launch, bounded by your `UISupportedInterfaceOrientations`. To force "specifically LandscapeLeft only," narrow the plist to `LandscapeLeft` only — don't rely on passing `kOrientationLandscape` vs `kOrientationLandscapeFlipped` to differentiate, because today they don't. 🎯T36 tracks aligning the API with its behavior (either collapse to a boolean or make the constants authoritative).
+**Authoritative orientation locks (🎯T36, v0.31.0+).** Each `wire::kOrientation*` constant now produces a specific runtime behaviour:
 
-If you find yourself editing `UISupportedInterfaceOrientations` to fix an orientation problem, you're in the right place — but make sure you've also set `SessionHostConfig.orientation` non-zero, or the lock won't survive the iPad's swivel gesture.
+| Constant | iOS effect |
+|---|---|
+| `kOrientationPortrait` | UI locked to Portrait (home indicator at bottom) |
+| `kOrientationPortraitFlipped` | UI locked to PortraitUpsideDown |
+| `kOrientationLandscape` | UI locked to LandscapeRight (SDL convention; home indicator on left) |
+| `kOrientationLandscapeFlipped` | UI locked to LandscapeLeft |
+| `kOrientationAnyLandscape` | UI locked at launch to whichever landscape iOS picks; user can't rotate mid-play. Use for tilt games where the player flips the device freely. |
+
+The engine narrows `UISupportedInterfaceOrientations` to the requested mask at runtime, so iOS rotates the UI at launch even if the device was held in a non-matching orientation. The `Info.plist`'s `UISupportedInterfaceOrientations` becomes the **fallback** (used when no runtime lock is set), not the gate. You can leave the plist permissive and let `SessionConfig.orientation` decide.
+
+If `SessionConfig.orientation` is set but the plist's allowed set doesn't include the requested orientation, the engine logs a loud `SPDLOG_WARN` pointing at the mismatch — the override still works (swizzle overrides plist at runtime), but narrowing the plist matches engine intent and avoids brief launch flicker.
 
 ## ged Features
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -932,7 +932,7 @@ targets:
   T36:
     name: SessionConfig.orientation API matches its behaviour — either authoritative per-orientation lock or a clean boolean
     status: identified
-    value: 0.0
+    value: 5.0
     cost: 0.0
     acceptance:
     - 'Either: SessionConfig.orientation is renamed/repurposed as a boolean (option 1), or: passing different kOrientation* constants produces different runtime behaviour (option 2)'
@@ -973,6 +973,16 @@ targets:
       The trigger for picking between #1 and #2: a game wants per-orientation-only lock that the plist alone can't easily express (e.g., "lock to LandscapeLeft, never LandscapeRight, never adapt to device flip mid-play"). At that point, #2 is the right choice. Until then, #1 is honesty.
 
       Constraint to remember: the only iPad orientation-lock mechanism that survives iPadOS 26 multitasking is the `prefersInterfaceOrientationLocked` swizzle (Apple TN3192). Both options have to keep using it; only the input shape changes.
+
+      ---
+      UPDATE 2026-05-24 (multimaze2 consumer incident — concrete cost realised):
+      multimaze2 (portrait tilt game) shipped landscape on iPad because its hand-rolled `ios/Info.plist` listed all four orientations from its first commit, while `main.cpp` correctly set `SessionHostConfig.orientation = kOrientationPortrait`. Knob 2 (swizzle, already in libge) armed and dutifully froze the LAUNCH orientation — which on an iPad held in landscape is landscape. Fix was purely consumer-side: narrow the plist to Portrait. But the failure was silent: nothing in ge flagged that the app requested Portrait while the live/allowed orientation was landscape. This is exactly the integration cost T36 predicted.
+
+      Two takeaways that raise this target's value:
+      - Strong argument for **option 2**: had `kOrientationPortrait` been authoritative (engine narrows supportedInterfaceOrientations to portrait regardless of plist), multimaze2 would have been correct out of the box with zero plist edits — which is precisely the "never fight this again" outcome consumers want.
+      - Cheap interim safeguard worth adding regardless of option 1/2: a **loud startup warning** when `SessionHostConfig.orientation` is non-zero and disagrees with the actual launch orientation / the plist's allowed set. A one-line log ("requested Portrait but launched Landscape; narrow UISupportedInterfaceOrientations") would have turned a multi-step device debugging session into a glance at the console.
+
+      Related: the CMake configure-time copy of Info.plist (consumer builds via add_subdirectory(ge); editing the source plist requires re-running cmake, not just rebuilding) is an adjacent footgun — see 🎯T35 (single CMake build path) and 🎯T30 (single integration path).
     origin: filed-during-v0.4.0-prep — surfaced when user asked 'do we allow setting any landscape or a specific landscape or both?' and the honest answer was 'the API suggests per-orientation control but the implementation treats the field as a boolean'
     discovered: 2026-05-02
   T37:

--- a/include/ge/Protocol.h
+++ b/include/ge/Protocol.h
@@ -78,27 +78,32 @@ constexpr uint8_t kSensorAccelerometer = 1;
 
 // Orientation constants — assigned from SDL_DisplayOrientation.
 //
-// CAVEAT (v0.3.0): playerForceOrientation() treats this field as a
-// boolean — any non-zero value enables the iPad orientation lock; the
-// SPECIFIC constant is not honored at runtime. The orientation that
-// gets locked is whichever one iOS picked at launch, constrained by
-// the app bundle's UISupportedInterfaceOrientations in Info.plist.
+// As of v0.31.0 (🎯T36) these constants are authoritative — passing
+// e.g. `kOrientationPortrait` makes the engine narrow
+// `supportedInterfaceOrientations` to portrait at runtime, so iOS
+// will rotate the UI to portrait at launch even if the device is held
+// in landscape and the plist allows all four orientations. The plist's
+// `UISupportedInterfaceOrientations` becomes the fallback (used when
+// the consumer hasn't requested a specific lock), not the gate.
 //
-// To force a specific orientation, narrow the plist:
-//   * "any landscape"   → LandscapeLeft + LandscapeRight
-//   * "LandscapeLeft only" → LandscapeLeft
-//   * "portrait only"   → Portrait + PortraitUpsideDown (or just Portrait)
+// On iPadOS 26+ the swizzled `prefersInterfaceOrientationLocked`
+// (Apple TN3192) freezes the post-launch orientation against the
+// multitasking swivel gesture — same mechanism as before, the
+// difference is the SPECIFIC orientation now matches what the
+// consumer asked for.
 //
-// Setting kOrientationLandscape vs kOrientationLandscapeFlipped today
-// is a no-op difference; both are simply "non-zero, lock please."
-//
-// 🎯T36 tracks aligning the API with its behavior (either collapse to
-// a boolean field, or make these constants authoritative by having the
-// engine narrow supportedInterfaceOrientations at runtime).
+// "Either landscape, lock at launch" (the tilt-game case where the
+// player flips the device freely) is `kOrientationAnyLandscape`.
+// Use it when accelerometer-driven gameplay needs the launch
+// orientation to win regardless of left/right.
 constexpr uint8_t kOrientationLandscape        = SDL_ORIENTATION_LANDSCAPE;
 constexpr uint8_t kOrientationLandscapeFlipped = SDL_ORIENTATION_LANDSCAPE_FLIPPED;
 constexpr uint8_t kOrientationPortrait         = SDL_ORIENTATION_PORTRAIT;
 constexpr uint8_t kOrientationPortraitFlipped  = SDL_ORIENTATION_PORTRAIT_FLIPPED;
+// "Lock at launch to whichever landscape the device is in; reject
+// mid-play rotations." Distinct from the specific constants above,
+// which force one specific landscape.
+constexpr uint8_t kOrientationAnyLandscape     = 0xFE;
 
 // Header for binary wire messages.
 struct MessageHeader {

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
         .headless = brokered,
         .appName = "tiltbuggy",
         .sensors = wire::kSensorAccelerometer,
-        .orientation = wire::kOrientationLandscape,
+        .orientation = wire::kOrientationAnyLandscape,
         .disableScreenSaver = true,
         .immersive = true,
     });

--- a/tools/player_orientation_ios.mm
+++ b/tools/player_orientation_ios.mm
@@ -1,54 +1,68 @@
 // Copyright 2026 Marcelo Cantos
 // SPDX-License-Identifier: Apache-2.0
 //
-// iOS orientation lock via prefersInterfaceOrientationLocked (iPadOS 26+).
-// This is Apple's official replacement for UIRequiresFullScreen (TN3192).
-// We swizzle UIViewController to override the property because SDL's
-// view controller doesn't know about our SessionConfig.
+// iOS orientation lock (🎯T36). Two swizzles on UIViewController:
 //
-// HOW THE LOCK ACTUALLY WORKS — read this before "simplifying" anything.
+//   1. `prefersInterfaceOrientationLocked` (Apple TN3192, iPadOS 26+)
+//      returns YES once a lock has been requested. This freezes the
+//      post-launch orientation against the iPadOS multitasking
+//      swivel gesture.
+//   2. `supportedInterfaceOrientations` is narrowed to the consumer's
+//      requested orientation when a lock is active. iOS rotates the
+//      UI at launch to a supported orientation, so the swizzle here
+//      effectively forces the specific orientation regardless of how
+//      the device was held when launching.
 //
-// The swizzle below alone CANNOT force a specific orientation. All it can do
-// is freeze the current orientation against the user's swivel gesture, and
-// the orientation it freezes to is bounded by supportedInterfaceOrientations
-// (which on iPad UIKit derives from Info.plist UISupportedInterfaceOrientations).
-//
-// To get "always landscape, ignore device orientation at launch", you need
-// BOTH pieces:
-//   1. Narrow UISupportedInterfaceOrientations in Info.plist to just the
-//      orientations you want. UIKit rotates the UI to a supported orientation
-//      at launch if the device is held in an unsupported one. (iPad
-//      multitasking ignores this list as a runtime restriction — the user
-//      can still resize the window — but the launch rotation still happens
-//      and the swizzle's lock is bounded by it.)
-//   2. The swizzle below, which overrides
-//      UIViewController.prefersInterfaceOrientationLocked (Apple TN3192,
-//      iPadOS 26+) to return YES, locking the post-launch orientation
-//      against swivel.
+// The plist's `UISupportedInterfaceOrientations` becomes the fallback
+// (consulted when no runtime lock is set) rather than the gate.
+// Consumers can leave the plist permissive (all four orientations)
+// and let `SessionConfig.orientation` decide at runtime.
 //
 // Things that DON'T work and should not be re-tried:
 //   * UIRequiresFullScreen                         — deprecated, ignored on iPad.
 //   * SDL_HINT_ORIENTATIONS                        — limits the supported set
 //                                                    only; no runtime force.
-//   * UIWindowScene requestGeometryUpdate          — silently no-ops on iPad.
+//   * UIWindowScene requestGeometryUpdate alone    — silently no-ops on iPad.
 //   * setNeedsUpdateOfSupportedInterfaceOrientations alone — only flips
 //                                                    UIKit's view of the
 //                                                    supported set; doesn't
 //                                                    create a lock.
-// History: e0da016 reverted the "plist alone" experiment; 5c2f2a5 added
-// this swizzle. Both commits are needed context if you're touching this.
 //
-// Direct-render apps (DirectRenderHost) call playerForceOrientation from
-// DirectRenderHost::send when SessionConfig.orientation is non-zero.
+// History:
+//   * e0da016 reverted the "plist alone" experiment.
+//   * 5c2f2a5 added the prefersInterfaceOrientationLocked swizzle (boolean-mode lock).
+//   * v0.31.0 (🎯T36) added the supportedInterfaceOrientations swizzle so
+//     the specific constant is honored.
 
 #include "player_orientation.h"
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #include <SDL3/SDL_video.h>
+#include <spdlog/spdlog.h>
 
-// Global flag — set by playerForceOrientation, read by the swizzled property.
-static BOOL g_orientationLocked = NO;
+// Sentinel matching ge::wire::kOrientationAnyLandscape (Protocol.h).
+// Kept in sync by inspection — Protocol.h's constant is exported as
+// uint8_t; both files have a comment pointing at the other.
+static constexpr uint8_t kLockAnyLandscape = 0xFE;
+
+// 0 = unlocked. Non-zero = the SDL_ORIENTATION_* (or sentinel) value
+// the consumer requested. Read by both swizzles.
+static uint8_t g_lockedOrientation = 0;
+
+// Map a requested lock value to the iOS interface-orientation mask.
+static UIInterfaceOrientationMask geLockMask(uint8_t lock) {
+    switch (lock) {
+        case SDL_ORIENTATION_PORTRAIT:          return UIInterfaceOrientationMaskPortrait;
+        case SDL_ORIENTATION_PORTRAIT_FLIPPED:  return UIInterfaceOrientationMaskPortraitUpsideDown;
+        // SDL's "Landscape" is the device tilted left (UIDeviceOrientationLandscapeLeft),
+        // which iOS surfaces to UIKit as UIInterfaceOrientationLandscapeRight.
+        case SDL_ORIENTATION_LANDSCAPE:         return UIInterfaceOrientationMaskLandscapeRight;
+        case SDL_ORIENTATION_LANDSCAPE_FLIPPED: return UIInterfaceOrientationMaskLandscapeLeft;
+        case kLockAnyLandscape:                 return UIInterfaceOrientationMaskLandscape;
+        default:                                return UIInterfaceOrientationMaskAll;
+    }
+}
 
 @interface UIViewController (GeOrientationLock)
 @end
@@ -56,14 +70,36 @@ static BOOL g_orientationLocked = NO;
 @implementation UIViewController (GeOrientationLock)
 
 + (void)load {
-    // Swizzle prefersInterfaceOrientationLocked if it exists (iPadOS 26+).
-    SEL sel = @selector(prefersInterfaceOrientationLocked);
-    Method orig = class_getInstanceMethod([UIViewController class], sel);
-    if (!orig) return;
-    IMP newImp = imp_implementationWithBlock(^BOOL(id self) {
-        return g_orientationLocked;
-    });
-    method_setImplementation(orig, newImp);
+    // Swizzle 1 — prefersInterfaceOrientationLocked (iPadOS 26+).
+    {
+        SEL sel = @selector(prefersInterfaceOrientationLocked);
+        Method orig = class_getInstanceMethod([UIViewController class], sel);
+        if (orig) {
+            IMP newImp = imp_implementationWithBlock(^BOOL(id self) {
+                return g_lockedOrientation != 0;
+            });
+            method_setImplementation(orig, newImp);
+        }
+    }
+
+    // Swizzle 2 — supportedInterfaceOrientations. When locked, narrow
+    // to the requested mask so iOS rotates the UI to it at launch.
+    // When unlocked, fall through to the original (plist-derived) mask.
+    {
+        SEL sel = @selector(supportedInterfaceOrientations);
+        Method orig = class_getInstanceMethod([UIViewController class], sel);
+        if (orig) {
+            IMP originalImp = method_getImplementation(orig);
+            IMP newImp = imp_implementationWithBlock(^UIInterfaceOrientationMask(id self) {
+                if (g_lockedOrientation == 0) {
+                    using OrigFn = UIInterfaceOrientationMask (*)(id, SEL);
+                    return ((OrigFn)originalImp)(self, sel);
+                }
+                return geLockMask(g_lockedOrientation);
+            });
+            method_setImplementation(orig, newImp);
+        }
+    }
 }
 
 @end
@@ -87,33 +123,68 @@ int playerGetPhysicalOrientation() {
     }
 }
 
+// Best-effort name for the diagnostic log.
+static const char* geLockName(uint8_t lock) {
+    switch (lock) {
+        case SDL_ORIENTATION_PORTRAIT:          return "Portrait";
+        case SDL_ORIENTATION_PORTRAIT_FLIPPED:  return "PortraitFlipped";
+        case SDL_ORIENTATION_LANDSCAPE:         return "Landscape (LandscapeRight)";
+        case SDL_ORIENTATION_LANDSCAPE_FLIPPED: return "LandscapeFlipped (LandscapeLeft)";
+        case kLockAnyLandscape:                 return "AnyLandscape";
+        default:                                return "Unknown";
+    }
+}
+
 void playerForceOrientation(uint8_t orientation) {
     if (orientation == 0) return;
 
-    // Start generating device orientation notifications early so that
-    // UIDevice.current.orientation is populated by the time the first
-    // keyboard tilt event arrives.
     if (!g_deviceOrientationActive) {
         [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
         g_deviceOrientationActive = true;
     }
 
-    g_orientationLocked = YES;
+    g_lockedOrientation = orientation;
+
+    UIInterfaceOrientationMask requested = geLockMask(orientation);
+    SPDLOG_INFO("playerForceOrientation: lock {} (mask=0x{:x})", geLockName(orientation), (unsigned)requested);
+
+    // Cross-check against the plist's UISupportedInterfaceOrientations. If
+    // none of the requested orientations are in the plist's allowed set,
+    // iOS won't be able to honor the lock during launch — a loud log
+    // saves the multimaze2-style debugging session.
+    NSArray<NSString*>* plistOrientations =
+        [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UISupportedInterfaceOrientations"];
+    if (plistOrientations) {
+        UIInterfaceOrientationMask plistMask = 0;
+        for (NSString* o in plistOrientations) {
+            if ([o isEqualToString:@"UIInterfaceOrientationPortrait"])           plistMask |= UIInterfaceOrientationMaskPortrait;
+            else if ([o isEqualToString:@"UIInterfaceOrientationPortraitUpsideDown"]) plistMask |= UIInterfaceOrientationMaskPortraitUpsideDown;
+            else if ([o isEqualToString:@"UIInterfaceOrientationLandscapeLeft"]) plistMask |= UIInterfaceOrientationMaskLandscapeLeft;
+            else if ([o isEqualToString:@"UIInterfaceOrientationLandscapeRight"]) plistMask |= UIInterfaceOrientationMaskLandscapeRight;
+        }
+        if ((plistMask & requested) == 0) {
+            SPDLOG_WARN(
+                "Info.plist UISupportedInterfaceOrientations (0x{:x}) does not include "
+                "requested orientation {} (0x{:x}). The swizzle overrides this at runtime, "
+                "but narrowing the plist matches engine intent and avoids brief launch flicker.",
+                (unsigned)plistMask, geLockName(orientation), (unsigned)requested);
+        }
+    }
 
     for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
         if (![s isKindOfClass:[UIWindowScene class]]) continue;
         UIWindowScene *scene = (UIWindowScene *)s;
         for (UIWindow *w in scene.windows) {
             UIViewController *vc = w.rootViewController;
-            SEL updateSel =
-                @selector(setNeedsUpdateOfPrefersInterfaceOrientationLocked);
+            // Refresh both the lock state and the supported-orientations
+            // set so iOS re-evaluates and rotates the UI if needed.
+            [vc setNeedsUpdateOfSupportedInterfaceOrientations];
+            SEL updateSel = @selector(setNeedsUpdateOfPrefersInterfaceOrientationLocked);
             if ([vc respondsToSelector:updateSel]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
                 [vc performSelector:updateSel];
 #pragma clang diagnostic pop
-            } else {
-                [vc setNeedsUpdateOfSupportedInterfaceOrientations];
             }
         }
     }


### PR DESCRIPTION
## Summary

`SessionConfig.orientation` now honors the specific `kOrientation*` constant — passing `kOrientationPortrait` makes the engine narrow `supportedInterfaceOrientations` to portrait at runtime, so iOS rotates the UI to portrait at launch even if the device is held landscape and the plist allows all four orientations. Implements option 2 from T36's design discussion, prompted by multimaze2's 2026-05-24 incident.

## Mapping

| Constant | iOS effect |
|---|---|
| `kOrientationPortrait` | Portrait |
| `kOrientationPortraitFlipped` | PortraitUpsideDown |
| `kOrientationLandscape` | LandscapeRight |
| `kOrientationLandscapeFlipped` | LandscapeLeft |
| **`kOrientationAnyLandscape`** (new) | Either landscape, lock after launch — for tilt games |

## Behaviour change

- TiltBuggy switches from `kOrientationLandscape` to `kOrientationAnyLandscape`. Previously the boolean-interpretation lock allowed either landscape at launch; the specific `kOrientationLandscape` constant would now lock to one landscape only, which would feel wrong for a tilt game where the player flips the device. `kOrientationAnyLandscape` preserves the launch-pose behaviour.
- Loud `SPDLOG_WARN` if the engine-requested orientation isn't in the plist's `UISupportedInterfaceOrientations`. Swizzle still overrides the plist at runtime, but the mismatch causes brief launch flicker that's worth surfacing.

## Verified

- macOS desktop: 145 doctest cases pass.
- iOS device build clean for iphoneos arm64.
- Deployed to Jevons. Runtime visual verification (does iPad rotate to landscape when held portrait at launch?) is consumer-side acceptance.

## Test plan

- [ ] Hold an iPad portrait, launch tiltbuggy → UI should rotate to landscape (LandscapeRight or LandscapeLeft, whichever iOS picks once it sees `MaskLandscape`).
- [ ] Hold an iPad landscape, launch → no rotation, stays in that landscape.
- [ ] Try iPadOS swivel gesture during play → orientation stays locked.
