### PR TITLE
ship: forward APP_ID through preflight + ship-* rules (🎯T64.2 followup #2)

### DIFF
--- a/Module.mk
+++ b/Module.mk
@@ -1194,6 +1194,7 @@ ge/SHIP_PATH = /usr/bin:/bin:/usr/sbin:/sbin:$(PATH)
 .PHONY: ship-preflight
 ship-preflight:
 	SHIP_SCHEME=$(SHIP_SCHEME) \
+	APP_ID=$(APP_ID) \
 	    $(ge)/tools/ship/preflight.sh \
 	    --lane $(if $(LANE),$(LANE),alpha) \
 	    $(if $(VERSION),--version $(VERSION),)
@@ -1215,6 +1216,7 @@ ship-worktree:
 ship-alpha:
 	PATH=$(ge/SHIP_PATH) \
 	SHIP_SCHEME=$(SHIP_SCHEME) \
+	APP_ID=$(APP_ID) \
 	    $(ge)/tools/ship/release.sh --lane alpha
 
 # ── ship-beta ──────────────────────────────────────────────────────────────
@@ -1227,6 +1229,7 @@ ship-beta:
 	    echo "Usage: make ship-beta VERSION=0.31.0"; exit 1; fi
 	PATH=$(ge/SHIP_PATH) \
 	SHIP_SCHEME=$(SHIP_SCHEME) \
+	APP_ID=$(APP_ID) \
 	    $(ge)/tools/ship/release.sh --lane beta --version $(VERSION)
 
 # ── ship-release ───────────────────────────────────────────────────────────
@@ -1243,6 +1246,7 @@ ship-release:
 	    echo "  make ship-release VERSION=$(VERSION) CONFIRM=1"; exit 1; fi
 	PATH=$(ge/SHIP_PATH) \
 	SHIP_SCHEME=$(SHIP_SCHEME) \
+	APP_ID=$(APP_ID) \
 	    $(ge)/tools/ship/release.sh --lane release --version $(VERSION) --confirm
 
 # ── ship-clean ─────────────────────────────────────────────────────────────

--- a/tools/ship/preflight.sh
+++ b/tools/ship/preflight.sh
@@ -92,6 +92,7 @@ required_vars=(
     APP_STORE_CONNECT_API_KEY_KEY_PATH
     MATCH_PASSWORD
     SHIP_SCHEME
+    APP_ID
 )
 for var in "${required_vars[@]}"; do
     if [ -z "${!var:-}" ]; then
@@ -144,11 +145,16 @@ else
   "in_house": false
 }
 JSON
+    # `match` needs --app_identifier to know what cert to verify; without
+    # it, the readonly check fails silently against an empty Appfile.
+    # Consuming game's Makefile exports APP_ID (e.g. com.squz.multimaze)
+    # before invoking ship-preflight; we just forward it.
     if ! (cd "${REPO_ROOT}" && bundle exec fastlane match appstore --readonly \
+          --app_identifier "${APP_ID}" \
           --api_key_path "${api_key_json}" 2>&1); then
-        fail "fastlane match appstore --readonly failed — run 'bundle exec fastlane sync_certs --api_key_path \"${api_key_json}\"' to diagnose"
+        fail "fastlane match appstore --readonly --app_identifier ${APP_ID} failed — run 'bundle exec fastlane sync_certs --app_identifier ${APP_ID} --api_key_path \"${api_key_json}\"' to diagnose"
     else
-        echo "  [PASS] fastlane match --readonly succeeded"
+        echo "  [PASS] fastlane match --readonly succeeded for ${APP_ID}"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Second preflight bug from the multimaze2 v3.0 ship run: \`match --readonly\` failed because no \`--app_identifier\` was passed; match doesn't know what cert to verify without it.

## Fix

- \`tools/ship/preflight.sh\` requires \`APP_ID\` env var; passes it as \`--app_identifier\` to \`match --readonly\`. Updates the diagnostic-repro hint in the failure message to include the new flag.
- \`Module.mk\` ship-preflight / ship-alpha / ship-beta / ship-release rules forward \`APP_ID\` (from the consuming game's Makefile, e.g. \`APP_ID := com.squz.multimaze\`) alongside the existing \`SHIP_SCHEME\` and \`PATH\`.

## Test plan

- [x] \`bash -n tools/ship/preflight.sh\` clean
- [ ] \`make ship-preflight\` from multimaze2 worktree with all env vars → READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)