### PR TITLE
ship/preflight: REPO_ROOT = superproject when consumed as submodule (🎯T64.2 followup #3)

### DIFF
--- a/tools/ship/preflight.sh
+++ b/tools/ship/preflight.sh
@@ -22,7 +22,17 @@
 
 set -uo pipefail
 
-REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+# REPO_ROOT must resolve to the CONSUMING project's root (where the
+# game's Gemfile, Matchfile, and ios/CMakeLists.txt live), not to ge's
+# own root (which is the submodule). When ge is consumed as a submodule
+# (the normal case), `git rev-parse --show-superproject-working-tree`
+# returns the parent project's working tree. When ge is run from its
+# own repo (e.g. for testing the ship scripts standalone), that command
+# returns empty and we fall back to ge's own toplevel.
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-superproject-working-tree 2>/dev/null)"
+if [ -z "${REPO_ROOT}" ]; then
+    REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+fi
 
 lane="${SHIP_LANE:-alpha}"
 version="${SHIP_VERSION:-}"


### PR DESCRIPTION
## Summary

Third preflight bug from multimaze2 v3.0 ship run: \`REPO_ROOT\` resolved to ge's own root (the submodule), not the consuming project's root.

Symptoms before fix:
- \`bundle exec fastlane\` ran in \`ge/\` directory where there's no Gemfile (consumer's Gemfile is at parent root) → match readonly failed
- working-tree check inspected ge submodule instead of consumer's tree

## Fix

Use \`git rev-parse --show-superproject-working-tree\` first (returns parent working tree when inside a submodule, empty otherwise), fall back to \`--show-toplevel\` for standalone-ge case.

## Test plan

- [x] \`bash -n\` clean
- [ ] \`make ship-preflight\` from multimaze2 worktree → READY (assuming submodule pointer is current)
- [ ] Running preflight.sh standalone from ge's own checkout still works (REPO_ROOT = ge root via fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)