### PR TITLE
ship: source-vs-execute guards + superproject REPO_ROOT across all scripts (🎯T64.2 followup #5)

### DIFF
--- a/tools/ship/build.sh
+++ b/tools/ship/build.sh
@@ -22,7 +22,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+# REPO_ROOT = consuming project root when ge is a submodule, else ge's own root.
+# See preflight.sh for the rationale.
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-superproject-working-tree 2>/dev/null)"
+if [ -z "${REPO_ROOT}" ]; then
+    REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+fi
 
 # Source helpers (idempotent — functions defined, no side effects).
 # shellcheck source=tools/ship/worktree.sh

--- a/tools/ship/manifest.sh
+++ b/tools/ship/manifest.sh
@@ -17,7 +17,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+# REPO_ROOT = consuming project root when ge is a submodule, else ge's own root.
+# See preflight.sh for the rationale.
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-superproject-working-tree 2>/dev/null)"
+if [ -z "${REPO_ROOT}" ]; then
+    REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+fi
 SHIP_BUILD_DIR="${REPO_ROOT}/build/ship"
 
 # ---------------------------------------------------------------------------
@@ -143,26 +148,28 @@ ship_manifest_embed_android() {
 # ---------------------------------------------------------------------------
 # Standalone mode
 # ---------------------------------------------------------------------------
-case "${1:-}" in
-    --write)
-        tag="${2:?Usage: manifest.sh --write TAG LANE [WORKTREE_DIR]}"
-        lane="${3:?Usage: manifest.sh --write TAG LANE [WORKTREE_DIR]}"
-        worktree="${4:-}"
-        ship_manifest_write "${tag}" "${lane}" "${worktree}"
-        ;;
-    --embed-ios)
-        ship_manifest_embed_ios "${2:?}" "${3:?}"
-        ;;
-    --embed-android)
-        ship_manifest_embed_android "${2:?}" "${3:?}"
-        ;;
-    "")
-        # Sourced — do nothing.
-        ;;
-    *)
-        echo "Usage: manifest.sh --write TAG LANE [WORKTREE_DIR]" >&2
-        echo "       manifest.sh --embed-ios WORKTREE_DIR MANIFEST_PATH" >&2
-        echo "       manifest.sh --embed-android WORKTREE_DIR MANIFEST_PATH" >&2
-        exit 1
-        ;;
-esac
+# Guard: only run when EXECUTED directly, not when SOURCED from
+# release.sh / build.sh. Same fix as worktree.sh — without this, `$1`
+# inherits the caller's argv and trips the unknown-arg path.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    case "${1:-}" in
+        --write)
+            tag="${2:?Usage: manifest.sh --write TAG LANE [WORKTREE_DIR]}"
+            lane="${3:?Usage: manifest.sh --write TAG LANE [WORKTREE_DIR]}"
+            worktree="${4:-}"
+            ship_manifest_write "${tag}" "${lane}" "${worktree}"
+            ;;
+        --embed-ios)
+            ship_manifest_embed_ios "${2:?}" "${3:?}"
+            ;;
+        --embed-android)
+            ship_manifest_embed_android "${2:?}" "${3:?}"
+            ;;
+        *)
+            echo "Usage: manifest.sh --write TAG LANE [WORKTREE_DIR]" >&2
+            echo "       manifest.sh --embed-ios WORKTREE_DIR MANIFEST_PATH" >&2
+            echo "       manifest.sh --embed-android WORKTREE_DIR MANIFEST_PATH" >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/tools/ship/release.sh
+++ b/tools/ship/release.sh
@@ -25,7 +25,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+# REPO_ROOT = consuming project root when ge is a submodule, else ge's own root.
+# See preflight.sh for the rationale.
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-superproject-working-tree 2>/dev/null)"
+if [ -z "${REPO_ROOT}" ]; then
+    REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+fi
 
 source "${SCRIPT_DIR}/worktree.sh"
 source "${SCRIPT_DIR}/manifest.sh"

--- a/tools/ship/worktree.sh
+++ b/tools/ship/worktree.sh
@@ -21,7 +21,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+# REPO_ROOT = consuming project root when ge is a submodule, else ge's own root.
+# See preflight.sh for the rationale.
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-superproject-working-tree 2>/dev/null)"
+if [ -z "${REPO_ROOT}" ]; then
+    REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+fi
 SHIP_BUILD_DIR="${REPO_ROOT}/build/ship"
 
 # ---------------------------------------------------------------------------
@@ -148,23 +153,25 @@ ship_worktree_clean() {
 # ---------------------------------------------------------------------------
 # Standalone mode
 # ---------------------------------------------------------------------------
-case "${1:-}" in
-    --create)
-        ship_worktree_create "${2:?Usage: worktree.sh --create TAG}"
-        echo "SHIP_WORKTREE_DIR=${SHIP_WORKTREE_DIR}"
-        ;;
-    --remove)
-        ship_worktree_remove "${2:-}"
-        ;;
-    --clean)
-        shift
-        ship_worktree_clean "$@"
-        ;;
-    "")
-        # Sourced — do nothing.
-        ;;
-    *)
-        echo "Usage: worktree.sh --create TAG | --remove [TAG] | --clean [--max-age-days N]" >&2
-        exit 1
-        ;;
-esac
+# Guard so this only runs when EXECUTED directly, not when SOURCED from
+# release.sh. Without the guard, `$1` here inherits the parent script's
+# argv (e.g. "--lane") and trips the unknown-arg path.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    case "${1:-}" in
+        --create)
+            ship_worktree_create "${2:?Usage: worktree.sh --create TAG}"
+            echo "SHIP_WORKTREE_DIR=${SHIP_WORKTREE_DIR}"
+            ;;
+        --remove)
+            ship_worktree_remove "${2:-}"
+            ;;
+        --clean)
+            shift
+            ship_worktree_clean "$@"
+            ;;
+        *)
+            echo "Usage: worktree.sh --create TAG | --remove [TAG] | --clean [--max-age-days N]" >&2
+            exit 1
+            ;;
+    esac
+fi


### PR DESCRIPTION
Cluster fix for two related bugs in release/build/worktree/manifest scripts:

1. **source-vs-execute leakage** — worktree.sh + manifest.sh ran their CLI `case "${1:-}"` block at top level when sourced from release.sh, inheriting the parent's `$1` and tripping the unknown-arg path. Guarded with `if [ "${BASH_SOURCE[0]}" = "${0}" ]`.

2. **REPO_ROOT computation** — all 4 scripts used `--show-toplevel` which resolves to ge's own root when consumed as a submodule. Switched to superproject-first pattern (same fix as preflight.sh in ge#90).

## Test plan
- [x] bash -n clean on all 4
- [ ] `make ship-alpha` from multimaze2 worktree → reaches fastlane build_ipa step