### PR TITLE
ship/release: don't override Homebrew PATH with system paths (🎯T64.2 followup #7)

### DIFF
--- a/tools/ship/release.sh
+++ b/tools/ship/release.sh
@@ -146,7 +146,7 @@ if [ "${lane}" = "alpha" ]; then
     echo "ship/release: building IPA..."
     (
         cd "${REPO_ROOT}"
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}" \
+        PATH="${PATH}:/usr/bin:/bin:/usr/sbin:/sbin" \
         SHIP_OUTPUT_DIR="${ipa_dir}" \
         bundle exec fastlane build_ipa \
             scheme:"${SHIP_SCHEME}" \
@@ -200,7 +200,7 @@ if [ "${lane}" = "beta" ]; then
 
     (
         cd "${REPO_ROOT}"
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}" \
+        PATH="${PATH}:/usr/bin:/bin:/usr/sbin:/sbin" \
         SHIP_OUTPUT_DIR="${ipa_dir}" \
         bundle exec fastlane build_ipa \
             scheme:"${SHIP_SCHEME}" \
@@ -269,7 +269,7 @@ if [ "${lane}" = "release" ]; then
 
     (
         cd "${REPO_ROOT}"
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}" \
+        PATH="${PATH}:/usr/bin:/bin:/usr/sbin:/sbin" \
         SHIP_OUTPUT_DIR="${ipa_dir}" \
         bundle exec fastlane build_ipa \
             scheme:"${SHIP_SCHEME}" \


### PR DESCRIPTION
Flip PATH prepend → append so Homebrew Ruby wins over system 2.6. Fixes `Could not find 'bundler' (4.0.11)` error during `make ship-alpha` on this laptop.