### PR TITLE
CMakeLists: add audio + RefreshRateBoost_apple sources missing from iOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ set(GE_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sdl_input.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/iap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/log.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/audio.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlift.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/src/sqlpipe.cpp
 )
@@ -196,6 +197,8 @@ if(APPLE)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/CutoutInsets_stub.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/iap_apple.mm
         ${CMAKE_CURRENT_SOURCE_DIR}/src/log_apple.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/audio_apple.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/render/RefreshRateBoost_apple.mm
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Attitude_apple.mm)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND GE_CORE_SOURCES


### PR DESCRIPTION
## Summary

- Adds `src/audio.cpp` to platform-neutral `GE_CORE_SOURCES`.
- Adds `src/audio_apple.mm` and `src/render/RefreshRateBoost_apple.mm` to the `if(APPLE)` branch.

`ge/Module.mk` (make build) picks these up unconditionally / on Apple, but `ge/CMakeLists.txt` (iOS Xcode build) never gained them after the T7/T43/T63 work landed. As a result `libge.a` built for iOS was missing:

- `ge::audio::installAppleAudioObservers`, `removeAppleAudioObservers`
- `ge::audio::onBackground`, `onForeground`
- `ge::RefreshRateBoost::*` (ctor, dtor, engagePress, releasePress, drainPresses)

Consumers linking ge for iOS (e.g. multimaze2) hit undefined-symbol errors at archive time. Confirmed locally — after this fix, `xcodebuild -project ios/build/xcode/MultiMaze.xcodeproj -scheme MultiMaze ... build` reports `** BUILD SUCCEEDED **`.

## Scope

iOS-only; the Apple branch is where the gap was. Android has a `RefreshRateBoost_android.cpp` that also isn't listed in the CMake Android branch — same pattern, but out of scope here. Will track separately if it becomes blocking.

## Test plan

- [x] iOS archive links cleanly against the patched libge.a (verified in /tmp/multimaze2-ship)
- [ ] CI: macOS unit tests still pass
- [ ] CI: iOS smoke build green

Refs 🎯T69 ship-prep.