### PR TITLE
fastlane: force App Store cert + Xcode 16 export method (🎯T69 ship-prep)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,6 +17,7 @@
 #
 # Env vars expected (consuming game's Makefile / shell profile sets):
 #   APP_ID                                  com.squz.<game>
+#   APPLE_TEAM_ID                           10-char Apple developer team ID
 #   APP_STORE_CONNECT_API_KEY_KEY_ID        ASC API key ID
 #   APP_STORE_CONNECT_API_KEY_ISSUER_ID     ASC issuer UUID
 #   APP_STORE_CONNECT_API_KEY_KEY_PATH      Path to AuthKey_<KEYID>.p8
@@ -70,16 +71,42 @@ platform :ios do
 
   desc "Build the IPA via gym, using the resolved match certs."
   lane :build_ipa do |opts|
+    type = opts[:type] || "appstore"
+    app_identifier = opts[:app_identifier] || ENV.fetch("APP_ID")
     sync_certs(
-      type:           opts[:type] || "appstore",
-      app_identifier: opts[:app_identifier] || ENV.fetch("APP_ID"),
+      type:           type,
+      app_identifier: app_identifier,
     )
+    # Force the archive to use the match-installed App Store cert + profile.
+    # CMakeLists sets CODE_SIGN_STYLE = Automatic, which makes Xcode pick the
+    # "Apple Development" identity for archive — wrong for App Store. We
+    # override via xcargs to force Manual + the match profile. APPLE_TEAM_ID
+    # must be set in the consumer's env (no fallback — wrong team ID silently
+    # signing the wrong way is worse than a hard error).
+    team_id = ENV.fetch("APPLE_TEAM_ID")
+    profile_name = "match AppStore #{app_identifier}"
+    # Xcode 16 deprecated "app-store" → "app-store-connect". gym 2.234.0
+    # still passes the old value by default, so we set it explicitly here
+    # and in export_options.
     gym(
-      project:          opts[:project]       || ENV.fetch("SHIP_PROJECT"),
-      scheme:           opts[:scheme]        || ENV.fetch("SHIP_SCHEME"),
-      configuration:    opts[:configuration] || "Release",
-      export_method:    opts[:export_method] || "app-store",
-      output_directory: opts[:output_dir]    || ENV.fetch("SHIP_OUTPUT_DIR"),
+      project:              opts[:project]       || ENV.fetch("SHIP_PROJECT"),
+      scheme:               opts[:scheme]        || ENV.fetch("SHIP_SCHEME"),
+      configuration:        opts[:configuration] || "Release",
+      export_method:        opts[:export_method] || "app-store-connect",
+      output_directory:     opts[:output_dir]    || ENV.fetch("SHIP_OUTPUT_DIR"),
+      codesigning_identity: "Apple Distribution",
+      xcargs: [
+        "CODE_SIGN_STYLE=Manual",
+        "DEVELOPMENT_TEAM=#{team_id}",
+        "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
+        "CODE_SIGN_IDENTITY='Apple Distribution'",
+      ].join(" "),
+      export_options: {
+        method:                "app-store-connect",
+        signingStyle:          "manual",
+        teamID:                team_id,
+        provisioningProfiles:  { app_identifier => profile_name },
+      },
     )
   end
 

--- a/tools/ship/preflight.sh
+++ b/tools/ship/preflight.sh
@@ -107,6 +107,7 @@ required_vars=(
     MATCH_PASSWORD
     SHIP_SCHEME
     APP_ID
+    APPLE_TEAM_ID
 )
 for var in "${required_vars[@]}"; do
     if [ -z "${!var:-}" ]; then


### PR DESCRIPTION
## Summary

Two layered ship-alpha failures fixed:

1. **Archive signed with dev cert, not App Store.** CMakeLists sets `CODE_SIGN_STYLE = Automatic`, so Xcode picked \`Apple Development: <user>\` during archive instead of the match-installed \`Apple Distribution\` cert. The exported IPA could not be uploaded to App Store Connect. Override via xcargs to force \`Manual\` signing with the match-installed profile.

2. **Xcode 16 deprecated \`app-store\` export method.** Replaced by \`app-store-connect\`. gym 2.234.0 still passes the old value by default, so the export step fails with \`exportArchive exportOptionsPlist error for key "method" expected one {} but found app-store\`. Explicit override in both \`export_method:\` and \`export_options.method:\`.

New required env var \`APPLE_TEAM_ID\` (10-char Apple developer team ID). No fallback — wrong team silently signing the wrong way is worse than a hard error. Added to preflight required-vars check and to the Fastfile env-var header.

## Test plan

- [x] After landing, multimaze2 \`make ship-alpha\` archives with \`Apple Distribution: Squz Pty Ltd (SWA3H3N7TW)\` and exports as \`app-store-connect\` — verified locally against a /Users/marcelo/work/_ship/multimaze2 worktree.
- [ ] Pilot upload succeeds and the build appears under https://appstoreconnect.apple.com/apps/355300331/testflight/ios/

Refs 🎯T69 ship-prep. Pairs with the about-to-land multimaze2 submodule bump.