### PR TITLE
fastlane: fix gym export_method arg (🎯T69 ship-prep)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -85,14 +85,17 @@ platform :ios do
     # signing the wrong way is worse than a hard error).
     team_id = ENV.fetch("APPLE_TEAM_ID")
     profile_name = "match AppStore #{app_identifier}"
-    # Xcode 16 deprecated "app-store" → "app-store-connect". gym 2.234.0
-    # still passes the old value by default, so we set it explicitly here
-    # and in export_options.
+    # Xcode 16 renamed the exportOptions.plist `method` value from
+    # "app-store" to "app-store-connect". gym 2.234.0's own `export_method`
+    # parameter only validates against the OLD names, so we keep
+    # `export_method: "app-store"` to satisfy gym's validation and override
+    # the actual plist value via `export_options.method: "app-store-connect"`
+    # (export_options wins when both are set).
     gym(
       project:              opts[:project]       || ENV.fetch("SHIP_PROJECT"),
       scheme:               opts[:scheme]        || ENV.fetch("SHIP_SCHEME"),
       configuration:        opts[:configuration] || "Release",
-      export_method:        opts[:export_method] || "app-store-connect",
+      export_method:        opts[:export_method] || "app-store",
       output_directory:     opts[:output_dir]    || ENV.fetch("SHIP_OUTPUT_DIR"),
       codesigning_identity: "Apple Distribution",
       xcargs: [


### PR DESCRIPTION
## Summary

PR #98 set gym's \`export_method:\` to \`\"app-store-connect\"\`, but gym 2.234.0's parameter validation only accepts the OLD names (\`app-store\`, \`validation\`, \`ad-hoc\`, ...) and errors out before reaching xcodebuild. Only the *exportOptions.plist* \`method\` key needs the new Xcode 16 value; gym auto-merges \`export_options\` into the plist, with \`export_options\` winning when both are set.

This fix:

- \`export_method: \"app-store\"\` — satisfies gym validation.
- \`export_options.method: \"app-store-connect\"\` — what xcodebuild actually reads.

## Test plan

- [ ] multimaze2 \`make ship-alpha\` reaches the xcodebuild export step without gym validation barfing.
- [ ] Pilot upload to https://appstoreconnect.apple.com/apps/355300331/testflight/ios/ succeeds.

Refs 🎯T69. Follow-up to #97 + #98.