### PR TITLE
build_project.rb: drop iphonesimulator from SUPPORTED_PLATFORMS

### DIFF
--- a/tools/ios-build/build_project.rb
+++ b/tools/ios-build/build_project.rb
@@ -207,7 +207,12 @@ module GE
           'CURRENT_PROJECT_VERSION' => @build_number,
           'IPHONEOS_DEPLOYMENT_TARGET' => @deployment_target,
           'TARGETED_DEVICE_FAMILY' => @device_family,
-          'SUPPORTED_PLATFORMS' => 'iphoneos iphonesimulator',
+          # Device-only. The simulator path requires a matching simulator
+          # runtime which isn't always installed on CI macOS runners, and
+          # App Store IPAs don't include simulator slices anyway. Local
+          # dev that needs the simulator can override via Xcode UI or
+          # consumer-side `extra_settings` once that surface lands.
+          'SUPPORTED_PLATFORMS' => 'iphoneos',
 
           # Squz signing — Manual + match-installed profile + Apple
           # Distribution: Squz Pty Ltd. See [[squz-cert-policy]].


### PR DESCRIPTION
GHA runner ran into 'No simulator runtime version ... available to use with iphonesimulator SDK' compiling Assets.xcassets. App Store IPAs are device-only anyway. Refs https://github.com/squz/multimaze2/actions/runs/26385822028