### PR TITLE
fastlane: setup_ci for CI keychain (unblocks codesign)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,6 +71,10 @@ platform :ios do
 
   desc "Build the IPA via gym, using the resolved match certs."
   lane :build_ipa do |opts|
+    # On CI: create a temporary keychain so match installs certs there
+    # and codesign can use them without prompting for the OS login
+    # keychain password (which CI runners can't answer). No-op locally.
+    setup_ci if ENV['CI']
     sync_certs(
       type:           opts[:type] || "appstore",
       app_identifier: opts[:app_identifier] || ENV.fetch("APP_ID"),


### PR DESCRIPTION
Run 7 hung 27min on codesign waiting for OS login keychain unlock. setup_ci creates a temp keychain match installs into; codesign reads from it without prompting. Refs https://github.com/squz/multimaze2/actions/runs/26386149124