### PR TITLE
T78: prebuilt verifier two-way submodule + prebuilt checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ MAKEFLAGS += -j$(shell sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || ech
 # Specific targets the delegator should proxy. `check` is the big one:
 # runs the 24-cell e2e matrix via the sample's Module.mk integration.
 .PHONY: all check matrix-test check-list unit-test init clean ged run bullseye ruby-test \
+        python-test \
         prebuild prebuild-ios-arm64 prebuild-ios-arm64-simulator prebuild-android-arm64 \
         ge/lift-headers depgraph clean-depgraph
 
@@ -44,7 +45,7 @@ cell.%:
 # Standing invariants for /cv. Exit 0 means all green; non-zero means a
 # violation. Stdout is relayed verbatim to the agent. Ignores untracked
 # files so the user's WIP notes don't trip the check.
-bullseye: ruby-test
+bullseye: ruby-test python-test
 	@git diff --quiet && git diff --cached --quiet \
 	  && echo "✓ no uncommitted changes to tracked files" \
 	  || { echo "✗ uncommitted changes to tracked files"; \
@@ -60,6 +61,12 @@ bullseye: ruby-test
 # every /cv invocation guards against regressions.
 ruby-test:
 	@bundle exec ruby tools/ios-build/test_build_project.rb
+
+# Python-side regression tests — currently the prebuilt-staleness
+# verifier (🎯T78). Runs in ~1s; wired into `bullseye` for the same
+# reason as ruby-test.
+python-test:
+	@python3 tools/test_verify_prebuilds.py
 
 # ── Prebuilt static libs (🎯T73) ───────────────────────────────────
 #

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2563,6 +2563,56 @@ targets:
     - sdl3
     origin: manual
     discovered: 2026-05-30
+  T76:
+    name: sprite_test/png_test pass against T38 SpriteVertex layout
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - make unit-test on the T38 sokol_gfx branch passes all sprite_test.cpp + png_test.cpp cases
+    - SpriteBatchTestAccess::quads(batch).size() reports the correct number of queued quads after addSprite/clear
+    - vertex-layout assertions (v[i].u/v/abgr/z) match what ge::SpriteBatch::addSprite actually writes into the Quad's verts[6]
+    context: 'Surfaced 2026-05-30 while porting multimaze2 onto PR #113 (squz/ge#113, the bgfx → sokol_gfx migration). multimaze2''s build is clean and bin/multimaze + bin/render_test all green, but make unit-test (which links ge''s TEST_OBJ) reports 9 failures, all in ge/src/sprite_test.cpp + ge/src/png_test.cpp. The vertex-attribute test expectations (line 86, 97-103, 113, 122) and the quads-size accessor (line 51, 61, 131) look like they were written against an earlier SpriteVertex layout (per-component float colour) and weren''t updated when the new packed-abgr layout landed. png_test:133/142''s `isNull()` checks likely fall out of the same SpriteBatchTestAccess infra. Pre-existing in the PR — not introduced by the multimaze2 consumer port (filed via the multimaze2-audit pattern in mm2''s CLAUDE.md).'
+    tags:
+    - multimaze-audit
+    - tests
+    - T38
+    origin: multimaze2-audit
+    discovered: 2026-05-30
+  T77:
+    name: iOS arm64 prebuilt libge.a regenerated against sokol_gfx
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - ge/prebuilt/ios-arm64/libge.a contains zero bgfx symbol references (`nm | grep bgfx | wc -l` == 0)
+    - ge/prebuilt/ios-arm64/manifest.json's submodule_shas no longer lists bkaradzic/bgfx, bkaradzic/bx, bkaradzic/bimg
+    - 'ge/prebuilt/ios-arm64/libbgfx.a, libbx.a, libbimg.a are removed (already removed in PR #113 root tree but the manifest+libge.a refresh wasn''t run)'
+    - Consumer apps' `xcodebuild -destination 'generic/platform=iOS'` link step succeeds against ge's prebuilt bundle
+    context: 'Found 2026-05-30 while porting multimaze2 onto PR #113. PR #113 dropped libbgfx/libbx/libbimg from ge/prebuilt/android-arm64/ and regenerated that manifest, but the iOS-arm64 prebuilt was NOT refreshed — libge.a still contains 53 bgfx symbol references and the manifest still lists the bgfx submodule SHAs. Consumer iOS builds fail at link time with `library ''bgfx'' not found` (the consumer''s xcodeproj still tries `-lbgfx -lbx -lbimg`; even after we patch build_project.rb to drop those, the prebuilt libge.a''s own bgfx references would still bite). Fix: re-run `tools/prebuild.sh` (or whatever the iOS-arm64 prebuild driver is on the T38 branch) against the sokol tree. Tracks with [[T75]] (Android 16KB-aligned libs) and PR #113''s "scope explicitly NOT in this PR" list.'
+    tags:
+    - multimaze-audit
+    - prebuilds
+    - T38
+    origin: multimaze2-audit
+    discovered: 2026-05-30
+  T78:
+    name: Prebuilt-staleness verifier catches T38-class prebuilt skew
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'The verifier in tools/verify-prebuilds.py (introduced by #108) fails CI when a prebuilt manifest''s submodule_shas reference a submodule that no longer exists in .gitmodules (e.g. bkaradzic/bgfx after PR #113 removed those submodules) OR when a prebuilt static lib was deleted but the manifest still claims its SHAs'
+    - 'The pre-commit / CI hook would have prevented PR #113 (commit a144f1b) from landing without also regenerating prebuilt/{ios-arm64,ios-arm64-simulator,android-arm64}/{libge.a,manifest.json}'
+    - 'Running the verifier today (against ge master post-PR #113) reports the bgfx/bx/bimg ghost SHAs in all three manifests'
+    context: 'Surfaced 2026-05-30 by the multimaze2 audit. PR #113 (T38 sokol migration) deleted prebuilt/{ios-arm64,ios-arm64-simulator,android-arm64}/lib{bgfx,bx,bimg}.a but did NOT regenerate libge.a in any of those trees and did NOT update the manifests — all three still list `vendor/github.com/bkaradzic/{bgfx,bx,bimg}` under submodule_shas and the libge.a binaries still carry bgfx symbols. The PR''s commit message acknowledged this ("iOS + Android device builds ... are the next iteration") but the PR description''s "Verified" table claimed mobile success, and the prebuilt-staleness verifier (94a54b4, PR #108) did not block the merge. T77 covers regenerating the artifacts themselves; this target covers the meta-issue — closing the verifier gap so the next T38-class migration can''t ship with this same skew. Blocks any future migration that deletes submodules without regenerating prebuilts.'
+    tags:
+    - multimaze-audit
+    - ci
+    - prebuilds
+    origin: multimaze2-audit
+    discovered: 2026-05-30
+    achieved: 2026-05-30
   T8:
     name: Distribution iOS builds support accelerometer simulation in the simulator
     status: identified

--- a/prebuilt/android-arm64/manifest.json
+++ b/prebuilt/android-arm64/manifest.json
@@ -8,7 +8,7 @@
   "scripts": {
     "tools/lift-headers.sh": "e13c31fd55a6550441d7ec5c3c76ce9a85e3bdca4649af8b07087df16d31c019",
     "tools/prebuild.sh": "3d7d5302adc900891ee8430d296b67e46e91a99fc724259980b3a9f5e29a025b",
-    "tools/verify-prebuilds.py": "255f877b2d4948a49db7ea085a2de4653b81088ff17468c8e162593e5667936c",
+    "tools/verify-prebuilds.py": "0db7386a7e013f7c032ce408d3d45b28ea10ec2f860f25d4bce1fca27a15a8fe",
     "tools/write-manifest.py": "e800a85a92a11733d2665b551d7be91b5a748b0abac8186dac0ff85450784232"
   },
   "submodule_shas": {

--- a/prebuilt/ios-arm64-simulator/manifest.json
+++ b/prebuilt/ios-arm64-simulator/manifest.json
@@ -8,7 +8,7 @@
   "scripts": {
     "tools/lift-headers.sh": "e13c31fd55a6550441d7ec5c3c76ce9a85e3bdca4649af8b07087df16d31c019",
     "tools/prebuild.sh": "3d7d5302adc900891ee8430d296b67e46e91a99fc724259980b3a9f5e29a025b",
-    "tools/verify-prebuilds.py": "255f877b2d4948a49db7ea085a2de4653b81088ff17468c8e162593e5667936c",
+    "tools/verify-prebuilds.py": "0db7386a7e013f7c032ce408d3d45b28ea10ec2f860f25d4bce1fca27a15a8fe",
     "tools/write-manifest.py": "e800a85a92a11733d2665b551d7be91b5a748b0abac8186dac0ff85450784232"
   },
   "submodule_shas": {

--- a/prebuilt/ios-arm64/manifest.json
+++ b/prebuilt/ios-arm64/manifest.json
@@ -9,7 +9,7 @@
   "scripts": {
     "tools/lift-headers.sh": "e13c31fd55a6550441d7ec5c3c76ce9a85e3bdca4649af8b07087df16d31c019",
     "tools/prebuild.sh": "3d7d5302adc900891ee8430d296b67e46e91a99fc724259980b3a9f5e29a025b",
-    "tools/verify-prebuilds.py": "255f877b2d4948a49db7ea085a2de4653b81088ff17468c8e162593e5667936c",
+    "tools/verify-prebuilds.py": "0db7386a7e013f7c032ce408d3d45b28ea10ec2f860f25d4bce1fca27a15a8fe",
     "tools/write-manifest.py": "e800a85a92a11733d2665b551d7be91b5a748b0abac8186dac0ff85450784232"
   },
   "submodule_shas": {

--- a/tools/test_verify_prebuilds.py
+++ b/tools/test_verify_prebuilds.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Regression tests for tools/verify-prebuilds.py (🎯T78).
+
+Each test builds a minimal fake "ge" repo in a TemporaryDirectory, drops
+a single manifest into prebuilt/<platform>/manifest.json, and runs the
+verifier against it via subprocess with GE_REPO_ROOT pointing at the
+temp dir. We check exit code + stderr for the expected diagnostic.
+
+Run: `python3 tools/test_verify_prebuilds.py`
+     `make python-test`           (wired into bullseye)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+VERIFIER = Path(__file__).resolve().parent / "verify-prebuilds.py"
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class FakeRepo:
+    """Minimal repo for verifier tests: a tmpdir with .gitmodules, fake
+    submodule worktrees, fake prebuilt .a files, and a manifest that
+    references them."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        self.submodules: dict[str, str] = {}  # path -> sha
+        self.scripts: dict[str, bytes] = {}
+        self.prebuilts: dict[str, bytes] = {}  # rel path -> bytes
+        self.inputs: dict[str, bytes] = {}     # rel path -> bytes
+
+    def add_submodule(self, path: str, sha: str = "a" * 40) -> "FakeRepo":
+        self.submodules[path] = sha
+        return self
+
+    def add_script(self, path: str, content: bytes = b"#!/bin/sh\n") -> "FakeRepo":
+        self.scripts[path] = content
+        return self
+
+    def add_prebuilt(self, path: str, content: bytes = b"\x00prebuilt") -> "FakeRepo":
+        self.prebuilts[path] = content
+        return self
+
+    def add_input(self, path: str, content: bytes = b"// stub\n") -> "FakeRepo":
+        self.inputs[path] = content
+        return self
+
+    def materialise(self) -> None:
+        """Write everything to disk. Must be called before run()."""
+        # .gitmodules + git init so `git submodule status` returns the
+        # right shape.
+        gitmodules = ""
+        for sm_path in self.submodules:
+            gitmodules += f'[submodule "{sm_path}"]\n\tpath = {sm_path}\n\turl = https://example.invalid\n'
+        (self.root / ".gitmodules").write_text(gitmodules)
+        subprocess.check_output(["git", "init", "-q"], cwd=self.root)
+        # Tell git about each submodule path. We don't actually init real
+        # submodules; we fake the commit-pointer index entries so
+        # `git submodule status` reports the SHA we asked for.
+        for sm_path, sha in self.submodules.items():
+            sm_dir = self.root / sm_path
+            sm_dir.mkdir(parents=True, exist_ok=True)
+            # Add a 160000 (gitlink) index entry pointing at the SHA.
+            subprocess.check_output(
+                ["git", "update-index", "--add", "--cacheinfo", f"160000,{sha},{sm_path}"],
+                cwd=self.root,
+            )
+        # Files.
+        for rel, content in self.scripts.items():
+            p = self.root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(content)
+        for rel, content in self.prebuilts.items():
+            p = self.root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(content)
+        for rel, content in self.inputs.items():
+            p = self.root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(content)
+
+    def write_manifest(
+        self,
+        platform: str = "ios-arm64",
+        *,
+        scripts: dict[str, str] | None = None,
+        submodule_shas: dict[str, str] | None = None,
+        prebuilts: dict[str, str] | None = None,
+        inputs: dict[str, str] | None = None,
+        version: int = 2,
+    ) -> Path:
+        """Write a manifest under prebuilt/<platform>/manifest.json.
+        Each kwarg defaults to a manifest that matches what materialise()
+        put on disk. Pass an override to introduce a mismatch."""
+        if scripts is None:
+            scripts = {rel: sha256(c) for rel, c in self.scripts.items()}
+        if submodule_shas is None:
+            submodule_shas = dict(self.submodules)
+        if prebuilts is None:
+            prebuilts = {rel: sha256(c) for rel, c in self.prebuilts.items()}
+        if inputs is None:
+            inputs = {rel: sha256(c) for rel, c in self.inputs.items()}
+
+        manifest = {
+            "version":         version,
+            "platform":        platform,
+            "toolchain":       {"clang": "fake-clang"},
+            "scripts":         scripts,
+            "submodule_shas":  submodule_shas,
+            "prebuilts":       prebuilts,
+            "inputs":          inputs,
+        }
+        manifest_path = self.root / f"prebuilt/{platform}/manifest.json"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        return manifest_path
+
+    def run(self, *args: str) -> subprocess.CompletedProcess:
+        env = {**os.environ, "GE_REPO_ROOT": str(self.root)}
+        return subprocess.run(
+            [sys.executable, str(VERIFIER), *args],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+
+class VerifierTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="ge-verify-test-")
+        self.repo = FakeRepo(Path(self.tmp))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ── happy path ─────────────────────────────────────────────────
+
+    def test_happy_path_passes(self) -> None:
+        self.repo.add_submodule("vendor/foo")
+        self.repo.add_script("tools/build.sh")
+        self.repo.add_prebuilt("prebuilt/ios-arm64/libge.a")
+        self.repo.add_input("src/main.cpp")
+        self.repo.materialise()
+        self.repo.write_manifest()
+
+        r = self.repo.run()
+        self.assertEqual(r.returncode, 0, f"stderr={r.stderr!r}")
+        self.assertIn("prebuilts ok", r.stdout)
+
+    # ── scripts ────────────────────────────────────────────────────
+
+    def test_script_hash_mismatch(self) -> None:
+        self.repo.add_script("tools/build.sh", b"version 1")
+        self.repo.materialise()
+        # Manifest claims a different hash.
+        self.repo.write_manifest(scripts={"tools/build.sh": sha256(b"version 2")})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("script changed: tools/build.sh", r.stderr)
+
+    def test_missing_script(self) -> None:
+        self.repo.materialise()
+        self.repo.write_manifest(scripts={"tools/gone.sh": sha256(b"")})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("missing script: tools/gone.sh", r.stderr)
+
+    # ── submodules ─────────────────────────────────────────────────
+
+    def test_submodule_sha_changed(self) -> None:
+        self.repo.add_submodule("vendor/foo", sha="b" * 40)
+        self.repo.materialise()
+        self.repo.write_manifest(submodule_shas={"vendor/foo": "a" * 40})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("submodule SHA changed: vendor/foo", r.stderr)
+
+    def test_manifest_references_ghost_submodule(self) -> None:
+        """A submodule listed in the manifest but no longer in
+        .gitmodules — the T38 case described in 🎯T78's context."""
+        self.repo.materialise()
+        self.repo.write_manifest(submodule_shas={"vendor/ghost": "a" * 40})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("submodule not configured: vendor/ghost", r.stderr)
+
+    def test_submodule_added_but_not_in_manifest(self) -> None:
+        """The converse case: a submodule in .gitmodules that the
+        manifest doesn't list. Means write-manifest wasn't re-run after
+        the submodule was added. Closed gap (🎯T78)."""
+        self.repo.add_submodule("vendor/new-thing")
+        self.repo.materialise()
+        self.repo.write_manifest(submodule_shas={})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("submodule not in manifest: vendor/new-thing", r.stderr)
+
+    # ── prebuilts ──────────────────────────────────────────────────
+
+    def test_prebuilt_hash_mismatch(self) -> None:
+        self.repo.add_prebuilt("prebuilt/ios-arm64/libge.a", b"v1")
+        self.repo.materialise()
+        self.repo.write_manifest(prebuilts={"prebuilt/ios-arm64/libge.a": sha256(b"v2")})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("prebuilt changed: prebuilt/ios-arm64/libge.a", r.stderr)
+
+    def test_missing_prebuilt(self) -> None:
+        """Manifest references a .a file that was deleted from disk."""
+        self.repo.materialise()
+        self.repo.write_manifest(
+            prebuilts={"prebuilt/ios-arm64/libgone.a": sha256(b"")},
+        )
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("missing prebuilt: prebuilt/ios-arm64/libgone.a", r.stderr)
+
+    def test_prebuilt_added_but_not_in_manifest(self) -> None:
+        """The converse: a .a appears in prebuilt/<platform>/ but the
+        manifest doesn't list it. Closed gap (🎯T78)."""
+        self.repo.add_prebuilt("prebuilt/ios-arm64/libnew.a", b"xyz")
+        self.repo.materialise()
+        self.repo.write_manifest(prebuilts={})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("prebuilt not in manifest: prebuilt/ios-arm64/libnew.a", r.stderr)
+
+    # ── inputs ─────────────────────────────────────────────────────
+
+    def test_input_hash_mismatch(self) -> None:
+        self.repo.add_input("src/main.cpp", b"// v1")
+        self.repo.materialise()
+        self.repo.write_manifest(inputs={"src/main.cpp": sha256(b"// v2")})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("input changed: src/main.cpp", r.stderr)
+
+    def test_missing_input(self) -> None:
+        self.repo.materialise()
+        self.repo.write_manifest(inputs={"src/gone.cpp": sha256(b"")})
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("missing input: src/gone.cpp", r.stderr)
+
+    # ── manifest format ────────────────────────────────────────────
+
+    def test_unsupported_version(self) -> None:
+        self.repo.materialise()
+        self.repo.write_manifest(version=99)
+
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("unsupported manifest version 99", r.stderr)
+
+    def test_no_manifests_at_all(self) -> None:
+        """`prebuilt/` empty — verifier should report that explicitly,
+        not silently pass."""
+        (self.repo.root / "prebuilt").mkdir()
+        # No git init, no submodules, no scripts — bare repo root.
+        r = self.repo.run()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("no prebuilt/*/manifest.json found", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/verify-prebuilds.py
+++ b/tools/verify-prebuilds.py
@@ -39,7 +39,12 @@ import sys
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+# Allow tests to point the verifier at a temp-dir fake repo via env var.
+# Falls back to the script's parent's parent (the ge repo root) for
+# normal invocation.
+REPO_ROOT = Path(
+    os.environ.get("GE_REPO_ROOT") or Path(__file__).resolve().parent.parent
+).resolve()
 SUPPORTED_MANIFEST_VERSIONS = {1, 2}
 
 
@@ -108,8 +113,15 @@ def verify_manifest(manifest_path: Path) -> tuple[list[str], int, dict[str, int]
             errors.append(f"script changed: {rel}")
 
     # 2) submodule SHAs — from `git submodule status`, no init needed.
+    #
+    # Two-way check (🎯T78): the manifest must reference every submodule
+    # currently in the tree AND every submodule it references must still
+    # exist. Without the converse check, a PR could add a new submodule
+    # (e.g. swapping bgfx for sokol) and forget to refresh the manifest;
+    # the verifier would silently pass on a stale build state.
     actual_shas = load_submodule_status()
-    for rel, expected in manifest.get("submodule_shas", {}).items():
+    manifest_shas = manifest.get("submodule_shas", {})
+    for rel, expected in manifest_shas.items():
         actual = actual_shas.get(rel)
         if actual is None:
             errors.append(f"submodule not configured: {rel}")
@@ -119,9 +131,18 @@ def verify_manifest(manifest_path: Path) -> tuple[list[str], int, dict[str, int]
                 f"    expected {expected[:12]}\n"
                 f"    actual   {actual[:12]}"
             )
+    for rel in actual_shas:
+        if rel not in manifest_shas:
+            errors.append(f"submodule not in manifest: {rel}")
 
     # 3) prebuilt .a files — skip if still LFS pointers (CI cheap path).
-    for rel, expected in manifest.get("prebuilts", {}).items():
+    #
+    # Two-way check (🎯T78): the manifest must reference every .a in
+    # prebuilt/<platform>/. A new .a appearing without a manifest refresh
+    # means the build was rerun in a way that produced new artefacts but
+    # the hashes weren't re-recorded — stale state by another name.
+    manifest_prebuilts = manifest.get("prebuilts", {})
+    for rel, expected in manifest_prebuilts.items():
         p = REPO_ROOT / rel
         if not p.exists():
             errors.append(f"missing prebuilt: {rel}")
@@ -132,6 +153,11 @@ def verify_manifest(manifest_path: Path) -> tuple[list[str], int, dict[str, int]
         actual = sha256_file(p)
         if actual != expected:
             errors.append(f"prebuilt changed: {rel}")
+    platform_dir = manifest_path.parent
+    for a in sorted(platform_dir.glob("*.a")):
+        rel = a.relative_to(REPO_ROOT).as_posix()
+        if rel not in manifest_prebuilts:
+            errors.append(f"prebuilt not in manifest: {rel}")
 
     # 4) inputs.
     for rel, expected in manifest.get("inputs", {}).items():


### PR DESCRIPTION
## Summary

The prebuilt-staleness verifier (\`tools/verify-prebuilds.py\`, introduced by #108) only walked one direction: for each entry in the manifest, check it exists on disk. That misses the converse case — submodules added to the tree, or \`.a\` files appearing in \`prebuilt/<platform>/\`, without the manifest being refreshed. Exactly how the T38 sokol-migration scenario described in 🎯T78's context would have shipped libge.a with stale bgfx symbols and ghost submodule SHAs.

Adds two-way checks to \`verify_manifest\`:

\`\`\`python
for rel in actual_shas:
    if rel not in manifest_shas:
        errors.append(f"submodule not in manifest: {rel}")

for a in platform_dir.glob("*.a"):
    if rel not in manifest_prebuilts:
        errors.append(f"prebuilt not in manifest: {rel}")
\`\`\`

\`write-manifest.py\` must now be re-run after either tree changes; otherwise the verifier fails CI / pre-commit.

Companion test suite at \`tools/test_verify_prebuilds.py\` — 13 cases covering happy path, every existing diagnostic, both newly-closed gaps, and the no-manifest case. Wired into \`make python-test\`, which \`make bullseye\` now depends on alongside \`ruby-test\`. ~1.4 s total.

Drive-by: \`REPO_ROOT\` honours \`$GE_REPO_ROOT\` so the tests can point the verifier at temp-dir fake repos. Default unchanged.

Retires 🎯T78.

## Test plan

- [x] \`make python-test\` — 13/13 pass
- [x] \`python3 tools/verify-prebuilds.py\` — exits 0 across all three platforms with current manifests
- [ ] CI green