### PR TITLE
🎯T75: 16 KB page-align Android shared libraries for Google Play

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,23 @@ sourceSets {
 
 **Apps that need custom Activity behavior** can subclass `ge.GeActivity` in their own `app/src/main/java/<package>/` tree, add `'src/main/java'` back to `java.srcDirs`, and point the manifest at the subclass. Zero-customization is the supported default — reach for a subclass only when the engine surface genuinely doesn't suffice.
 
+### 16 KB page alignment (🎯T75)
+
+**Every ge Android build produces 16 KB page-aligned shared libraries.** This is a hard contract, not a per-app opt-in: Google Play rejects submissions whose `.so` files are not 16 KB-aligned (Android 15+ devices ship 16 KB memory pages; Android 16 hard-blocks installs of 4 KB-aligned apps with an "ELF alignment check failed" system dialog).
+
+The contract is enforced in **one ge-owned place** — `cmake/android-arm64.cmake` appends `-Wl,-z,max-page-size=16384` to `CMAKE_SHARED_LINKER_FLAGS` before the consumer's `add_library(main SHARED …)` and before ge's SDL `add_subdirectory()` calls. Because `include()` does not open a new scope and the SDL subdirectories copy the flag at entry, **every** shared object in the build inherits it: `libmain.so`, `libSDL3.so`, `libSDL3_image.so`, `libSDL3_ttf.so`, and their transitive deps (freetype, harfbuzz, plutovg). Consumer apps need no Gradle or CMakeLists changes — bumping the ge submodule pointer is enough.
+
+**Why an explicit flag rather than relying on the NDK default:** NDK r28+ links 16 KB-aligned by default, but r27 and earlier default to 4 KB, and it is the consumer's *Gradle* build — not ge's `prebuild.sh` — that chooses the NDK linking the final `.so`. The explicit flag makes the contract NDK-version-independent. (The prebuilt `libge.a` and vendor `.a` static archives have no PT_LOAD segments, so alignment only matters at this final `.so` link.)
+
+**Verify** any built `.so`:
+
+```bash
+llvm-readelf -lW <lib>.so | grep LOAD
+# every PT_LOAD segment must show Align 0x4000 (16384)
+```
+
+`llvm-readelf` ships with the NDK (`<ndk>/toolchains/llvm/prebuilt/*/bin/`) and Homebrew LLVM.
+
 ### Developer Setup
 
 `ge/init` installs common prerequisites (Homebrew packages, Git LFS, VS Code settings, compiledb). The parent's `init` target should depend on it and expand the `ge/INIT_DONE` canned recipe at the end:

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2544,7 +2544,7 @@ targets:
     discovered: 2026-05-30
   T75:
     name: ge Android builds produce 16 KB page-aligned shared libraries, so Google Play accepts submissions
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2563,6 +2563,7 @@ targets:
     - sdl3
     origin: manual
     discovered: 2026-05-30
+    achieved: 2026-05-31
   T76:
     name: sprite_test/png_test pass against T38 SpriteVertex layout
     status: identified
@@ -2613,6 +2614,17 @@ targets:
     origin: multimaze2-audit
     discovered: 2026-05-30
     achieved: 2026-05-30
+  T8:
+    name: Distribution iOS builds support accelerometer simulation in the simulator
+    status: identified
+    value: 3.0
+    cost: 5.0
+    acceptance:
+    - ⌥+WASD tilts the simulated device's accelerometer in distribution/release iOS Simulator builds (not just Debug builds)
+    - Test on a Release-configuration iOS Simulator build of any ge-based app
+    context: iOS Simulator's accelerometer emulation (⌥+WASD keyboard shortcut) only works in Debug-configuration builds by default. Distribution/Release builds disable it, which makes it impossible to test tilt-based input on the simulator without a physical device. Likely caused by an Info.plist key, build flag, or entitlement that's stripped in Release configurations. Investigate and document the fix in ge so all consumer apps benefit.
+    origin: manual
+    discovered: 2026-04-15
   T80:
     name: ge coordinate types are unit-tagged via a generic Unit&lt;T, Dim&gt; wrapper
     status: identified
@@ -2683,17 +2695,6 @@ targets:
     - T60-followup
     origin: multimaze2-audit
     discovered: 2026-05-31
-  T8:
-    name: Distribution iOS builds support accelerometer simulation in the simulator
-    status: identified
-    value: 3.0
-    cost: 5.0
-    acceptance:
-    - ⌥+WASD tilts the simulated device's accelerometer in distribution/release iOS Simulator builds (not just Debug builds)
-    - Test on a Release-configuration iOS Simulator build of any ge-based app
-    context: iOS Simulator's accelerometer emulation (⌥+WASD keyboard shortcut) only works in Debug-configuration builds by default. Distribution/Release builds disable it, which makes it impossible to test tilt-based input on the simulator without a physical device. Likely caused by an Info.plist key, build flag, or entitlement that's stripped in Release configurations. Investigate and document the fix in ge so all consumer apps benefit.
-    origin: manual
-    discovered: 2026-04-15
   T9:
     name: ge exposes device tilt as optional parallax input to games
     status: converging

--- a/cmake/android-arm64.cmake
+++ b/cmake/android-arm64.cmake
@@ -44,6 +44,27 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
         "(CMAKE_SYSTEM_NAME is '${CMAKE_SYSTEM_NAME}')")
 endif()
 
+# ── 16 KB page alignment (🎯T75) ────────────────────────────────────
+#
+# Google Play rejects submissions whose shared libraries are not 16 KB
+# page-aligned (Android 15+ devices ship 16 KB pages; Android 16 hard-
+# blocks installs of 4 KB-aligned apps). NDK r28+ links .so files with
+# 16 KB-aligned PT_LOAD segments by default, but NDK r27 and earlier
+# (and any build that pins an older NDK) default to 4 KB — and the
+# consumer's Gradle build, not ge's prebuild.sh, chooses the NDK that
+# links the final .so. Make the contract explicit and NDK-version-
+# independent here.
+#
+# This line sits before both the consumer's `add_library(main SHARED …)`
+# (which runs in the same directory scope, since include() does not open
+# a new scope) and the SDL `add_subdirectory()` calls below (which copy
+# this scope's CMAKE_SHARED_LINKER_FLAGS at entry). So every shared
+# object in the build — libmain.so, libSDL3.so, libSDL3_image.so,
+# libSDL3_ttf.so, and their transitive deps — links 16 KB-aligned.
+#
+# Verify:  llvm-readelf -lW <lib>.so  → every PT_LOAD shows Align 0x4000.
+string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-z,max-page-size=16384")
+
 set(GE_PREBUILT_DIR "${GE_ROOT}/prebuilt/android-arm64")
 set(GE_VENDOR "${GE_ROOT}/vendor")
 set(GE_HEADERS "${GE_ROOT}/headers")


### PR DESCRIPTION
## 🎯T75 — 16 KB page-aligned Android shared libraries

Google Play rejects submissions whose `.so` files aren't 16 KB page-aligned; Android 16 hard-blocks installs of 4 KB-aligned apps with an *"ELF alignment check failed"* system dialog. NDK r28+ links 16 KB-aligned by default, but it's the consumer's **Gradle** build (not ge's `prebuild.sh`) that chooses the NDK linking the final `.so` — and the in-use **NDK r27.0.12077973 defaults to 4 KB**.

### Fix (one ge-owned edit)

`cmake/android-arm64.cmake` appends `-Wl,-z,max-page-size=16384` to `CMAKE_SHARED_LINKER_FLAGS` before the consumer's `add_library(main SHARED …)` and before ge's SDL `add_subdirectory()` calls.

- `include()` doesn't open a new scope → the flag reaches **libmain.so**.
- The SDL subdirectories copy the scope's flags at entry → it reaches **libSDL3.so / libSDL3_image.so / libSDL3_ttf.so** and their transitive deps (freetype, harfbuzz, plutovg).

Consumers inherit it by bumping the ge submodule — no Gradle or CMakeLists changes. Explicit flag (rather than relying on the NDK default) makes the contract NDK-version-independent. The prebuilt `libge.a` / vendor `.a` archives have no PT_LOAD segments, so alignment only matters at this final `.so` link — no prebuild regeneration needed.

### Verification (clean tiltbuggy Android build, NDK r27)

The flag is present in the lld `LINK_FLAGS` for **every** shared target (`main`, `SDL3-shared`, `SDL3_image-shared`, `SDL3_ttf-shared`), and `llvm-readelf -lW` shows **`Align 0x4000` on every PT_LOAD** of:

```
PASS  libmain.so         all PT_LOAD Align=0x4000
PASS  libSDL3.so         all PT_LOAD Align=0x4000
PASS  libSDL3_image.so   all PT_LOAD Align=0x4000
PASS  libSDL3_ttf.so     all PT_LOAD Align=0x4000
PASS  libc++_shared.so   all PT_LOAD Align=0x4000
```

(The NDK's own ABI probe in the same build shows `-z max-page-size=4096`, confirming r27's 4 KB default — i.e. these `.so` would be 4 KB-aligned without the flag.)

### Docs

New "16 KB page alignment (🎯T75)" subsection in CLAUDE.md's Android section documenting the contract, the single enforcement point, and the `llvm-readelf` verification recipe.

### Target

🎯T75 retired in this PR. Acceptance #1 (vendored SDL `.so`), #2 (libmain.so), and #5 (docs) are met and verified above. #3 (no Android-16 dialog) and #4 (Play Console alignment check) are deterministic consequences of the verified 16 KB ELF alignment; the actual Play upload is a consumer-repo release action.

### CI

No checks run on this PR — the changed paths (`cmake/`, `CLAUDE.md`) are outside the `verify-prebuilds` trigger set, and ge ships no binaries from CI. Verification is the local `llvm-readelf` proof above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
