### PR TITLE
🎯T110: ge/ios-device — IDE-free iOS development build + deploy lane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,6 +464,21 @@ The Vite dev server proxies `/api`, `/ws`, and `/mcp` to ged at `localhost:42069
 
 **iOS and Android player builds are currently broken** — they still reference Dawn/WebGPU and need to be ported to bgfx + H.264 decode. The CMakeLists files and build scripts have been scrubbed of Dawn references and marked TODO.
 
+### iOS code signing — development vs ship (🎯T110)
+
+Two signing paths, deliberately separate. `build_project.rb` owns the `CODE_SIGN_*` settings — **never hand-edit signing into the generated xcodeproj.**
+
+- **Development — `make ge/ios-device`** (install on your own test devices). Debug build with `GE_IOS_SIGNING=development` → **Automatic** signing + **Apple Development** (no match, no shared secret), paired with `xcodebuild -allowProvisioningUpdates`. Each developer signs with **their own** cert; iOS devices accumulate multiple dev certs fine, so "different developers, different certs" is a non-problem at the dev layer (match would be *worse* here — shared secret, single point of failure). Sim builds (`make ge/ios`) don't sign.
+- **Ship — `make ge/ios-device-release`** (TestFlight / App Store). Release build, default `GE_IOS_SIGNING=appstore` → **Manual** + **Apple Distribution (Squz)** + the **match**-installed `match AppStore <bundle>` profile. The Distribution cert is the one identity that genuinely must be shared, so it lives in match (`fastlane/Fastfile`, `MATCH_PASSWORD` + ASC API key). See [[project_squz_cert_policy]].
+
+**The Apple model in one line:** a *certificate* says **who** signed; a *provisioning profile* says **what that signature may do** (which app, which devices — or any device for App Store — which entitlements). The cert's display name (`Apple Development: MARCELO CANTOS`) names the *member*; the `TeamIdentifier` (`SWA3H3N7TW`) is what attributes the build to **Squz**. They are not the same entity — a dev cert under Team Squz is still a Squz build.
+
+**A new device needs one-time enrollment.** `-allowProvisioningUpdates` reuses *already-registered* devices but will **not** enroll a brand-new one headlessly (`error: Device … isn't registered`). Today: connect it and Run once from Xcode (which enrolls it), then every later CLI build/deploy just works. The headless equivalent — a `fastlane register_devices` step keyed on the ASC API key — is the open piece of 🎯T110; until it lands, a never-before-seen device needs that single Xcode Run. Enrollment is **once per device, ever** — not per build.
+
+**Deployment floor is iOS 16.3** (`build_project.rb` default). Dropping to iOS 15 buys ~2–4% of old/weak/low-spend devices and costs `@available` guards around the iOS-16+ orientation-lock stack — not worth it.
+
+**Installing to a device:** modern devices via `spyder deploy_app` (or Apple `devicectl`, iOS 17+ only); iOS ≤16 devices use go-ios's lockdown path (spyder's high-level deploy/launch/screenshot assume the iOS-17 RemoteXPC tunnel — gap tracked as spyder 🎯T78).
+
 ### iOS orientation lock (iPadOS 26+)
 
 **Locking iPad orientation is a TWO-knob setup, and you need both:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,6 +464,21 @@ The Vite dev server proxies `/api`, `/ws`, and `/mcp` to ged at `localhost:42069
 
 **iOS and Android player builds are currently broken** — they still reference Dawn/WebGPU and need to be ported to bgfx + H.264 decode. The CMakeLists files and build scripts have been scrubbed of Dawn references and marked TODO.
 
+### iOS code signing — development vs ship (🎯T110)
+
+Two signing paths, deliberately separate. `build_project.rb` owns the `CODE_SIGN_*` settings — **never hand-edit signing into the generated xcodeproj.**
+
+- **Development — `make ge/ios-device`** (install on your own test devices). Debug build with `GE_IOS_SIGNING=development` → **Automatic** signing + **Apple Development** (no match, no shared secret), paired with `xcodebuild -allowProvisioningUpdates`. Each developer signs with **their own** cert; iOS devices accumulate multiple dev certs fine, so "different developers, different certs" is a non-problem at the dev layer (match would be *worse* here — shared secret, single point of failure). Sim builds (`make ge/ios`) don't sign.
+- **Ship — `make ge/ios-device-release`** (TestFlight / App Store). Release build, default `GE_IOS_SIGNING=appstore` → **Manual** + **Apple Distribution (Squz)** + the **match**-installed `match AppStore <bundle>` profile. The Distribution cert is the one identity that genuinely must be shared, so it lives in match (`fastlane/Fastfile`, `MATCH_PASSWORD` + ASC API key). See [[project_squz_cert_policy]].
+
+**The Apple model in one line:** a *certificate* says **who** signed; a *provisioning profile* says **what that signature may do** (which app, which devices — or any device for App Store — which entitlements). The cert's display name (`Apple Development: MARCELO CANTOS`) names the *member*; the `TeamIdentifier` (`SWA3H3N7TW`) is what attributes the build to **Squz**. They are not the same entity — a dev cert under Team Squz is still a Squz build.
+
+**A new device needs one-time enrollment.** `-allowProvisioningUpdates` reuses *already-registered* devices but will **not** enroll a brand-new one headlessly (`error: Device … isn't registered`). Today: connect it and Run once from Xcode (which enrolls it), then every later CLI build/deploy just works. The headless equivalent — a `fastlane register_devices` step keyed on the ASC API key — is the open piece of 🎯T110; until it lands, a never-before-seen device needs that single Xcode Run. Enrollment is **once per device, ever** — not per build.
+
+**Deployment floor is iOS 16.3** (`build_project.rb` default). Dropping to iOS 15 buys ~2–4% of old/weak/low-spend devices and costs `@available` guards around the iOS-16+ orientation-lock stack — not worth it.
+
+**Installing to a device:** modern devices via `spyder deploy_app` (or Apple `devicectl`, iOS 17+ only); iOS ≤16 devices use go-ios's lockdown path (spyder's high-level deploy/launch/screenshot assume the iOS-17 RemoteXPC tunnel — gap tracked as spyder 🎯T78).
+
 ### iOS orientation lock (iPadOS 26+)
 
 **Locking iPad orientation is a TWO-knob setup, and you need both:**

--- a/Module.mk
+++ b/Module.mk
@@ -729,6 +729,28 @@ ge/ios-device-release: $(APP_SHADERS) $(ge/RENDER_SHADERS)
 	    -allowProvisioningUpdates \
 	    build
 
+# ── iOS physical-device DEVELOPMENT build (deploy to your own devices) ─
+# `make ge/ios-device` builds a Debug, development-signed .app for installing
+# on a developer's own registered test devices. GE_IOS_SIGNING=development makes
+# build_project.rb emit Automatic signing + Apple Development (no match), and
+# `-allowProvisioningUpdates` lets Xcode mint/renew the per-developer dev cert,
+# create the Team Provisioning Profile, and register any connected+trusted
+# device. No shared certs, no match passphrase — each developer signs with their
+# own identity (the ship path stays on match AppStore via ge/ios-device-release).
+.PHONY: ge/ios-device
+ge/ios-device: $(APP_SHADERS) $(ge/RENDER_SHADERS)
+	@if [ ! -d ios ]; then \
+	    echo "ios/ not found — run 'make ge/ios-init APP_ID=... APP_NAME=...' first"; \
+	    exit 1; \
+	fi
+	GE_IOS_SIGNING=development bundle exec ruby ios/project.rb
+	cd ios && xcodebuild \
+	    -project $(APP_BIN_NAME).xcodeproj -scheme $(APP_BIN_NAME) \
+	    -configuration Debug -destination "generic/platform=iOS" \
+	    -derivedDataPath build-device-dev \
+	    -allowProvisioningUpdates \
+	    build
+
 # (ge player iOS physical-device build target retired in 🎯T73.3 — see
 # the player section above.)
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -416,6 +416,26 @@ targets:
     - documentation
     origin: decomposed from T11
     discovered: 2026-04-12
+  T110:
+    name: ge has an IDE-free iOS development build + deploy path (per-developer signing, headless device registration)
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - build_project.rb supports a :development signing mode (CODE_SIGN_STYLE=Automatic + Apple Development, no match profile) selectable via GE_IOS_SIGNING=development; the default stays :appstore so the release/match path is unchanged.
+    - '`make ge/ios-device` builds a Debug, development-signed .app and pairs it with `xcodebuild -allowProvisioningUpdates`, so each developer signs with their own cert (no match, no shared secret) and installs on the team''s registered devices.'
+    - A brand-new device can be enrolled into the team headlessly via an App Store Connect API key (fastlane register_devices), so deploying to a never-before-seen device does NOT require the Xcode GUI. (Today this still needs a one-time Xcode 'Run' or a manual portal add.)
+    - 'CLAUDE.md + AGENTS.md document the dev-vs-ship iOS signing split: development = `make ge/ios-device` + automatic per-developer signing; ship = `make ge/ios-device-release` + match AppStore (Distribution). Plus the one-time-per-new-device enrollment step.'
+    - 'Verified: a ge consumer (tiltbuggy) deploys + renders on physical iOS devices via the dev lane (confirmed on iPad mini A17 Pro, iPad Air 5, iPhone 13, iPhone 8, post-🎯T107).'
+    context: 'From the 2026-06-07 dev-vs-ship signing investigation while verifying T107 didn''t break iOS. build_project.rb was ship-only (Manual + CODE_SIGN_IDENTITY ''Apple Distribution'' + PROVISIONING_PROFILE_SPECIFIER ''match AppStore <bundle>''), so it could not produce a build installable on a developer''s own test devices — the device build came out UNSIGNED (match profile not installed) and every install was rejected (''No code signature found''). `-allowProvisioningUpdates` is inert under Manual signing. Added a :development signing mode + a `make ge/ios-device` lane (Debug, Automatic/Apple Development, -allowProvisioningUpdates). Conclusion of the broader discussion: dev = per-developer automatic signing (iOS devices accumulate multiple dev certs fine; no ''cert mixture'' problem at the dev layer; match would be worse here — shared secret, single point of failure); ship = match AppStore (one shared Distribution cert, the only thing that genuinely must be shared). The single remaining IDE dependency is new-DEVICE registration: `-allowProvisioningUpdates` reuses already-registered devices but won''t enroll a brand-new one headlessly; Xcode''s GUI does it on first Run, and the headless equivalent is an ASC-API-key `fastlane register_devices` step — wiring that into the dev tooling is the open piece. iOS deployment floor stays at 16.3 (dropping iOS 15 loses ~2-4% of old/weak/low-spend devices and would cost @available guards around the iOS-16+ orientation-lock stack — not worth it).'
+    tags:
+    - ios
+    - signing
+    - build-tooling
+    - fastlane
+    - dev-workflow
+    origin: manual
+    discovered: 2026-06-07
   T12:
     name: ge's render subsystem synthesises ⌥WASD accelerometer events uniformly across all host contexts
     status: achieved

--- a/tools/ios-build/build_project.rb
+++ b/tools/ios-build/build_project.rb
@@ -106,6 +106,15 @@ module GE
         display_name: nil,
         team_id: ENV.fetch('APPLE_TEAM_ID'),
         signing_profile: nil,
+        # Device signing mode:
+        #   :appstore (default) — Manual + match AppStore profile + Apple
+        #     Distribution (Squz). For release/TestFlight via gym.
+        #   :development — Automatic + Apple Development. For installing on a
+        #     developer's own registered test devices; pair the build with
+        #     `xcodebuild -allowProvisioningUpdates`. Per-developer cert, no
+        #     match. Resolved from GE_IOS_SIGNING when not passed explicitly,
+        #     so the dev make-lane just sets the env (no consumer edit).
+        signing: nil,
         deployment_target: '16.3',
         device_family: '1,2', # 1=iPhone, 2=iPad
         extra_defines: [],
@@ -129,6 +138,10 @@ module GE
         @display_name = display_name || app_name
         @team_id = team_id
         @signing_profile = signing_profile || "match AppStore #{bundle_id}"
+        @signing = (signing || ENV.fetch('GE_IOS_SIGNING', 'appstore')).to_sym
+        unless %i[appstore development].include?(@signing)
+          raise ArgumentError, "signing must be :appstore or :development (got #{@signing})"
+        end
         @deployment_target = deployment_target
         @device_family = device_family
         @extra_defines = extra_defines
@@ -204,16 +217,28 @@ module GE
           # device and sim builds without regenerating.
           'SUPPORTED_PLATFORMS' => @simulator ? 'iphoneos iphonesimulator' : 'iphoneos',
 
-          # Squz signing — Manual + match-installed profile + Apple
-          # Distribution: Squz Pty Ltd. See [[squz-cert-policy]].
-          # Simulator builds don't enforce signing, but Xcode still
-          # respects these settings when targeting iphoneos.
-          'CODE_SIGN_STYLE' => 'Manual',
-          'DEVELOPMENT_TEAM' => @team_id,
-          'CODE_SIGN_IDENTITY' => 'Apple Distribution',
-          'PROVISIONING_PROFILE_SPECIFIER' => @signing_profile,
-          # Simulator code-sign settings: no profile required. Xcode
-          # accepts `--` (any identity) for sim and skips entitlements.
+          # Device signing (iphoneos). @signing picks the mode:
+          #   :appstore    — Manual + match AppStore profile + Apple Distribution
+          #                  (Squz). Release/TestFlight via gym. [[squz-cert-policy]]
+          #   :development — Automatic + Apple Development. Installs on a dev's own
+          #                  registered devices; build with
+          #                  `xcodebuild -allowProvisioningUpdates` so Xcode mints
+          #                  the dev cert + Team Provisioning Profile and registers
+          #                  connected devices. Per-developer cert, no match.
+          **(@signing == :development ?
+            {
+              'CODE_SIGN_STYLE'                => 'Automatic',
+              'DEVELOPMENT_TEAM'               => @team_id,
+              'CODE_SIGN_IDENTITY'             => 'Apple Development',
+              'PROVISIONING_PROFILE_SPECIFIER' => '',
+            } : {
+              'CODE_SIGN_STYLE'                => 'Manual',
+              'DEVELOPMENT_TEAM'               => @team_id,
+              'CODE_SIGN_IDENTITY'             => 'Apple Distribution',
+              'PROVISIONING_PROFILE_SPECIFIER' => @signing_profile,
+            }),
+          # Simulator code-sign settings (both modes): no profile required.
+          # Xcode accepts `--` (any identity) for sim and skips entitlements.
           'CODE_SIGN_IDENTITY[sdk=iphonesimulator*]' => '-',
           'CODE_SIGN_STYLE[sdk=iphonesimulator*]' => 'Automatic',
           'PROVISIONING_PROFILE_SPECIFIER[sdk=iphonesimulator*]' => '',

--- a/tools/ios-build/test_build_project.rb
+++ b/tools/ios-build/test_build_project.rb
@@ -59,7 +59,7 @@ class BuildProjectTest < Minitest::Test
     abs
   end
 
-  def build(resources:, engine_mode: :prebuilt)
+  def build(resources:, engine_mode: :prebuilt, signing: nil)
     GE::IOS::ProjectBuilder.new(
       app_name: 'TestApp',
       bundle_id: 'com.example.testapp',
@@ -71,9 +71,16 @@ class BuildProjectTest < Minitest::Test
       ge_root: @ge_root,
       resources: resources,
       engine_mode: engine_mode,
+      signing: signing,
     ).generate
 
     Xcodeproj::Project.open(File.join(@ios_dir, 'TestApp.xcodeproj'))
+  end
+
+  # Build settings for the app target's first build configuration (signing
+  # settings are shared across Debug/Release, so either config carries them).
+  def app_build_settings(project)
+    project.targets.first.build_configurations.first.build_settings
   end
 
   def source_phase_paths(project)
@@ -326,5 +333,34 @@ class BuildProjectTest < Minitest::Test
     assert_includes paths, '../ge/src/debug.cpp'
     assert_includes paths, '../ge/src/SessionHost.mm'
     assert_includes paths, '../ge/vendor/src/sqlpipe.cpp'
+  end
+
+  # 🎯T110: signing modes — ship (default) vs development device install.
+  def test_appstore_signing_is_the_default
+    bs = app_build_settings(build(resources: []))
+    assert_equal 'Manual', bs['CODE_SIGN_STYLE']
+    assert_equal 'Apple Distribution', bs['CODE_SIGN_IDENTITY']
+    assert_equal 'match AppStore com.example.testapp', bs['PROVISIONING_PROFILE_SPECIFIER']
+  end
+
+  def test_development_signing_mode
+    bs = app_build_settings(build(resources: [], signing: :development))
+    assert_equal 'Automatic', bs['CODE_SIGN_STYLE']
+    assert_equal 'Apple Development', bs['CODE_SIGN_IDENTITY']
+    assert_equal '', bs['PROVISIONING_PROFILE_SPECIFIER']
+    # Simulator override is identical in both modes (sim never enforces signing).
+    assert_equal '-', bs['CODE_SIGN_IDENTITY[sdk=iphonesimulator*]']
+  end
+
+  def test_signing_mode_resolves_from_env_when_not_passed
+    ENV['GE_IOS_SIGNING'] = 'development'
+    bs = app_build_settings(build(resources: []))
+    assert_equal 'Automatic', bs['CODE_SIGN_STYLE']
+  ensure
+    ENV.delete('GE_IOS_SIGNING')
+  end
+
+  def test_invalid_signing_mode_raises
+    assert_raises(ArgumentError) { build(resources: [], signing: :bogus) }
   end
 end


### PR DESCRIPTION
Adds an **IDE-free iOS development build + deploy lane** (🎯T110). Surfaced while verifying 🎯T107 didn't break iOS — `build_project.rb` was ship-only, so there was no way to install on a developer's own test devices (the device build came out **unsigned** → every install rejected with "No code signature found").

## What changed
- **`build_project.rb`** gains a `signing:` mode — `:appstore` (default, unchanged) or `:development`, resolved from `GE_IOS_SIGNING` when not passed. `:development` emits **Automatic + Apple Development** (no provisioning specifier); `:appstore` stays **Manual + Apple Distribution + match AppStore**, so the release/match path and existing consumers (multimaze2) are untouched.
- **`make ge/ios-device`** — Debug, `GE_IOS_SIGNING=development`, paired with `xcodebuild -allowProvisioningUpdates`. Each developer signs with their **own** cert; no match, no shared secret.
- **`test_build_project.rb`** — covers both modes, env resolution, and invalid-mode raise (16 runs, 0 failures).
- **CLAUDE.md / AGENTS.md** — document the dev-vs-ship signing split, the Apple cert/profile model, and one-time-per-new-device enrollment.

## Why dev = per-developer signing (not match)
iOS devices accumulate multiple developer certs fine — "different developers, different certs" is a non-problem at the dev layer, and match (one shared cert) would be *worse*: shared secret + single point of failure. **Ship** stays on match AppStore — the Distribution cert is the one identity that genuinely must be shared.

## Verification
Deployed tiltbuggy to physical devices via the dev lane, post-T107: **iPad mini A17 Pro** (screenshot-confirmed render), **iPad Air 5**, **iPhone 13**, **iPhone 8** — all rendering on Metal. iOS deployment floor stays **16.3** (the iOS-15 iPad mini 4 is intentionally unsupported — ~2–4% of old/low-spend devices, not worth `@available`-guarding the iOS-16+ orientation stack).

## Open follow-ups (in 🎯T110 acceptance)
- Headless new-device enrollment via an ASC API key (`fastlane register_devices`) so a never-before-seen device skips the one-time Xcode Run.
- Filed **spyder 🎯T78** separately: deploy/launch/screenshot iOS ≤16 via go-ios lockdown (no tunneld), so old devices work through spyder's normal surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
