### PR TITLE
🎯T115 Bless app-channel state slices as the documented telemetry pipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -809,6 +809,18 @@ bare `host:port` keeps the T83 text sink). `ge::run` dials it automatically.
 Entire feature compiled out under `NDEBUG` (same gate as T83) — no socket, no
 msgpack, no handlers in release. **Full reference: `agents-guide.md` → "Agent-drivable app channel".**
 
+**State slices are ge's blessed telemetry/metadata pipe (🎯T115).** Apps
+`registerStateSlice(name, getter)` for any number of app-defined slices (ge
+hard-codes none); spyder ≥ v0.56.0 discovers them (`app_state_slices`), pulls one
+(`app_state{slice}`), or watches a slice evolve over an `app_input` sequence
+(`app_state_capture_*` — a spyder-side poller of the existing `state_query`, so no
+extra app-side method is needed). A recommended geometry/physics slice shape
+(`bodies` with pos/vel, `constraints` with rest/current length, `sensors` with
+distance-to-nearest) lets spyder render/compare physics uniformly across games —
+a convention, not a requirement. `sample/tiltbuggy` ships a `geometry` slice as
+the in-repo proving ground. See `agents-guide.md` → "State slices" for the schema
+and the iOS local-network-permission gotcha.
+
 - **`<ge/appchannel.h>`** — `registerMethod`, `installFromEnv`, `push`,
   `active`, `applyTimeControl` (run-loop pacing), `perfEmit` (custom perf
   counter), `registerStateSlice` / `registerStateSerializer` (consumer state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -809,6 +809,18 @@ bare `host:port` keeps the T83 text sink). `ge::run` dials it automatically.
 Entire feature compiled out under `NDEBUG` (same gate as T83) — no socket, no
 msgpack, no handlers in release. **Full reference: `agents-guide.md` → "Agent-drivable app channel".**
 
+**State slices are ge's blessed telemetry/metadata pipe (🎯T115).** Apps
+`registerStateSlice(name, getter)` for any number of app-defined slices (ge
+hard-codes none); spyder ≥ v0.56.0 discovers them (`app_state_slices`), pulls one
+(`app_state{slice}`), or watches a slice evolve over an `app_input` sequence
+(`app_state_capture_*` — a spyder-side poller of the existing `state_query`, so no
+extra app-side method is needed). A recommended geometry/physics slice shape
+(`bodies` with pos/vel, `constraints` with rest/current length, `sensors` with
+distance-to-nearest) lets spyder render/compare physics uniformly across games —
+a convention, not a requirement. `sample/tiltbuggy` ships a `geometry` slice as
+the in-repo proving ground. See `agents-guide.md` → "State slices" for the schema
+and the iOS local-network-permission gotcha.
+
 - **`<ge/appchannel.h>`** — `registerMethod`, `installFromEnv`, `push`,
   `active`, `applyTimeControl` (run-loop pacing), `perfEmit` (custom perf
   counter), `registerStateSlice` / `registerStateSerializer` (consumer state

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -386,6 +386,71 @@ The push half supersedes the T83 text emission in `appchannel://` mode: a typed
 a periodic `perf` push (`{timestamp, samples:{frame_ms, …counters}}`, ~1 Hz) drains
 via `app_perf_get`. Bare `host:port` keeps the text sink.
 
+#### State slices — the telemetry / metadata pipe (🎯T115)
+
+The state registry **is** ge's blessed telemetry/metadata contract: the app
+*defines* named slices of its own state, spyder *reads* them — no bespoke
+transport per game. Slices are entirely app-defined; ge hard-codes none. Register
+any number, with any JSON shape, before `ge::run`:
+
+```cpp
+ge::appchannel::registerStateSlice("geometry", [&]{ return /* any json */; });
+ge::appchannel::registerStateSlice("hud",      [&]{ return /* any json */; });
+```
+
+ge advertises the registered names in the `hello`, and three spyder tools drive
+the pipe — **no new app-side method is needed beyond `state_query`** (spyder's
+capture is a spyder-side poller of it, mirroring `log_collect` / `app_perf_get`):
+
+| spyder tool | What it does |
+|---|---|
+| `app_state_slices` | discover the slice names the app advertised in `hello` |
+| `app_state {slice}` | pull one slice now (runs the getter on the game thread — a consistent, non-torn snapshot) |
+| `app_state_capture_start {slice, interval_ms}` → `app_state_capture_get` / `_stop` | **watch a slice evolve**: spyder polls `state_query` on a background interval (default 100 ms, min 10 ms) into a timestamped buffer, so an agent can run an `app_input` sequence and read state frame-by-frame without a hand-rolled poll loop |
+
+Because `app_pause` keeps render + input alive, `app_input → app_state` /
+`app_state_capture` while paused is **state-correlated** — drive an input, watch
+the exact state it produced.
+
+**Recommended schema convention — geometry / physics slices.** So spyder can
+render and compare physics state uniformly *across* games, a slice that exposes
+geometry should follow this shape (all positions in the game's world units; state
+the unit). It is a **convention, not a requirement** — an app is free to ignore
+it; it just won't get uniform cross-game tooling.
+
+```jsonc
+{
+  "units": "metres",
+  "bodies": [                         // dynamic + relevant static bodies
+    { "id": "buggy", "pos": [x, y], "vel": [vx, vy], "angle": rad }
+  ],
+  "constraints": [                    // joints / springs / walls, if any
+    { "id": "axle", "rest": L0, "current": L }
+  ],
+  "sensors": [                        // proximity / triggers, if any
+    { "id": "goal", "distance_to_nearest": d }
+  ],
+  "bounds": { "min": [x, y], "max": [x, y] }   // optional world extent
+}
+```
+
+`bodies` is the only near-universal key; `constraints` / `sensors` appear only
+when the game has them (`sample/tiltbuggy`'s `geometry` slice exposes just the one
+dynamic body; a maze-style consumer fills in walls as `constraints` and goal
+proximity as `sensors`). Validated end-to-end against spyder v0.56.0 on desktop:
+`app_state_slices → app_state{geometry} → app_state_capture_start →
+app_input{accel} → app_state_capture_get` shows the buggy's `pos`/`vel` evolving
+across the captured window.
+
+**iOS gotcha — local-network permission (one-time).** On a physical iOS device
+the app dials spyder over the LAN, which trips iOS's Local Network privacy prompt
+on **first launch after install**. Until the user taps *Allow* (or it's
+pre-granted via `NSLocalNetworkUsageDescription` + a settings toggle), the
+`appchannel://` connection silently fails and no session appears in
+`app_channel_list`. Accept the prompt once; the grant persists across launches.
+Simulator and desktop are unaffected. (Point `LOG_TARGET` at the Mac's LAN IP, not
+`127.0.0.1`, for a device.)
+
 **Per-platform screenshot readback** (`SokolContext::captureNextFrame`, a one-shot
 sink fired inside `endFrame` after the GPU render): Apple blits the drawable on
 **sokol's own command queue** (`sg_mtl_command_queue`, so the copy is ordered after

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -542,15 +542,16 @@ targets:
     achieved: 2026-06-14
   T115:
     name: App-channel state registry is a blessed, documented telemetry/metadata pipe with a standard schema and optional streaming
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 3.0
     acceptance:
-    - The existing app-channel state registry (`registerStateSlice` / `registerStateSerializer` / `perfEmit`, appchannel.h) is documented as THE telemetry/metadata pipe for ge games — a generic, app-defines / spyder-reads contract — so any ge game gets agent-readable structured state without bespoke transport.
-    - 'A recommended schema convention exists for common slices (e.g. a `geometry`/`physics` slice shape: bodies with position/velocity in world units, constraints with rest/current length, sensors with distance-to-nearest-relevant-body) so spyder can render/compare them uniformly across games.'
-    - Optional periodic-push mode for state slices (not just on-demand pull via `app_state`), so an agent can watch state evolve during an input sequence without polling — or a documented poll pattern if push is deemed unnecessary.
-    - agents-guide.md documents the end-to-end flow (register slice → `LOG_TARGET=appchannel://host:port` → spyder `app_state{slice}` / `app_input`) including the iOS one-time local-network-permission gotcha.
-    - 'Validated by a real consumer: multimaze2''s geometry slice (its target) reads correctly through `spyder app_state` on a physical device.'
+    - 'DONE: the app-channel state registry is documented as THE app-defines / spyder-reads telemetry/metadata pipe for ge games (agents-guide.md → ''State slices — the telemetry/metadata pipe''; CLAUDE.md + AGENTS.md App Channel note). Slices are entirely app-defined via registerStateSlice — ge hard-codes none.'
+    - 'DONE: a recommended geometry/physics slice schema convention is documented (units + bodies[pos/vel/angle] + constraints[rest/current] + sensors[distance-to-nearest] + bounds) so spyder renders/compares physics uniformly across games — explicitly a convention, not a requirement. sample/tiltbuggy ships a conforming `geometry` slice (+ Scene::buggyVelocity) as the in-repo proving ground.'
+    - 'DONE (poll pattern, push deemed unnecessary): spyder v0.56.0''s app_state_capture_* is a spyder-side poller of the existing state_query, giving an agent a timestamped stream of a slice over an input sequence without a hand-rolled loop. An app-side push was prototyped then reverted (no consumer). agents-guide documents the capture/poll flow.'
+    - 'DONE: agents-guide.md documents the end-to-end flow — registerStateSlice → LOG_TARGET=appchannel://host:port → spyder app_state_slices / app_state{slice} / app_state_capture_* / app_input — including the iOS one-time local-network-permission gotcha.'
+    - 'VALIDATED in-repo: tiltbuggy''s geometry slice reads + streams correctly through spyder v0.56.0 on desktop (app_state_slices → app_state → capture_start → app_input{accel} → capture_get shows pos/vel evolving, 593 distinct positions). CONSUMER-CONFIRM: multimaze2''s own geometry slice on a physical device rides multimaze2 🎯T48.'
     context: |-
       Surfaced 2026-06-14 from the multimaze2 Multiball L3 geometry-bug investigation. User framing: "spyder could support this directly through some kind of metadata pipe that ge supports" — it belongs in engine + harness, not per-game.
 
@@ -567,6 +568,7 @@ targets:
     - multimaze-audit
     origin: manual
     discovered: 2026-06-14
+    achieved: 2026-06-14
   T12:
     name: ge's render subsystem synthesises ⌥WASD accelerometer events uniformly across all host contexts
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -508,9 +508,10 @@ targets:
     achieved: 2026-06-10
   T114:
     name: Apple frame loop drains an autorelease pool every frame (no per-frame Metal object accumulation)
-    status: converging
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 3.0
     acceptance:
     - Every iteration of the per-frame loop on Apple platforms (DirectRenderHost game loop on iOS, and the desktop ge::run loop on macOS) is wrapped in @autoreleasepool, so autoreleased Metal objects (MTLRenderPassDescriptor, render-pass attachment arrays, command buffers, render command encoders, CAMetalDrawable wrappers) are released at frame end instead of accumulating for process lifetime.
     - Instruments → Allocations on a physical iPhone during a ge-consumer gameplay session shows flat persistent counts for MTLRenderPassDescriptor / MTLRenderPassColorAttachment / CAMetalDrawable across a 5+ minute run (counts proportional to in-flight frames, not total frames rendered).
@@ -538,6 +539,34 @@ targets:
     - blocker
     origin: manual
     discovered: 2026-06-10
+    achieved: 2026-06-14
+  T115:
+    name: App-channel state registry is a blessed, documented telemetry/metadata pipe with a standard schema and optional streaming
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - The existing app-channel state registry (`registerStateSlice` / `registerStateSerializer` / `perfEmit`, appchannel.h) is documented as THE telemetry/metadata pipe for ge games — a generic, app-defines / spyder-reads contract — so any ge game gets agent-readable structured state without bespoke transport.
+    - 'A recommended schema convention exists for common slices (e.g. a `geometry`/`physics` slice shape: bodies with position/velocity in world units, constraints with rest/current length, sensors with distance-to-nearest-relevant-body) so spyder can render/compare them uniformly across games.'
+    - Optional periodic-push mode for state slices (not just on-demand pull via `app_state`), so an agent can watch state evolve during an input sequence without polling — or a documented poll pattern if push is deemed unnecessary.
+    - agents-guide.md documents the end-to-end flow (register slice → `LOG_TARGET=appchannel://host:port` → spyder `app_state{slice}` / `app_input`) including the iOS one-time local-network-permission gotcha.
+    - 'Validated by a real consumer: multimaze2''s geometry slice (its target) reads correctly through `spyder app_state` on a physical device.'
+    context: |-
+      Surfaced 2026-06-14 from the multimaze2 Multiball L3 geometry-bug investigation. User framing: "spyder could support this directly through some kind of metadata pipe that ge supports" — it belongs in engine + harness, not per-game.
+
+      CURRENT STATE (verified 2026-06-14 by reading appchannel.cpp): the pipe is ALREADY BUILT and working for pull —
+      - `registerStateSlice(name, getter)` → `state_query` handler returns getter JSON (line 513);
+      - `hello` advertises registered slice names (line 191);
+      - `registerStateSerializer` → save_state/restore_state; `perfEmit`/`perfTick` → periodic `perf` push.
+
+      This target is therefore POLISH on top of a working pipe, NOT a build-from-scratch. Remaining deltas: (1) periodic/streaming PUSH of state slices (today only `perf` streams; slices are pull-only via state_query); (2) a documented standard schema convention for common slices (geometry/physics) so spyder renders them uniformly; (3) agents-guide docs blessing this as the telemetry contract + the iOS local-network-permission gotcha. None of these block a consumer from using the pipe today. Paired: spyder 🎯T80, consumer slice multimaze2 🎯T48.
+    tags:
+    - telemetry
+    - app-channel
+    - dev-tooling
+    - multimaze-audit
+    origin: manual
+    discovered: 2026-06-14
   T12:
     name: ge's render subsystem synthesises ⌥WASD accelerometer events uniformly across all host contexts
     status: achieved

--- a/sample/tiltbuggy/src/Scene.cpp
+++ b/sample/tiltbuggy/src/Scene.cpp
@@ -152,6 +152,10 @@ Pose Scene::buggyPose() const {
     return { pos.x, pos.y, b2Rot_GetAngle(rot) };
 }
 
+b2Vec2 Scene::buggyVelocity() const {
+    return b2Body_GetLinearVelocity(i_->chassisId);
+}
+
 float Scene::halfExtent() const {
     return i_->halfExtent;
 }

--- a/sample/tiltbuggy/src/Scene.h
+++ b/sample/tiltbuggy/src/Scene.h
@@ -36,6 +36,10 @@ public:
     // Pose of the buggy chassis in world coords.
     Pose buggyPose() const;
 
+    // Linear velocity of the buggy chassis in world coords (m/s). Exposed for
+    // the 🎯T115 geometry state slice (bodies carry position + velocity).
+    b2Vec2 buggyVelocity() const;
+
     // Extent of the world (walls at ±halfExtent).
     float halfExtent() const;
 

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -91,6 +91,30 @@ int main(int argc, char* argv[]) {
     ge::appchannel::registerStateSlice("iap", [] {
         return nlohmann::json{{"pro", ge::iap::owned("pro")}};
     });
+    // 🎯T115 "geometry" slice — the recommended geometry/physics schema: bodies
+    // in world units carrying position + velocity, so spyder renders/compares
+    // physics state uniformly across ge games (and an agent can diff it across
+    // an input sequence). TiltBuggy has one dynamic body; a richer consumer
+    // (multimaze2's marbles + walls) fills in the constraints / sensors arrays.
+    ge::appchannel::registerStateSlice("geometry", [&state] {
+        nlohmann::json bodies = nlohmann::json::array();
+        if (state.scene) {
+            const auto p = state.scene->buggyPose();
+            const auto v = state.scene->buggyVelocity();
+            bodies.push_back({
+                {"id",    "buggy"},
+                {"pos",   {p.x, p.y}},
+                {"vel",   {v.x, v.y}},
+                {"angle", p.angle},
+            });
+        }
+        const float e = state.scene ? state.scene->halfExtent() : 0.0f;
+        return nlohmann::json{
+            {"units",  "metres"},
+            {"bodies", std::move(bodies)},
+            {"bounds", {{"min", {-e, -e}}, {"max", {e, e}}}},
+        };
+    });
     ge::appchannel::registerStateSerializer(
         [&state] {
             return nlohmann::json{


### PR DESCRIPTION
## 🎯T115 — App-channel state slices are the blessed, documented telemetry/metadata pipe

The app-channel state registry (`registerStateSlice` + `state_query`, 🎯T92.5) was already a working **pull** pipe. Spyder **v0.56.0** just landed the read side — `app_state_slices` (discovery) and `app_state_capture_*` (a spyder-side poller of `state_query` that streams a slice into a timestamped buffer). This PR blesses + documents the pipe as THE *app-defines / spyder-reads* telemetry contract and proves it in-repo.

### What shipped (all ge-side)

- **agents-guide.md** — new *"State slices — the telemetry/metadata pipe"* subsection:
  - slices are **entirely app-defined** (`registerStateSlice`); ge hard-codes none.
  - discovery / pull / capture tool table (`app_state_slices`, `app_state`, `app_state_capture_*`).
  - a **recommended geometry/physics schema convention** (`units` + `bodies[pos/vel/angle]` + `constraints[rest/current]` + `sensors[distance-to-nearest]` + `bounds`) so spyder renders/compares physics uniformly *across* games — explicitly a convention, not a requirement.
  - the **iOS one-time local-network-permission gotcha**.
- **CLAUDE.md / AGENTS.md** — matching App Channel note (kept in sync).
- **sample/tiltbuggy** — a conforming `geometry` slice (+ `Scene::buggyVelocity`) as the in-repo proving ground.

### Validated end-to-end against spyder v0.56.0 (desktop)

`app_state_slices` → `app_state{geometry}` → `app_state_capture_start{interval_ms:50}` → `app_input{accel}` → `app_state_capture_get`: 1338 timestamped samples, the buggy's `pos`/`vel` evolving across the captured window (**593 distinct positions**). Slice discovery returned `["geometry","iap","scene"]`; the pull returned the schema-shaped JSON.

### Notes

- **No engine/libge change.** An app-side push (`state_subscribe` + per-frame `stateStreamTick`) was prototyped, then **reverted** once spyder v0.56.0 proved it polls `state_query` instead — the push had no consumer, and acceptance #3 explicitly allows a documented poll pattern when push is unnecessary. libge is byte-identical to master, so `verify-prebuilds` is untouched and no prebuild refresh is needed.
- **Consumer-confirm:** multimaze2's own geometry slice on a *physical device* rides multimaze2 🎯T48.
- **Bundled bullseye state:** the branch also carries a prior-session bullseye commit (`cf0057a`) that was unpushed on local master — it **retired 🎯T114** (autorelease fix; its device validation completed 2026-06-14) and **created 🎯T115**. Included so origin gets current target state; the squash collapses it. This PR then retires 🎯T115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
