### PR TITLE
🎯T117 Header-only box2d→state-slice convenience (ge::box2d::worldGeometry)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -822,8 +822,14 @@ the in-repo proving ground. Consumers may also volunteer a representative
 `example` payload per slice (optional third arg to `registerStateSlice`, 🎯T116),
 emitted in the hello as a `{name, example}` descriptor (spyder ≥ v0.57.0) so an
 agent gets a filter-writing template at connect time; slices without one keep the
-compact bare-string form. See `agents-guide.md` → "State slices" for the schema
-and the iOS local-network-permission gotcha.
+compact bare-string form. **box2d consumers** populate a physics slice in one
+line with `ge::box2d::worldGeometry(worldId)` (header-only `<ge/box2d_slice.h>`,
+🎯T117) — it walks the whole `b2World` via `b2World_OverlapAABB` and emits the
+geometry schema (body names → `id`s, shape outlines under `shapes`);
+`ge::box2d::body(label, id)` is the curated single-body form. `libge` stays
+box2d-free (the header is consumed only by apps that already link box2d). See
+`agents-guide.md` → "State slices" for the schema and the iOS
+local-network-permission gotcha.
 
 - **`<ge/appchannel.h>`** — `registerMethod`, `installFromEnv`, `push`,
   `active`, `applyTimeControl` (run-loop pacing), `perfEmit` (custom perf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -822,8 +822,14 @@ the in-repo proving ground. Consumers may also volunteer a representative
 `example` payload per slice (optional third arg to `registerStateSlice`, 🎯T116),
 emitted in the hello as a `{name, example}` descriptor (spyder ≥ v0.57.0) so an
 agent gets a filter-writing template at connect time; slices without one keep the
-compact bare-string form. See `agents-guide.md` → "State slices" for the schema
-and the iOS local-network-permission gotcha.
+compact bare-string form. **box2d consumers** populate a physics slice in one
+line with `ge::box2d::worldGeometry(worldId)` (header-only `<ge/box2d_slice.h>`,
+🎯T117) — it walks the whole `b2World` via `b2World_OverlapAABB` and emits the
+geometry schema (body names → `id`s, shape outlines under `shapes`);
+`ge::box2d::body(label, id)` is the curated single-body form. `libge` stays
+box2d-free (the header is consumed only by apps that already link box2d). See
+`agents-guide.md` → "State slices" for the schema and the iOS
+local-network-permission gotcha.
 
 - **`<ge/appchannel.h>`** — `registerMethod`, `installFromEnv`, `push`,
   `active`, `applyTimeControl` (run-loop pacing), `perfEmit` (custom perf

--- a/Module.mk
+++ b/Module.mk
@@ -243,6 +243,7 @@ ge/TEST_SRC = \
 	$(ge)/src/text_test.cpp \
 	$(ge)/src/sprite_test.cpp \
 	$(ge)/src/appchannel_test.cpp \
+	$(ge)/src/box2d_slice_test.cpp \
 	$(ge)/src/transform_test.cpp \
 	$(ge)/src/Ortho_test.cpp \
 	$(ge)/src/gesture_test.cpp \

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -459,12 +459,28 @@ it; it just won't get uniform cross-game tooling.
 ```
 
 `bodies` is the only near-universal key; `constraints` / `sensors` appear only
-when the game has them (`sample/tiltbuggy`'s `geometry` slice exposes just the one
-dynamic body; a maze-style consumer fills in walls as `constraints` and goal
-proximity as `sensors`). Validated end-to-end against spyder v0.56.0 on desktop:
-`app_state_slices → app_state{geometry} → app_state_capture_start →
-app_input{accel} → app_state_capture_get` shows the buggy's `pos`/`vel` evolving
-across the captured window.
+when the game has them.
+
+**box2d consumers get the `bodies` array for free (🎯T117).**
+`ge::box2d::worldGeometry(worldId)` (header-only `<ge/box2d_slice.h>`) walks every
+body/shape in a `b2World` via `b2World_OverlapAABB` and emits this schema directly
+— box2d body names (`b2BodyDef.name`) become the `id`s, each body's shape outlines
+ride under a `shapes` key. Drop it into a getter and add the bits box2d can't know
+(`units`, `bounds`, app-specific `constraints`/`sensors`):
+
+```cpp
+ge::appchannel::registerStateSlice("geometry", [&]{
+    auto g = ge::box2d::worldGeometry(state.scene->worldId());
+    g["units"] = "metres";
+    return g;                                   // or ge::box2d::body(label, id) for one
+});
+```
+
+`sample/tiltbuggy`'s `geometry` slice is wired this way — its named `arena`
+(walls + surface patches) and `buggy` bodies. Validated end-to-end against spyder
+v0.57.0 on desktop: `app_state{geometry, select:'.bodies[]|select(.id=="buggy")'}`
+returns the buggy's live `pos`/`vel`/`angle`/`shapes` directly — no screenshot, no
+pixel parsing.
 
 **iOS gotcha — local-network permission (one-time).** On a physical iOS device
 the app dials spyder over the LAN, which trips iOS's Local Network privacy prompt

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -591,6 +591,27 @@ targets:
     origin: manual
     discovered: 2026-06-14
     achieved: 2026-06-14
+  T117:
+    name: ge offers a header-only box2d→state-slice convenience so apps expose physics objects as data without per-body boilerplate
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - <ge/box2d_slice.h> exists, header-only. libge stays physics-agnostic (box2d is APP_LIBS, never compiled into libge); the header is consumed only by apps that already link box2d.
+    - ge::box2d::worldGeometry(b2WorldId) walks EVERY shape via b2World_OverlapAABB over a world-covering AABB, groups shapes by body, and emits the recommended geometry schema { bodies:[{id, pos, vel, angle, shapes:[outline]}] }. `id` is the box2d body name (b2BodyDef.name) when set, else a synthesised id. Zero per-body app code.
+    - ge::box2d::body(label, b2BodyId) and bodyState(b2BodyId) provide the curated single-body form ({id,pos,vel,angle} / {pos,vel,angle}); worldGeometry and body emit the same body shape so an app can mix them.
+    - No appchannel/libge coupling and no app-side jq — the helpers are pure box2d→nlohmann::json; the app drops the result into its own registerStateSlice getter.
+    - 'A ge unit test builds a tiny in-test b2World (a named dynamic circle + an unnamed static box), calls worldGeometry, and asserts the enumeration: both bodies present, name used as id, pos/vel/angle correct, circle + polygon shape outlines emitted.'
+    - sample/tiltbuggy's geometry slice is rewired through ge::box2d (proving ground), replacing its hand-rolled body formatting; agents-guide documents the helper.
+    context: 'Follow-on to 🎯T116 / 🎯T115. User goal: let an agent process physics objects directly (spyder app_state) instead of screenshotting + parsing pixels. ge can''t auto-own the slice (it has no world handle; b2World is app-owned) but box2d DOES know every body — b2World_OverlapAABB over a world-covering AABB calls back with a b2ShapeId for every shape (static/sleeping/dynamic), and b2Shape_GetBody → b2BodyId gives name/pos/vel/angle. So a header-only helper reads the world out into the recommended geometry schema with one line in the app. Light-touch: ge formats, the app composes (can add constraints/sensors/custom fields). Design co-developed with the user 2026-06-14. Released together with T116.'
+    tags:
+    - telemetry
+    - app-channel
+    - box2d
+    - physics
+    - dev-tooling
+    origin: manual
+    discovered: 2026-06-14
   T12:
     name: ge's render subsystem synthesises ⌥WASD accelerometer events uniformly across all host contexts
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -593,16 +593,17 @@ targets:
     achieved: 2026-06-14
   T117:
     name: ge offers a header-only box2d→state-slice convenience so apps expose physics objects as data without per-body boilerplate
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 2.0
     acceptance:
-    - <ge/box2d_slice.h> exists, header-only. libge stays physics-agnostic (box2d is APP_LIBS, never compiled into libge); the header is consumed only by apps that already link box2d.
-    - ge::box2d::worldGeometry(b2WorldId) walks EVERY shape via b2World_OverlapAABB over a world-covering AABB, groups shapes by body, and emits the recommended geometry schema { bodies:[{id, pos, vel, angle, shapes:[outline]}] }. `id` is the box2d body name (b2BodyDef.name) when set, else a synthesised id. Zero per-body app code.
-    - ge::box2d::body(label, b2BodyId) and bodyState(b2BodyId) provide the curated single-body form ({id,pos,vel,angle} / {pos,vel,angle}); worldGeometry and body emit the same body shape so an app can mix them.
-    - No appchannel/libge coupling and no app-side jq — the helpers are pure box2d→nlohmann::json; the app drops the result into its own registerStateSlice getter.
-    - 'A ge unit test builds a tiny in-test b2World (a named dynamic circle + an unnamed static box), calls worldGeometry, and asserts the enumeration: both bodies present, name used as id, pos/vel/angle correct, circle + polygon shape outlines emitted.'
-    - sample/tiltbuggy's geometry slice is rewired through ge::box2d (proving ground), replacing its hand-rolled body formatting; agents-guide documents the helper.
+    - 'DONE: include/ge/box2d_slice.h exists, header-only. libge stays box2d-free (verify-prebuilds green, no prebuild change); the header is consumed only by apps that already link box2d.'
+    - 'DONE: ge::box2d::worldGeometry(b2WorldId) walks every shape via b2World_OverlapAABB over a world-covering AABB, groups shapes by body, emits { bodies:[{id, pos, vel, angle, shapes:[outline]}] }; b2BodyDef.name → id, else synthesised. Validated live vs spyder v0.57.0: app_state{geometry} returned `arena` (4 wall segments + 2 surface polygons) and `buggy` (1 polygon), both named.'
+    - 'DONE: ge::box2d::body(label, b2BodyId) and bodyState(b2BodyId) provide the curated single-body form; same body shape as worldGeometry so they compose.'
+    - 'DONE: no appchannel/libge coupling and no app-side jq — pure box2d→nlohmann::json; the app drops the result into its own getter (and a server-side jq `select` picks bodies out, e.g. .bodies[]|select(.id=="buggy")).'
+    - 'DONE: src/box2d_slice_test.cpp — 2 tests over a tiny in-test b2World (named dynamic circle + unnamed static box) asserting enumeration, name→id, pos/vel/angle, and circle/polygon outlines. 240/240 pass.'
+    - 'DONE: sample/tiltbuggy''s geometry slice rewired through ge::box2d::worldGeometry (Scene exposes worldId(); chassis/ground named buggy/arena), dropping the hand-rolled formatting; agents-guide.md + CLAUDE.md + AGENTS.md document the helper.'
     context: 'Follow-on to 🎯T116 / 🎯T115. User goal: let an agent process physics objects directly (spyder app_state) instead of screenshotting + parsing pixels. ge can''t auto-own the slice (it has no world handle; b2World is app-owned) but box2d DOES know every body — b2World_OverlapAABB over a world-covering AABB calls back with a b2ShapeId for every shape (static/sleeping/dynamic), and b2Shape_GetBody → b2BodyId gives name/pos/vel/angle. So a header-only helper reads the world out into the recommended geometry schema with one line in the app. Light-touch: ge formats, the app composes (can add constraints/sensors/custom fields). Design co-developed with the user 2026-06-14. Released together with T116.'
     tags:
     - telemetry
@@ -612,6 +613,7 @@ targets:
     - dev-tooling
     origin: manual
     discovered: 2026-06-14
+    achieved: 2026-06-14
   T12:
     name: ge's render subsystem synthesises ⌥WASD accelerometer events uniformly across all host contexts
     status: achieved

--- a/include/ge/box2d_slice.h
+++ b/include/ge/box2d_slice.h
@@ -1,0 +1,133 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// 🎯T117 — box2d → app-channel state-slice convenience. Header-only on purpose:
+// libge stays physics-agnostic (it never links box2d — box2d is APP_LIBS), so
+// only apps that already use box2d ever pull this in. The app owns its b2World;
+// these helpers read it out into the recommended geometry schema (see
+// agents-guide.md → "State slices") so a connected agent can process physics
+// objects directly via spyder `app_state{...}` instead of screenshotting and
+// parsing pixels.
+//
+// Two entry points, same body shape so they compose:
+//   worldGeometry(world) — automatic: walk EVERY shape via b2World_OverlapAABB
+//                          and emit one entry per body. Zero per-body code.
+//   body(id, bodyId)     — curated: one labelled body, when an app wants only
+//                          specific bodies or its own labels.
+//
+// ge formats; the app composes. Drop the result into a registerStateSlice
+// getter and add whatever else the game wants (constraints, sensors, custom
+// fields) alongside it:
+//
+//   ge::appchannel::registerStateSlice("physics",
+//       [&]{ return ge::box2d::worldGeometry(state.worldId); });
+//
+// Shapes are reported in body-local coordinates; apply the body's `pos` + `angle`
+// to place them in the world. Positions are in the world's own units (box2d
+// doesn't know if that's metres or pixels — the app should add a `units` field
+// if it cares).
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <box2d/box2d.h>
+#include <nlohmann/json.hpp>
+
+namespace ge::box2d {
+
+// {pos:[x,y], vel:[vx,vy], angle} for one body, in the world's own units.
+inline nlohmann::json bodyState(b2BodyId body) {
+    const b2Vec2 p = b2Body_GetPosition(body);
+    const b2Vec2 v = b2Body_GetLinearVelocity(body);
+    return {
+        {"pos",   {p.x, p.y}},
+        {"vel",   {v.x, v.y}},
+        {"angle", b2Rot_GetAngle(b2Body_GetRotation(body))},
+    };
+}
+
+// {id, pos, vel, angle} — bodyState() plus a caller-supplied label.
+inline nlohmann::json body(std::string_view id, b2BodyId b) {
+    nlohmann::json j = bodyState(b);
+    j["id"] = std::string(id);
+    return j;
+}
+
+namespace detail {
+
+// Compact body-local outline of one shape: {type, …defining params…}.
+inline nlohmann::json shapeOutline(b2ShapeId s) {
+    switch (b2Shape_GetType(s)) {
+        case b2_circleShape: {
+            const b2Circle c = b2Shape_GetCircle(s);
+            return {{"type", "circle"}, {"center", {c.center.x, c.center.y}}, {"radius", c.radius}};
+        }
+        case b2_capsuleShape: {
+            const b2Capsule c = b2Shape_GetCapsule(s);
+            return {{"type", "capsule"},
+                    {"p1", {c.center1.x, c.center1.y}}, {"p2", {c.center2.x, c.center2.y}},
+                    {"radius", c.radius}};
+        }
+        case b2_segmentShape: {
+            const b2Segment seg = b2Shape_GetSegment(s);
+            return {{"type", "segment"},
+                    {"p1", {seg.point1.x, seg.point1.y}}, {"p2", {seg.point2.x, seg.point2.y}}};
+        }
+        case b2_polygonShape: {
+            const b2Polygon poly = b2Shape_GetPolygon(s);
+            nlohmann::json verts = nlohmann::json::array();
+            for (int i = 0; i < poly.count; ++i)
+                verts.push_back({poly.vertices[i].x, poly.vertices[i].y});
+            return {{"type", "polygon"}, {"vertices", std::move(verts)}};
+        }
+        default:
+            return {{"type", "other"}};
+    }
+}
+
+} // namespace detail
+
+// Walk EVERY shape in `world` (via b2World_OverlapAABB over a world-covering
+// AABB — static, sleeping, and dynamic alike) and emit the recommended geometry
+// schema: { "bodies": [ {id, pos, vel, angle, shapes:[outline…]} ] }, one entry
+// per body, shapes grouped under their body. `id` is the box2d body name
+// (b2BodyDef.name) when the app set one, else a synthesised "body_<n>". Pass the
+// app's world AABB as `bounds` to clip the walk; the default covers everything.
+inline nlohmann::json worldGeometry(
+    b2WorldId world,
+    b2AABB bounds = {{-1.0e9f, -1.0e9f}, {1.0e9f, 1.0e9f}}) {
+    struct Accum {
+        std::vector<std::uint64_t>                     order;   // first-seen body order
+        std::unordered_map<std::uint64_t, nlohmann::json> byBody;
+    } acc;
+
+    auto collect = [](b2ShapeId shape, void* ctx) -> bool {
+        auto& a = *static_cast<Accum*>(ctx);
+        const b2BodyId b   = b2Shape_GetBody(shape);
+        const std::uint64_t key = b2StoreBodyId(b);
+        auto it = a.byBody.find(key);
+        if (it == a.byBody.end()) {
+            const char* name = b2Body_GetName(b);
+            nlohmann::json entry = body(
+                (name && name[0]) ? std::string(name)
+                                  : "body_" + std::to_string(a.order.size()),
+                b);
+            entry["shapes"] = nlohmann::json::array();
+            it = a.byBody.emplace(key, std::move(entry)).first;
+            a.order.push_back(key);
+        }
+        it->second["shapes"].push_back(detail::shapeOutline(shape));
+        return true;  // keep visiting — we want every shape
+    };
+    b2World_OverlapAABB(world, bounds, b2DefaultQueryFilter(), collect, &acc);
+
+    nlohmann::json bodies = nlohmann::json::array();
+    for (std::uint64_t k : acc.order) bodies.push_back(std::move(acc.byBody[k]));
+    return {{"bodies", std::move(bodies)}};
+}
+
+} // namespace ge::box2d

--- a/sample/tiltbuggy/src/Scene.cpp
+++ b/sample/tiltbuggy/src/Scene.cpp
@@ -51,6 +51,7 @@ struct Scene::Impl {
         {
             b2BodyDef bdef = b2DefaultBodyDef();
             bdef.type = b2_staticBody;
+            bdef.name = "arena";  // 🎯T117 names ride through worldGeometry as ids
             groundId = b2CreateBody(worldId, &bdef);
         }
 
@@ -79,6 +80,7 @@ struct Scene::Impl {
         {
             b2BodyDef bdef = b2DefaultBodyDef();
             bdef.type = b2_dynamicBody;
+            bdef.name = "buggy";  // 🎯T117 → geometry slice id
             bdef.position = {0.0f, 0.0f};
             bdef.linearDamping = 0.5f;
             bdef.angularDamping = 2.0f;
@@ -152,8 +154,8 @@ Pose Scene::buggyPose() const {
     return { pos.x, pos.y, b2Rot_GetAngle(rot) };
 }
 
-b2Vec2 Scene::buggyVelocity() const {
-    return b2Body_GetLinearVelocity(i_->chassisId);
+b2WorldId Scene::worldId() const {
+    return i_->worldId;
 }
 
 float Scene::halfExtent() const {

--- a/sample/tiltbuggy/src/Scene.h
+++ b/sample/tiltbuggy/src/Scene.h
@@ -36,9 +36,9 @@ public:
     // Pose of the buggy chassis in world coords.
     Pose buggyPose() const;
 
-    // Linear velocity of the buggy chassis in world coords (m/s). Exposed for
-    // the 🎯T115 geometry state slice (bodies carry position + velocity).
-    b2Vec2 buggyVelocity() const;
+    // The box2d world — exposed so the 🎯T117 geometry slice can read every body
+    // out via ge::box2d::worldGeometry(scene->worldId()).
+    b2WorldId worldId() const;
 
     // Extent of the world (walls at ±halfExtent).
     float halfExtent() const;

--- a/sample/tiltbuggy/src/main.cpp
+++ b/sample/tiltbuggy/src/main.cpp
@@ -11,6 +11,7 @@
 #include "Scene.h"
 
 #include <ge/appchannel.h>
+#include <ge/box2d_slice.h>
 #include <ge/iap.h>
 #include <ge/Protocol.h>
 #include <ge/Resource.h>
@@ -97,32 +98,29 @@ int main(int argc, char* argv[]) {
     // an input sequence). TiltBuggy has one dynamic body; a richer consumer
     // (multimaze2's marbles + walls) fills in the constraints / sensors arrays.
     ge::appchannel::registerStateSlice("geometry", [&state] {
-        nlohmann::json bodies = nlohmann::json::array();
-        if (state.scene) {
-            const auto p = state.scene->buggyPose();
-            const auto v = state.scene->buggyVelocity();
-            bodies.push_back({
-                {"id",    "buggy"},
-                {"pos",   {p.x, p.y}},
-                {"vel",   {v.x, v.y}},
-                {"angle", p.angle},
-            });
-        }
+        // 🎯T117 The whole physics world as data, read out by
+        // ge::box2d::worldGeometry — no hand-rolled body formatting. It walks
+        // every body/shape (the arena walls, surface patches, and the named
+        // "buggy"); the app just adds the unit + bounds context box2d can't know.
+        nlohmann::json geo = state.scene
+            ? ge::box2d::worldGeometry(state.scene->worldId())
+            : nlohmann::json{{"bodies", nlohmann::json::array()}};
+        geo["units"] = "metres";
         const float e = state.scene ? state.scene->halfExtent() : 0.0f;
-        return nlohmann::json{
-            {"units",  "metres"},
-            {"bodies", std::move(bodies)},
-            {"bounds", {{"min", {-e, -e}}, {"max", {e, e}}}},
-        };
+        geo["bounds"] = {{"min", {-e, -e}}, {"max", {e, e}}};
+        return geo;
     },
-    // 🎯T116 A representative example payload — the slice's shape (one body),
-    // advertised in the hello so a connected agent can write a jq filter (e.g.
-    // `.bodies[0].vel`) without a state_query round-trip. One-line snapshot of
-    // the shape, not live data.
+    // 🎯T116 example — the slice's shape, for filter-writing without a
+    // state_query round-trip. One representative named body with a shape outline
+    // (worldGeometry emits one entry per body, shapes grouped under it).
     nlohmann::json{
         {"units",  "metres"},
         {"bodies", nlohmann::json::array({
-            {{"id", "buggy"}, {"pos", {0.0, 0.0}}, {"vel", {0.0, 0.0}}, {"angle", 0.0}},
+            {{"id", "buggy"}, {"pos", {0.0, 0.0}}, {"vel", {0.0, 0.0}}, {"angle", 0.0},
+             {"shapes", nlohmann::json::array({
+                 {{"type", "polygon"},
+                  {"vertices", {{-0.03, -0.016}, {0.03, -0.016}, {0.03, 0.016}, {-0.03, 0.016}}}},
+             })}},
         })},
         {"bounds", {{"min", {-0.625, -0.625}}, {"max", {0.625, 0.625}}}},
     });

--- a/src/box2d_slice_test.cpp
+++ b/src/box2d_slice_test.cpp
@@ -1,0 +1,93 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+//
+// 🎯T117 — ge::box2d state-slice helpers, exercised against a tiny in-test
+// b2World. (box2d is linked into the test binary via APP_LIBS.)
+
+#include <ge/box2d_slice.h>
+
+#include <doctest.h>
+
+#include <string>
+
+using nlohmann::json;
+
+TEST_CASE("ge::box2d::worldGeometry enumerates every body with names + shapes") {
+    b2WorldDef wd = b2DefaultWorldDef();
+    wd.gravity = {0.0f, 0.0f};
+    b2WorldId world = b2CreateWorld(&wd);
+
+    // A named dynamic circle at (1,2) moving right at 3.
+    b2BodyDef bd = b2DefaultBodyDef();
+    bd.type           = b2_dynamicBody;
+    bd.position       = {1.0f, 2.0f};
+    bd.linearVelocity = {3.0f, 0.0f};
+    bd.name           = "marble";
+    b2BodyId marble = b2CreateBody(world, &bd);
+    b2ShapeDef sd = b2DefaultShapeDef();
+    b2Circle circle = {{0.0f, 0.0f}, 0.5f};
+    b2CreateCircleShape(marble, &sd, &circle);
+
+    // An unnamed static box at the origin.
+    b2BodyDef bd2 = b2DefaultBodyDef();  // default type is static
+    b2BodyId wall = b2CreateBody(world, &bd2);
+    b2Polygon box = b2MakeBox(1.0f, 0.5f);
+    b2CreatePolygonShape(wall, &sd, &box);
+
+    const json geo = ge::box2d::worldGeometry(world);
+    REQUIRE(geo.contains("bodies"));
+    const auto& bodies = geo["bodies"];
+    REQUIRE(bodies.size() == 2);
+
+    // Broad-phase walk order isn't guaranteed — find each by identity.
+    const json* marbleJ = nullptr;
+    const json* wallJ   = nullptr;
+    for (const auto& b : bodies) {
+        if (b.contains("id") && b["id"] == "marble") marbleJ = &b;
+        else                                         wallJ   = &b;
+    }
+    REQUIRE(marbleJ);
+    REQUIRE(wallJ);
+
+    // Marble: named, pos/vel/angle read out, one circle shape (radius 0.5).
+    CHECK((*marbleJ)["pos"][0].get<float>() == doctest::Approx(1.0f));
+    CHECK((*marbleJ)["pos"][1].get<float>() == doctest::Approx(2.0f));
+    CHECK((*marbleJ)["vel"][0].get<float>() == doctest::Approx(3.0f));
+    CHECK((*marbleJ)["vel"][1].get<float>() == doctest::Approx(0.0f));
+    CHECK((*marbleJ)["angle"].get<float>() == doctest::Approx(0.0f));
+    REQUIRE((*marbleJ)["shapes"].size() == 1);
+    CHECK((*marbleJ)["shapes"][0]["type"] == "circle");
+    CHECK((*marbleJ)["shapes"][0]["radius"].get<float>() == doctest::Approx(0.5f));
+
+    // Wall: unnamed → synthesised id, one polygon shape (4 verts).
+    CHECK((*wallJ)["id"].get<std::string>().rfind("body_", 0) == 0);
+    REQUIRE((*wallJ)["shapes"].size() == 1);
+    CHECK((*wallJ)["shapes"][0]["type"] == "polygon");
+    CHECK((*wallJ)["shapes"][0]["vertices"].size() == 4);
+
+    b2DestroyWorld(world);
+}
+
+TEST_CASE("ge::box2d::body / bodyState produce the curated single-body form") {
+    b2WorldDef wd = b2DefaultWorldDef();
+    wd.gravity = {0.0f, 0.0f};
+    b2WorldId world = b2CreateWorld(&wd);
+
+    b2BodyDef bd = b2DefaultBodyDef();
+    bd.type           = b2_dynamicBody;
+    bd.position       = {5.0f, -1.0f};
+    bd.linearVelocity = {0.0f, 2.0f};
+    b2BodyId id = b2CreateBody(world, &bd);
+
+    const auto st = ge::box2d::bodyState(id);
+    CHECK(st["pos"][0].get<float>() == doctest::Approx(5.0f));
+    CHECK(st["pos"][1].get<float>() == doctest::Approx(-1.0f));
+    CHECK(st["vel"][1].get<float>() == doctest::Approx(2.0f));
+    CHECK_FALSE(st.contains("id"));  // bodyState is unlabelled
+
+    const auto labelled = ge::box2d::body("hero", id);
+    CHECK(labelled["id"] == "hero");
+    CHECK(labelled["pos"][0].get<float>() == doctest::Approx(5.0f));
+
+    b2DestroyWorld(world);
+}


### PR DESCRIPTION
## 🎯T117 — header-only box2d → state-slice convenience

Follow-on to 🎯T116/🎯T115. The motivating ask: analyse a game's physics objects *directly* (spyder `app_state`) instead of screenshotting and parsing pixels. ge can't own the slice (the `b2World` is app-owned), but **box2d knows every body** — so a header-only helper reads the world out into the recommended geometry schema.

### `include/ge/box2d_slice.h` (header-only — `libge` stays box2d-free)

- **`worldGeometry(b2WorldId)`** — walks **every** shape via `b2World_OverlapAABB` over a world-covering AABB, groups shapes by body, emits `{ bodies:[{id, pos, vel, angle, shapes:[outline]}] }`. box2d body names (`b2BodyDef.name`) become `id`s; unnamed bodies get a synthesised id. **Zero per-body app code.**
- **`body(label, b2BodyId)` / `bodyState(b2BodyId)`** — curated single-body form, same shape so they compose. No appchannel/libge coupling, no app-side jq.

### Proving ground + tests

- `sample/tiltbuggy`'s `geometry` slice is **rewired through `worldGeometry`** (Scene exposes `worldId()`; chassis/ground named `buggy`/`arena`), dropping the hand-rolled body formatting + the now-unused `buggyVelocity`.
- `src/box2d_slice_test.cpp` — 2 tests over a tiny in-test `b2World` (named dynamic circle + unnamed static box) asserting enumeration, name→id, pos/vel/angle, circle/polygon outlines. **240/240 pass.**
- Docs: `agents-guide.md`, `CLAUDE.md`, `AGENTS.md`.

### Validated end-to-end vs spyder v0.57.0 (desktop)

`app_state{geometry}` returned the whole world — `arena` (4 wall `segment`s + 2 surface-patch `polygon`s) and `buggy` (1 `polygon`), both named — and a server-side jq `select:'.bodies[]|select(.id=="buggy")'` picked the buggy out directly. No screenshot, no pixel parsing.

**No libge change** → prebuilts untouched (`verify-prebuilds` green). The branch carries the T117 creation + retirement bullseye auto-commits (squash collapses them).

**Releases together with 🎯T116** (already on master) as v0.60.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
