### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/release-ged.yml
+++ b/.github/workflows/release-ged.yml
@@ -12,11 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ged/go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
@@ -73,7 +73,7 @@ jobs:
           echo "track=${TRACK}"     >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: temurin
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/verify-prebuilds.yml
+++ b/.github/workflows/verify-prebuilds.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout (no submodules, no LFS download)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
           lfs: false


### PR DESCRIPTION
## What

Bump GitHub Actions to their Node-24-native majors to clear the Node-20 runtime deprecation. GitHub force-migrates deprecated (Node-20) actions to Node 24 on **2026-06-16**; pinning ahead avoids surprise behaviour changes.

## Bump map

| action | after |
|---|---|
| actions/checkout | v6 |
| actions/setup-go | v6 |
| actions/setup-node | v6 |
| actions/cache | v5 |
| actions/setup-java | v5 |
| actions/setup-python | v6 |
| actions/upload-artifact | v7 |
| actions/download-artifact | v8 |

upload/download bumped as a matched pair (v7 ↔ v8) so the artifact handshake stays compatible.

Part of 🎯T4 (fleet-wide Actions deprecation sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)