### PR TITLE
🎯T133 Android swapchain gets a depth buffer (Vulkan + GLES3)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1153,9 +1153,10 @@ targets:
     achieved: 2026-06-30
   T133:
     name: Android swapchain provides a depth buffer (Vulkan + GLES3) so depth testing works
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 5.0
     acceptance:
     - 'The Android swapchain pass exposes a real depth(-stencil) attachment on BOTH backends: SokolContext_android sets desc.environment.defaults.depth_format and pass.swapchain.depth_format to a concrete format (e.g. SG_PIXELFORMAT_DEPTH or DEPTH_STENCIL), not SG_PIXELFORMAT_NONE; the GLES path requests SDL_GL_DEPTH_SIZE>=24 (currently 0); the Vulkan path (VkM) creates a per-frame/per-image depth VkImage+view and binds it into the sokol swapchain descriptor.'
     - A pipeline with depth.compare=LESS_EQUAL + depth.write_enabled correctly occludes later-submitted geometry behind nearer earlier-submitted geometry on-device, on a Vulkan device (Mali-G710) and on a GLES3 fallback device.
@@ -1172,6 +1173,7 @@ targets:
     - esfera2-audit
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-06-30
   T134:
     name: Render-on-demand idles a static screen even while an accelerometer/sensor stream is active
     status: achieved

--- a/prebuilt/android-arm64/libge.a
+++ b/prebuilt/android-arm64/libge.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d6a90981ae25525d7e6ad3c71c426684ecf7bccddb1c5d7bc188b0415d35eb95
-size 17100836
+oid sha256:f978f1701e738600c1a9ff3e19ddb42f3d9d5241f2dbf8ffb7968d5cc37565b4
+size 17107980

--- a/prebuilt/android-arm64/manifest.json
+++ b/prebuilt/android-arm64/manifest.json
@@ -25,7 +25,7 @@
   },
   "prebuilts": {
     "prebuilt/android-arm64/libbox2d.a": "85a8ce40deb59b2974892fe760af787d4c21142e01387d4912a85e86486254e2",
-    "prebuilt/android-arm64/libge.a": "d6a90981ae25525d7e6ad3c71c426684ecf7bccddb1c5d7bc188b0415d35eb95",
+    "prebuilt/android-arm64/libge.a": "f978f1701e738600c1a9ff3e19ddb42f3d9d5241f2dbf8ffb7968d5cc37565b4",
     "prebuilt/android-arm64/libliteparser.a": "ab444e1270fd03c88ceb27fb93e8185b5a9ecf48c961e03cddae9c2698d5193c",
     "prebuilt/android-arm64/liblunasvg_ge.a": "cc63e5a0de8f7daab5259564e94d9538527f6a9716ac93e065c2bf4a7b95f585",
     "prebuilt/android-arm64/liblz4_ge.a": "7f2617fd20adbeaf156e9722f4986584e30fde605771113d10e7683703029a08",
@@ -195,7 +195,7 @@
     "src/SdlContext_android.cpp": "9877caf9cdad736c025a3c2eb5a519c77ac1cf400fbc604b1bf319927a7ced6a",
     "src/SessionHost.mm": "4fadd2466e8a73f4d32e08aa24555aed33a4e73af6441e01bb9a498b620deecd",
     "src/Signal.cpp": "046894fcec4714783605a5db81815178fd100994210922c97cc33e90fae4309c",
-    "src/SokolContext_android.cpp": "0d3f747e069b8ce4aeaa52907af7936aea9598f6cd8ddf65f341ce665b330b9a",
+    "src/SokolContext_android.cpp": "1896624a495e1f3dde797e6aa06f8d58ee119c2631e55e1c417f25f8f7da5d62",
     "src/appchannel.cpp": "92526169e5c7c76860ed066f9647dd36c6758550f16db3e8a72e2f0d241536e0",
     "src/appchannel_internal.h": "e7df9d1945c56681bb94b499af4b86eb71a108e8614e5ce8be1ac9ddd6e88fce",
     "src/audio.cpp": "ca77dc5018c813a98b6dea1ccc06ea0a3b3f68e17914188be6c88ca21bb1df21",

--- a/src/SokolContext_android.cpp
+++ b/src/SokolContext_android.cpp
@@ -132,7 +132,7 @@ struct GlesM final : SokolContext::M {
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
         SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-        SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
+        SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);  // 🎯T133: swapchain depth buffer
         SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   8);
         SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
         SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,  8);
@@ -157,7 +157,7 @@ struct GlesM final : SokolContext::M {
 
         sg_desc desc{};
         desc.environment.defaults.color_format = SG_PIXELFORMAT_RGBA8;  // T39
-        desc.environment.defaults.depth_format = SG_PIXELFORMAT_NONE;
+        desc.environment.defaults.depth_format = SG_PIXELFORMAT_DEPTH;   // 🎯T133
         desc.environment.defaults.sample_count = 1;
         desc.logger.func = sokolLog;
         ge_sokol_set_api(ge_sokol_bind_gles());
@@ -197,13 +197,16 @@ struct GlesM final : SokolContext::M {
         act.colors[0].clear_value  = clearColor
             ? sg_color{clearColor[0], clearColor[1], clearColor[2], clearColor[3]}
             : sg_color{0.f, 0.f, 0.f, 1.f};
+        act.depth.load_action  = SG_LOADACTION_CLEAR;   // 🎯T133: clear depth to far
+        act.depth.store_action = SG_STOREACTION_DONTCARE;
+        act.depth.clear_value  = 1.0f;
 
         auto& sc = pass.swapchain;
         sc.width        = width;
         sc.height       = height;
         sc.sample_count = 1;
         sc.color_format = SG_PIXELFORMAT_RGBA8;
-        sc.depth_format = SG_PIXELFORMAT_NONE;
+        sc.depth_format = SG_PIXELFORMAT_DEPTH;   // 🎯T133: matches EGL 24-bit depth
         sc.gl.framebuffer = 0;  // FBO 0 == default EGL window framebuffer
         sg_begin_pass(&pass);
     }
@@ -267,6 +270,18 @@ struct VkM final : SokolContext::M {
     std::vector<VkImage>       images;
     std::vector<VkImageView>   views;
 
+    // 🎯T133: per-image depth attachment. sokol's swapchain pass needs a
+    // depth-stencil image/view when depth_format != NONE; without it the
+    // consumer's depth.compare/write are silently no-ops (sokol-metal is
+    // lenient and tests anyway, but GLES/Vulkan honour NONE). VK_FORMAT_D32_SFLOAT
+    // is what sokol maps SG_PIXELFORMAT_DEPTH to, and is a guaranteed-supported
+    // depth attachment format. One per swapchain image so frames in flight don't
+    // share a depth buffer.
+    static constexpr VkFormat  kDepthFormat = VK_FORMAT_D32_SFLOAT;
+    std::vector<VkImage>        depthImages;
+    std::vector<VkDeviceMemory> depthMemories;
+    std::vector<VkImageView>    depthViews;
+
     struct Sync {
         VkSemaphore presentComplete = VK_NULL_HANDLE;
         VkSemaphore renderFinished  = VK_NULL_HANDLE;
@@ -299,7 +314,7 @@ struct VkM final : SokolContext::M {
 
         sg_desc desc{};
         desc.environment.defaults.color_format = sgFormat(swapchainFormat);
-        desc.environment.defaults.depth_format = SG_PIXELFORMAT_NONE;
+        desc.environment.defaults.depth_format = SG_PIXELFORMAT_DEPTH;   // 🎯T133
         desc.environment.defaults.sample_count = 1;
         desc.environment.vulkan.instance           = instance;
         desc.environment.vulkan.physical_device    = physicalDevice;
@@ -446,8 +461,70 @@ struct VkM final : SokolContext::M {
             if (view) vkDestroyImageView(device, view, nullptr);
         views.clear();
         images.clear();
+        // 🎯T133: tear down the depth attachments alongside the color images.
+        for (VkImageView v : depthViews)    if (v) vkDestroyImageView(device, v, nullptr);
+        for (VkImage img : depthImages)     if (img) vkDestroyImage(device, img, nullptr);
+        for (VkDeviceMemory m : depthMemories) if (m) vkFreeMemory(device, m, nullptr);
+        depthViews.clear();
+        depthImages.clear();
+        depthMemories.clear();
         if (swapchain) vkDestroySwapchainKHR(device, swapchain, nullptr);
         swapchain = VK_NULL_HANDLE;
+    }
+
+    // 🎯T133: pick a DEVICE_LOCAL memory type for the depth image.
+    uint32_t findMemoryType(uint32_t typeBits, VkMemoryPropertyFlags want) {
+        VkPhysicalDeviceMemoryProperties mp;
+        vkGetPhysicalDeviceMemoryProperties(physicalDevice, &mp);
+        for (uint32_t i = 0; i < mp.memoryTypeCount; ++i)
+            if ((typeBits & (1u << i)) && (mp.memoryTypes[i].propertyFlags & want) == want)
+                return i;
+        return UINT32_MAX;
+    }
+
+    // 🎯T133: one depth image + view per swapchain image, at the current extent.
+    // Called from createSwapchain after the color views exist.
+    bool createDepthResources(uint32_t count) {
+        depthImages.resize(count, VK_NULL_HANDLE);
+        depthMemories.resize(count, VK_NULL_HANDLE);
+        depthViews.resize(count, VK_NULL_HANDLE);
+        for (uint32_t i = 0; i < count; ++i) {
+            VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+            ici.imageType     = VK_IMAGE_TYPE_2D;
+            ici.format        = kDepthFormat;
+            ici.extent        = {extent.width, extent.height, 1};
+            ici.mipLevels     = 1;
+            ici.arrayLayers   = 1;
+            ici.samples       = VK_SAMPLE_COUNT_1_BIT;
+            ici.tiling        = VK_IMAGE_TILING_OPTIMAL;
+            ici.usage         = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+            ici.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+            ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            if (!vkOk(vkCreateImage(device, &ici, nullptr, &depthImages[i]), "vkCreateImage(depth)"))
+                return false;
+
+            VkMemoryRequirements mr;
+            vkGetImageMemoryRequirements(device, depthImages[i], &mr);
+            uint32_t mt = findMemoryType(mr.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            if (mt == UINT32_MAX) { SPDLOG_ERROR("no DEVICE_LOCAL memory for depth image"); return false; }
+            VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+            mai.allocationSize  = mr.size;
+            mai.memoryTypeIndex = mt;
+            if (!vkOk(vkAllocateMemory(device, &mai, nullptr, &depthMemories[i]), "vkAllocateMemory(depth)"))
+                return false;
+            vkBindImageMemory(device, depthImages[i], depthMemories[i], 0);
+
+            VkImageViewCreateInfo vi{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+            vi.image                       = depthImages[i];
+            vi.viewType                    = VK_IMAGE_VIEW_TYPE_2D;
+            vi.format                      = kDepthFormat;
+            vi.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+            vi.subresourceRange.levelCount = 1;
+            vi.subresourceRange.layerCount = 1;
+            if (!vkOk(vkCreateImageView(device, &vi, nullptr, &depthViews[i]), "vkCreateImageView(depth)"))
+                return false;
+        }
+        return true;
     }
 
     bool createSwapchain() {
@@ -521,6 +598,8 @@ struct VkM final : SokolContext::M {
             if (!vkOk(vkCreateImageView(device, &vi, nullptr, &views[i]), "vkCreateImageView"))
                 return false;
         }
+
+        if (!createDepthResources(actualCount)) return false;  // 🎯T133
 
         sync.resize(std::max<size_t>(2, actualCount));
         VkSemaphoreCreateInfo si{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
@@ -667,15 +746,20 @@ struct VkM final : SokolContext::M {
         act.colors[0].clear_value  = clearColor
             ? sg_color{clearColor[0], clearColor[1], clearColor[2], clearColor[3]}
             : sg_color{0.f, 0.f, 0.f, 1.f};
+        act.depth.load_action  = SG_LOADACTION_CLEAR;   // 🎯T133: clear depth to far
+        act.depth.store_action = SG_STOREACTION_DONTCARE;
+        act.depth.clear_value  = 1.0f;
 
         auto& sc = pass.swapchain;
         sc.width        = width;
         sc.height       = height;
         sc.sample_count = 1;
         sc.color_format = sgFormat(swapchainFormat);
-        sc.depth_format = SG_PIXELFORMAT_NONE;
+        sc.depth_format = SG_PIXELFORMAT_DEPTH;   // 🎯T133
         sc.vulkan.render_image               = vkHandle(images[imageIndex]);
         sc.vulkan.render_view                = vkHandle(views[imageIndex]);
+        sc.vulkan.depth_stencil_image        = vkHandle(depthImages[imageIndex]);  // 🎯T133
+        sc.vulkan.depth_stencil_view         = vkHandle(depthViews[imageIndex]);   // 🎯T133
         sc.vulkan.render_finished_semaphore  = vkHandle(s.renderFinished);
         sc.vulkan.present_complete_semaphore = vkHandle(s.presentComplete);
         sg_begin_pass(&pass);


### PR DESCRIPTION
## Problem

The Android swapchain was created with `depth_format = SG_PIXELFORMAT_NONE` on **both** backends (GLES set `SDL_GL_DEPTH_SIZE 0`; the Vulkan path tracked only color images). With no depth attachment, a consumer pipeline's `depth.compare` / `write_enabled` are silent no-ops.

sokol-**metal** is lenient — it depth-tests anyway — so the gap was invisible on Apple, and `tiltbuggy` (a single convex back-face-culled globe) never needed depth. But sokol-GLES3 and the Vulkan backend honour `NONE`, so any consumer that depth-tests **opaque geometry against translucent geometry** breaks on Android.

**esfera2** is the first such consumer: opaque chess pieces drawn before the translucent two-pass sphere cells were repainted over by those cells, so they vanished everywhere except where they cleared the sphere's silhouette.

## Fix

Provide a real depth buffer for the swapchain pass on both backends:

- **GLES3** — request `SDL_GL_DEPTH_SIZE 24`; set env + swapchain `depth_format = SG_PIXELFORMAT_DEPTH`; clear depth each frame.
- **Vulkan** — create one `VK_FORMAT_D32_SFLOAT` depth image + view per swapchain image (sokol maps `SG_PIXELFORMAT_DEPTH → D32_SFLOAT`, a guaranteed depth-attachment format), bind via `sc.vulkan.depth_stencil_image/view`, recreate on swapchain resize, clear depth each frame.

Change is entirely under `#if __ANDROID__` — Apple/desktop paths untouched.

## Verification

On-device, esfera2 pieces render correctly across the full sphere on:
- **Pixel Tablet** (Mali-G710, **Vulkan**)
- **SM-G9980** (**GLES3** fallback)

matching the Metal reference. No sokol validation errors.

## Follow-up

Apple/desktop currently relies on sokol-metal's depth leniency rather than an explicit depth attachment — a latent risk if a future sokol bump tightens that. Worth a separate target to make Metal's swapchain depth explicit too. Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)