### PR TITLE
ios: add consumer vendor/include to header search paths (T139)

### DIFF
--- a/tools/ios-build/build_project.rb
+++ b/tools/ios-build/build_project.rb
@@ -313,6 +313,7 @@ module GE
         [
           File.join(proj_rel, 'src'),
           File.join(proj_rel, 'include'),
+          File.join(proj_rel, 'vendor/include'),   # consumer's vendored headers (harmless if absent)
           File.join(ge_rel, 'include'),
           File.join(ge_rel, 'vendor/include'),
           # Header-only deps + SDL3 stack — lifted from their submodules


### PR DESCRIPTION
`build_project.rb`'s `header_search_paths` included the consumer's `src/` and `include/` plus ge's own `vendor/include`, but **not the consumer's `vendor/include`**. Apps that vendor headers there (e.g. yourworld2's `dr_mp3.h`) failed to compile for iOS (`'dr_mp3.h' file not found`).

Add `proj_rel/vendor/include` to the header search paths — harmless when the directory is absent.

**Verified:** yourworld2's iOS *simulator* target now builds (`BUILD SUCCEEDED`) via `make ge/ios` (no signing needed for the simulator). This is the first half of 🎯T139; the template's non-recursive `src/*.cpp` default glob and per-app resource list are consumer-side config (the consumer overrides them in their generated `project.rb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)