### PR TITLE
ge-icon-gen: alpha-free iOS App Store marketing icon (T138)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ ge ships a build-time tool, `bin/ge-icon-gen`, that takes one source SVG and wri
 
 **What gets generated:**
 
-- iOS: `Assets.xcassets/AppIcon.appiconset/icon.png` (1024×1024) + `Contents.json`. Single-source mode (Xcode 15+) — Xcode generates the smaller per-size icons automatically at build time.
+- iOS: `Assets.xcassets/AppIcon.appiconset/icon.png` (1024×1024) + `Contents.json`. Single-source mode (Xcode 15+) — Xcode generates the smaller per-size icons automatically at build time. The icon is written as **opaque RGB with no alpha channel** (🎯T138): App Store Connect / Transporter validation rejects a marketing icon that carries *any* alpha channel, even one whose pixels are all opaque, so ge-icon-gen flattens it. This is the only iOS icon (single-source), so it covers the whole iOS surface; the Android round / adaptive icons keep their alpha (they need transparent corners / a masked foreground).
 - Android legacy: `mipmap-{m,h,xh,xxh,xxxh}dpi/ic_launcher.png` and matching `_round.png` at 48 / 72 / 96 / 144 / 192 px.
 - Android adaptive: `drawable/ic_launcher_foreground.png` (432×432, full-bleed master SVG) + `drawable/ic_launcher_background.xml` (solid color from `ge/APP_ICON_BG_COLOR`, default white) + `mipmap-anydpi-v26/ic_launcher.xml` and `_round.xml` adaptive manifests.
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1481,7 +1481,7 @@ targets:
     achieved: 2026-07-01
   T138:
     name: App-icon generator emits an opaque (alpha-free) iOS App Store marketing icon
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1500,6 +1500,22 @@ targets:
     - app-store
     - ge-icon-gen
     - multimaze
+    origin: manual
+    discovered: 2026-07-01
+    achieved: 2026-07-01
+  T139:
+    name: ge/ios-init generates a CMakeLists that builds a consuming app out of the box
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'The iOS project ge/ios-init scaffolds (ios/CMakeLists.txt) builds the consuming app without per-app hand-editing: it discovers the app''s sources (or the app declares them once in a way the template consumes), bundles the app''s runtime assets, and — critically — runs a sokol-shdc pre-build step to generate the app''s build/shaders/*.h from shaders/*.glsl (GE_SHDC_LANGS), matching what the Makefile build does. Today the generated CMakeLists hardcodes a stale source list, globs obsolete bgfx *.bin shaders, omits most runtime assets, and has no shader-generation step, so a consuming app''s iOS target neither compiles nor bundles correctly.'
+    - 'Verify with yourworld2: `make ios` then an xcodebuild compile (signing disabled) of the YourWorld target succeeds after only `ge/ios-init` + adding the app''s own sources/assets through the supported mechanism — no manual CMake surgery on the generated file (which is gitignored and regenerated).'
+    context: 'Precise diagnosis (2026-07-01, from yourworld2 T58 audit; corrected after a configure probe). The CANONICAL and ONLY viable iOS path is ge tools/ios-build/build_project.rb (xcodeproj gem) from tools/ios-template/project.rb.in. A consumer''s local CMake path is NOT viable: `make ios` -> `cmake -G Xcode` does `add_subdirectory(<app>/ge)` but ge has no CMakeLists.txt (it builds via Module.mk/Make), so cmake configure fails immediately (''does not contain a CMakeLists.txt file''). So build_project.rb is the path to fix. Concrete gaps in project.rb.in: (1) game_sources globs `src/*.cpp`+`src/*.mm` NON-recursively, dropping a consumer''s src/ui/*.cpp (yourworld2 has src/ui/Draw.cpp, Overlay.cpp); (2) no sokol-shdc pre-build phase generating build/shaders/*.h from the app''s shaders/*.glsl (sokol-shdc is vendored at ge/vendor/github.com/floooh/sokol-tools-bin/bin/osx_arm64/sokol-shdc; template still references bgfx shaders/metal); (3) resources are a manual list — consumer declares manifest/meshes/cubemap/flags/icons/audio/poi.json. Fix project.rb.in, verify a consumer (yourworld2 and/or the sample) compiles with signing disabled. Then full T58 is only Apple signing + device. Shared-engine infra (affects all consumers) — deliberate ge PR + sample test, not an inline consumer hack.'
+    tags:
+    - yourworld2-audit
+    - ios
+    - build
     origin: manual
     discovered: 2026-07-01
   T14:

--- a/tools/icon-gen.cpp
+++ b/tools/icon-gen.cpp
@@ -12,7 +12,9 @@
 // At least one of --ios-out / --android-res-out is required.
 //
 // iOS output (single-source mode, Xcode 15+):
-//   <appiconset-dir>/icon.png         1024×1024 master
+//   <appiconset-dir>/icon.png         1024×1024 master — OPAQUE RGB, no alpha
+//                                     channel (🎯T138: App Store validation
+//                                     rejects any alpha on the marketing icon)
 //   <appiconset-dir>/Contents.json    universal/ios platform manifest
 //
 // Android output:
@@ -115,7 +117,40 @@ bool writePng(const std::string& path,
     return stbi_write_png(path.c_str(), w, h, 4, rgba.data(), w * 4) != 0;
 }
 
-bool rasterToPng(const std::string& svg, int size, const std::string& outPath) {
+// 🎯T138 Flatten RGBA → opaque RGB (drops the alpha channel entirely),
+// compositing any non-opaque pixel over `bg`. Apple's App Store marketing-icon
+// validation rejects a 1024×1024 icon that carries an alpha channel AT ALL —
+// even when every pixel is opaque (alpha 255), which a full-bleed rasterized
+// icon is. A full-bleed icon has alpha 255 throughout, so `bg` never actually
+// shows; it's just a safe fallback for a stray transparent edge.
+std::vector<uint8_t> flattenToRgb(const std::vector<uint8_t>& rgba, int w, int h,
+                                  uint8_t bg = 255) {
+    const size_t n = static_cast<size_t>(w) * h;
+    std::vector<uint8_t> rgb(n * 3);
+    for (size_t i = 0; i < n; ++i) {
+        const uint32_t a = rgba[i * 4 + 3];
+        for (int c = 0; c < 3; ++c)
+            rgb[i * 3 + c] = static_cast<uint8_t>(
+                (rgba[i * 4 + c] * a + bg * (255 - a) + 127) / 255);
+    }
+    return rgb;
+}
+
+bool writePngRgb(const std::string& path,
+                 const std::vector<uint8_t>& rgb,
+                 int w, int h) {
+    auto slash = path.rfind('/');
+    if (slash != std::string::npos) {
+        if (!mkpath(path.substr(0, slash))) return false;
+    }
+    return stbi_write_png(path.c_str(), w, h, 3, rgb.data(), w * 3) != 0;
+}
+
+// `opaque` (🎯T138): write 3-channel RGB with NO alpha channel — required for
+// the iOS App Store marketing icon. Default false keeps the RGBA channel, which
+// Android round / adaptive icons need (transparent corners / a masked layer).
+bool rasterToPng(const std::string& svg, int size, const std::string& outPath,
+                 bool opaque = false) {
     auto pixels = ge::rasterizeSvgToPixels(svg, size, size);
     if (pixels.isNull()) {
         std::fprintf(stderr, "icon-gen: rasterizeSvgToPixels failed at %d×%d for %s\n",
@@ -123,7 +158,11 @@ bool rasterToPng(const std::string& svg, int size, const std::string& outPath) {
         return false;
     }
     unpremultiply(pixels.rgba);
-    if (!writePng(outPath, pixels.rgba, pixels.width, pixels.height)) {
+    const bool ok = opaque
+        ? writePngRgb(outPath, flattenToRgb(pixels.rgba, pixels.width, pixels.height),
+                      pixels.width, pixels.height)
+        : writePng(outPath, pixels.rgba, pixels.width, pixels.height);
+    if (!ok) {
         std::fprintf(stderr, "icon-gen: writePng failed for %s\n", outPath.c_str());
         return false;
     }
@@ -203,7 +242,10 @@ bool generateIos(const std::string& svg, const std::string& outDir) {
         std::fprintf(stderr, "icon-gen: cannot create %s\n", outDir.c_str());
         return false;
     }
-    if (!rasterToPng(svg, 1024, outDir + "/icon.png")) return false;
+    // 🎯T138 opaque=true: NO alpha channel — App Store validation rejects any
+    // alpha on the 1024 marketing icon. This is the only iOS icon (single-source
+    // appiconset), so it's the whole iOS surface; Android keeps its alpha.
+    if (!rasterToPng(svg, 1024, outDir + "/icon.png", /*opaque=*/true)) return false;
     if (!writeFile(outDir + "/Contents.json", kIosContentsJson)) {
         std::fprintf(stderr, "icon-gen: failed to write %s/Contents.json\n", outDir.c_str());
         return false;


### PR DESCRIPTION
Fixes 🎯T138 — surfaced shipping **multimaze2 3.0.0** to the App Store: Transporter upload failed with *"The large app icon … can't be transparent or contain an alpha channel."*

**Root cause:** `ge::rasterizeSvgToPixels` emits premultiplied RGBA, so ge-icon-gen's `icon.png` was RGBA (alpha all 255 — a full-bleed opaque icon, but the *channel* exists). Apple rejects any alpha channel on the marketing icon, regardless of pixel values.

**Fix:** flatten the iOS marketing icon to **opaque 3-channel RGB** (no alpha channel). `flattenToRgb()` composites over an opaque background (irrelevant for a full-bleed icon, a safe fallback for a stray transparent edge); `writePngRgb()` writes 3 channels. `rasterToPng` gains an `opaque` flag, set **only** for `ios/…/AppIcon.appiconset/icon.png`.

**Decision (acceptance #3):** alpha is dropped **only for the iOS marketing icon** — which, in single-source mode (Xcode 15+), is the *only* iOS icon, so it covers the whole iOS surface. Android round / adaptive icons keep their alpha (transparent corners / masked foreground) via the unchanged RGBA path.

**Verified** (generate from `sample/tiltbuggy/icons/icon.svg`):
- iOS `icon.png` → PNG **colortype 2 (RGB, no alpha)** ✓
- Android `ic_launcher_round.png` → PNG **colortype 6 (RGBA)** ✓ (alpha preserved)

Tool-source change only (not a `libge` input) — `verify-prebuilds` stays green, no prebuild regen. multimaze2 can drop its local alpha-flatten stopgap once the ge submodule is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)