### PR TITLE
Close Plateau P hygiene gaps (README, STABILITY, release-surface, PR residue)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MAKEFLAGS += -j$(shell sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || ech
 # Specific targets the delegator should proxy. `check` is the big one:
 # runs the 24-cell e2e matrix via the sample's Module.mk integration.
 .PHONY: all check matrix-test check-list unit-test init clean run bullseye ruby-test \
-        python-test dispatch-null-safety-test \
+        python-test dispatch-null-safety-test release-surface-test \
         prebuild prebuild-ios-arm64 prebuild-ios-arm64-simulator prebuild-android-arm64 \
         prebuild-libge prebuild-libge-ios-arm64 prebuild-libge-ios-arm64-simulator \
         prebuild-libge-android-arm64 \
@@ -47,7 +47,7 @@ cell.%:
 # Standing invariants for /cv. Exit 0 means all green; non-zero means a
 # violation. Stdout is relayed verbatim to the agent. Ignores untracked
 # files so the user's WIP notes don't trip the check.
-bullseye: ruby-test python-test
+bullseye: ruby-test python-test dispatch-null-safety-test release-surface-test
 	@git diff --quiet && git diff --cached --quiet \
 	  && echo "✓ no uncommitted changes to tracked files" \
 	  || { echo "✗ uncommitted changes to tracked files"; \
@@ -82,6 +82,11 @@ dispatch-null-safety-test:
 	    tools/sokol-dispatch/generated/ge_sokol_dispatch.c \
 	    tools/sokol-dispatch/nullsafe_test.c
 	@build/dispatch-nullsafe-test
+
+# 🎯T145 acceptance #2: NDEBUG strips app-channel; default (non-GE_SERVER)
+# sample link dead-strips stream/encode symbols.
+release-surface-test:
+	@tools/check-release-surface.sh
 
 # ── Prebuilt static libs (🎯T73) ───────────────────────────────────
 #

--- a/README.md
+++ b/README.md
@@ -1,127 +1,146 @@
 # ge
 
-Rendering and asset engine for Dawn (WebGPU) + SDL3 applications. Provides RAII resource management, manifest-driven asset loading, and animation utilities.
+Reusable C++20 rendering engine for Squz games. Built on **sokol_gfx** + **SDL3**
+(Metal on Apple; Vulkan with GLES3 fallback on Android). Consumed as a git
+submodule via `Module.mk`.
+
+**Dev control plane is [spyder](https://github.com/marcelocantos/spyder)** —
+device inventory, launch, tweaks, logs, screenshots, and the optional H.264
+stream relay. The historical `ged` daemon has been removed (🎯T145 / Plateau P).
+Do not start `ged`; there is no `make ged` / `bin/ged`.
+
+Full agent/developer guide: [`AGENTS.md`](AGENTS.md). Agent-drivable app-channel
+and state slices: [`agents-guide.md`](agents-guide.md).
+
+## Architecture
+
+| Layer | Owner |
+|---|---|
+| Simulation, render, encode, wire schema, app-channel **client** | **ge** |
+| Inventory, launch, reserve, inspect, tweak, logs, dashboard, stream **relay** | **spyder** |
+
+**Primary modality — direct:** `ge::run` opens a local window (or mobile
+surface). Dev builds dial spyder's app-channel when `SPYDER_APP_CHANNEL` is set
+(injected by `spyder launch`). No streaming required for inspect/tweak/logs.
+
+**Optional — server stream (dev only):** a `GE_SERVER=1` build dials spyder's
+H.264 relay; a native player attaches through spyder. Release (`NDEBUG`) builds
+compile the app-channel out; streaming lives only in the server-mode variant.
+
+## Quick start
+
+```bash
+# Control plane (once per machine)
+brew services start spyder   # or: spyder serve
+
+# Sample (from this repo)
+make                         # builds sample/tiltbuggy
+make -C sample/tiltbuggy run # or: bin/tiltbuggy from the sample tree
+make unit-test               # doctest suite
+```
+
+## Integrating into an app
+
+```makefile
+BUILD_DIR := build
+CXX := clang++
+
+-include ge/Module.mk
+ge/Module.mk:
+	git submodule update --init --recursive
+
+CXXFLAGS := -std=c++20 -O2 $(ge/INCLUDES)
+# … link against $(ge/LIB) $(ge/SDL_LIBS) and platform frameworks
+```
+
+```cpp
+#include <ge/SessionHost.h>
+
+int main() {
+    MyState state;
+    ge::run([&](ge::Context ctx) -> ge::RunConfig {
+        auto app = std::make_shared<MyApp>(ctx);
+        return {
+            .onUpdate   = [&, app](float dt) { app->update(dt, state); },
+            .onRender   = [&, app](const ge::Context& c) {
+                auto p = c.swapchainPass();  // open before any draws
+                app->render(state, c);
+            },
+            .onEvent    = [&, app](const SDL_Event& e) { app->event(e, state); },
+            .onShutdown = [&, app]() { app->shutdown(); },
+        };
+    });
+}
+```
+
+See `sample/tiltbuggy/` for a complete reference app.
 
 ## Dependencies
 
-- [Dawn](https://dawn.googlesource.com/dawn) — WebGPU implementation
-- [SDL3](https://libsdl.org/) + SDL3_image — Windowing, input, image loading
-- [spdlog](https://github.com/gabime/spdlog) — Logging (header-only)
-- [linalg.h](https://github.com/sgorsten/linalg) — Linear algebra (header-only)
-- [doctest](https://github.com/doctest/doctest) — Testing (header-only)
-- [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) — Constrained Delaunay triangulation *(opt-in only; not linked into `libge.a`. Non-commercial license — see [`NOTICES.md`](NOTICES.md#triangle-j-r-shewchuk) before shipping in a paid product.)*
+Vendored under `vendor/` (submodules / amalgams):
 
-Dependencies live in `vendor/` as git submodules or vendored sources.
-
-## Integration
-
-ge is consumed as a git submodule. The parent project includes `Module.mk` from its own Makefile:
-
-```makefile
-include ge/Module.mk
-```
-
-This exports variables (`ge/LIB`, `ge/OBJ`, `ge/FRAMEWORK_LIBS`, etc.) and pattern rules for compiling engine sources, test sources, and shaders. There is no standalone build.
-
-### iOS / iPad orientation lock
-
-iPadOS 26+ ignores the usual single-knob orientation locks (`UIRequiresFullScreen`, `SDL_HINT_ORIENTATIONS`, `requestGeometryUpdate`, even narrowing `UISupportedInterfaceOrientations` alone). To lock orientation on iPad you need **two things together**:
-
-1. Narrow `UISupportedInterfaceOrientations` in your `Info.plist` to the orientation(s) you want allowed (e.g. just `LandscapeLeft` and `LandscapeRight` for a landscape-only game).
-2. Set `SessionHostConfig.orientation = wire::kOrientationLandscape` (or any other non-zero `wire::kOrientation*`) when calling `ge::run`. The engine handles the swizzle (Apple TN3192 — `prefersInterfaceOrientationLocked`) for you, and the orientation source is linked into `libge` from v0.3.0+.
-
-Plist alone won't survive iPad multitasking; the swizzle alone locks "whatever orientation the user happened to be holding the device in at launch." Ship both. Setting different `kOrientation*` constants is currently a boolean ("lock yes/no"); the plist decides *which* orientation. See `agents-guide.md` and `CLAUDE.md` (search for "iOS orientation lock") for the full background and history.
+- [sokol](https://github.com/floooh/sokol) — `sokol_gfx` (Metal / Vulkan / GLES3)
+- [SDL3](https://libsdl.org/) + SDL3_image + SDL3_ttf
+- [spdlog](https://github.com/gabime/spdlog), [linalg.h](https://github.com/sgorsten/linalg), [doctest](https://github.com/doctest/doctest)
+- [lunasvg](https://github.com/sammycage/lunasvg) (SVG), box2d (optional consumer), sqlite/sqlpipe
+- [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) — **opt-in only**; not linked into `libge.a`. Non-commercial license — see [`NOTICES.md`](NOTICES.md)
 
 ## Structure
 
 ```
-include/        Public headers (one per class)
-src/            Implementation + unit tests (*_test.cpp)
-shaders/        Test shaders (app shaders live in the parent project)
-vendor/         Third-party dependencies
-Module.mk       Build rules and exported variables
+include/ge/     Public headers
+src/            Implementation + *_test.cpp
+tools/          Player, prebuild, matrix, ship, icon-gen, iOS/Android templates
+sample/         In-tree apps (tiltbuggy is the reference)
+prebuilt/       Cross-arch libge.a + manifests
+Module.mk       Consumer build contract
+AGENTS.md       Canonical project instructions
 ```
 
-## API Overview
+## Public surface (pointers)
 
-### Platform
+| Area | Headers |
+|------|---------|
+| Session / entry | `SessionHost.h` — `ge::run`, `Context`, `RunConfig` |
+| Render | `Pass.h`, `sprite.h`, `svg.h`, `png.h`, `text.h`, `debug.h` |
+| Input / UI | `button.h`, `sdl_input.h`, `gesture.h`, `long_press.h` |
+| Animation | `GlobeController.h`, `DampedRotation.h`, `DampedValue.h` |
+| Platform | `audio.h`, `iap.h`, `log.h`, `Resource.h` |
+| Dev channel | `appchannel.h` (compiled out under `NDEBUG`) |
+| Wire protocol | `Protocol.h` (`wire::`), player/bridge headers |
 
-| Header | Description |
-|--------|-------------|
-| `GpuContext.h` | WebGPU device/queue/surface lifecycle |
-| `SdlContext.h` | RAII SDL3 window and event loop setup |
+Stability catalogue (pre-1.0): [`STABILITY.md`](STABILITY.md).
 
-### Resources
+## Player stream address
 
-| Header | Description |
-|--------|-------------|
-| `WgpuResource.h` | Move-only RAII wrapper for WebGPU handles (`BufferHandle`, `TextureHandle`, `SamplerHandle`, etc.) |
-| `CaptureTarget.h` | Offscreen framebuffer with RGBA8 color texture for readback |
-| `ShaderUtil.h` | `ge::loadProgram()` — load compiled vertex + fragment shaders |
+Native player default port is **3030** (spyder `serve`). Prefer
+`stream_addr` / `GE_STREAM_ADDR` (legacy aliases: `ged_addr` / `GE_DAEMON_ADDR`).
 
-### Assets
-
-| Header | Description |
-|--------|-------------|
-| `Mesh.h` | Vertex/index buffer pair with binary stream loader |
-| `Texture.h` | GPU texture loaded from image files via SDL3_image |
-| `svg.h` | SVG rasterization, live-document rendering, hit testing, font registration, and post-layout document/element bounds measurement |
-| `Model.h` | Mesh + texture binding |
-| `ModelFormat.h` | `ge::MeshVertex` — vertex layout (pos3f + uv2f) |
-| `ManifestSchema.h` | JSON-serializable manifest types, templated on app metadata |
-| `ManifestLoader.h` | `ge::loadManifest<Meta>()` — loads manifest + mesh pack + textures |
-
-### Animation
-
-| Header | Description |
-|--------|-------------|
-| `DampedRotation.h` | Quaternion rotation with angular velocity and exponential decay |
-| `DampedValue.h` | 1D value with velocity and exponential decay |
-| `DeltaTimer.h` | Frame delta-time tracking |
-
-### Testing
-
-| Header | Description |
-|--------|-------------|
-| `ImageDiff.h` | CPU and GPU pixel comparison (RMS difference) |
-
-## Dev control plane
-
-Use **[spyder](https://github.com/marcelocantos/spyder)** for device inventory, launch, tweaks, logs, screenshots, and the optional H.264 stream relay. The historical `ged` daemon has been removed from this repo.
-
-## Launching the Player with a Specific Stream Relay Address
-
-For automated and scripted launches (CI, matrix testing, agent workflows), point the
-native player at spyder's stream relay (same host/port as `spyder serve`, default
-`127.0.0.1:3030` for local; use the machine LAN IP from a phone).
-
-**Desktop**
 ```bash
+# Desktop
 bin/player --host 127.0.0.1 --port 3030 --name <server-name>
-```
 
-**iOS Simulator** — pass `-stream_addr host:port` as a launch argument :
-```bash
+# iOS Simulator
 xcrun simctl launch <udid> com.squz.player -stream_addr localhost:3030
-```
 
-**iOS Device** — use `devicectl` with `--console-pty` and pass args after `--`:
-```bash
+# iOS device (devicectl)
 xcrun devicectl device process launch --console-pty --device <udid> com.squz.player -- -stream_addr 192.168.1.100:3030
-```
 
-**Android Emulator** — pass `--es stream_addr host:port` to `am start`:
-```bash
+# Android emulator / device
 adb shell am start -n com.squz.player/.GeActivity --es stream_addr 10.0.2.2:3030
-```
-
-**Android Device** — same syntax with the Mac's LAN IP:
-```bash
 adb shell am start -n com.squz.player/.GeActivity --es stream_addr 192.168.1.100:3030
 ```
 
-If the parameter is absent the player falls back to any saved address, then QR scan.
+## iOS orientation lock
+
+On iPadOS 26+ you need **both**:
+
+1. Narrow `UISupportedInterfaceOrientations` in `Info.plist`.
+2. Set `SessionHostConfig.orientation` to a non-zero `wire::kOrientation*`.
+
+Details: `AGENTS.md` (iOS orientation lock).
 
 ## License
 
-See individual files and `vendor/` subdirectories for license terms.
+See individual files and `vendor/` for license terms. Engine code is Apache-2.0
+unless noted. Triangle is not linked into `libge.a` by default — see `NOTICES.md`.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -2,20 +2,21 @@
 
 **Pre-1.0 stability tracking for the `ge` engine.**
 
-Snapshot as of: **v0.1.0** (first release).
+Snapshot as of: **v0.74.0** (Plateau P closed — ged removed; spyder is sole control plane).
 
 ---
 
-
-> **Plateau P (2026-07-11):** the `ged` daemon and its dashboard SPA (`web/`) were **removed**. Dev control plane is [spyder](https://github.com/marcelocantos/spyder); ge keeps app-side app-channel + optional server-mode H.264 encode. Entries below that catalogue `ged` HTTP/MCP routes are **historical** until rewritten.
+> **Plateau P (2026-07-11):** the `ged` daemon and dashboard SPA were **removed**.
+> Dev control plane is [spyder](https://github.com/marcelocantos/spyder).
+> ge keeps the app-side app-channel client + optional `GE_SERVER` H.264 encode.
+> Release-surface oracle: `make release-surface-test` (🎯T145 acceptance #2).
 
 ## Stability commitment
 
 ge is **pre-1.0**. Breaking changes to the public C++ API, CLI / launch
-surface, Makefile / `Module.mk` exports, wire protocol (historical ged HTTP/MCP catalogue retired)
-surface, and file formats may land in any minor release while we remain
-pre-1.0. The pre-1.0 period exists so that these surfaces can be refined
-without ecosystem friction.
+surface, Makefile / `Module.mk` exports, wire protocol, and file formats may
+land in any minor release while we remain pre-1.0. The pre-1.0 period exists
+so that these surfaces can be refined without ecosystem friction.
 
 Once **1.0** ships, every item in the interaction surface catalogue
 below becomes a binding backwards-compatibility contract. Post-1.0
@@ -55,38 +56,44 @@ All public API lives under `include/ge/*.h`.
 
 - `ge::` — primary engine namespace; session host, rendering, platform, I/O, assets, animation.
 - `wire::` — C-style POD structs and constants for the H.264 streaming wire protocol.
-- `tweak::` — runtime parameter tweak system (dashboard-driven live editing).
+- `tweak::` — runtime parameter tweak system (spyder / app-channel live editing).
 - `imgdiff::` — image comparison utilities (testing).
 - Top-level (no namespace) — `DampedRotation`, `DampedValue`, `DeltaTimer`, `SdlContext`, `EventWatchHandle`, `FrameLog<Entry>`.
 
 ### Session host / entry point
 
-- `ge::run(Factory factory, const SessionHostConfig& config = {}) → void`. Blocks until SIGINT or all sessions end; drives the bgfx loop, H.264 pipeline, and per-session state. **Stable**.
+- `ge::run(Factory factory, const SessionHostConfig& config = {}) → void`. Blocks until SIGINT / host exit; drives the sokol frame loop (direct) or server-mode stream path when built with `GE_SERVER_BUILD`. **Stable**.
 - `ge::Factory = std::function<RunConfig(Context)>`. **Stable**.
-- `ge::Context` — cheaply copyable (shared_ptr internals) platform context passed to the factory.
-  - `int width() const` / `int height() const` — **Stable**
+- `ge::Context` — cheaply copyable (shared_ptr internals) platform context.
+  - `drawSafeRectInPts()` / `uiSafeRectInPts()` / `fullRectInPts()` → `Rect` — **Stable** (🎯T60; point space)
+  - `pixelsPerPt()` / `ptsPerPixel()` / `deviceUiScale()` — **Stable**
   - `DeviceClass deviceClass() const` — **Stable**
-  - `std::shared_ptr<sqlpipe::Database> db() const` — **Needs review**. The `db()` getter exposes a concrete `sqlpipe::Database`; interface may change when the persistence story stabilises.
+  - `Pass swapchainPass() const` — **Stable** (🎯T101; open at top of `onRender`)
+  - `std::shared_ptr<sqlpipe::Database> db() const` — **Needs review** (concrete sqlpipe type)
+  - `parallax()`, `fps()` / `frameTime()`, render-on-demand controls — **Needs review** / **Fluid**
 - `ge::DeviceClass : uint8_t { Unknown=0, Phone=1, Tablet=2, Desktop=3 }`. **Stable**.
 - `ge::RunConfig` — designated-initialiser struct of render-loop callbacks.
   - `std::function<void(float dt)> onUpdate` — **Stable**
-  - `std::function<void(int w, int h)> onRender` — **Stable**
+  - `std::function<void(const Context&)> onRender` — **Stable**
   - `std::function<void(const SDL_Event&)> onEvent` — **Stable**
   - `std::function<void()> onShutdown` — **Stable**
+  - Optional: `onBackPressed`, `onMemoryWarning`, `onMetrics` — **Needs review**
 - `ge::SessionHostConfig` — configuration passed to `ge::run`.
   - `int width`, `int height` — **Stable**
-  - `bool headless` — **Stable**
+  - `bool headless` / `hidden` — **Stable** / **Needs review**
   - `const char* orgName`, `const char* appName` — **Stable**
-  - `std::string schemaDdl` — **Needs review**. sqlpipe auto-migration API is still evolving.
-  - `uint8_t sensors` — **Needs review**. Raw bitmask; a named enum would be cleaner before 1.0.
-  - `uint8_t orientation` — **Needs review**. Raw byte; could be typed `wire::Orientation`.
-  - `bool disableScreenSaver` — **Stable**.
+  - `std::string schemaDdl` — **Needs review**
+  - `uint8_t sensors`, `uint8_t orientation` — **Needs review** (raw bytes)
+  - `bool disableScreenSaver`, `parallaxFactor`, `metricsReportThreshold`, `crashDiagnostics` — **Needs review**
+- `ge::renderToPng` / `ge::renderBatch` — headless one-shot PNG (🎯T124). **Stable**.
 
 ### Rendering
 
-- `ge::BgfxConfig` — POD struct (`width`, `height`, `headless`, `title`). **Needs review**.
-- `ge::BgfxContext` — RAII bgfx init/shutdown, exposes `width()`, `height()`, `shouldQuit()`, `window()`. **Needs review**. Exposed to consumers wanting manual bgfx control, but `ge::run` wraps all typical usage.
-- `ge::RenderHost` — abstract interface between engine and render subsystem. Pure-virtual methods: `width()`, `height()`, `deviceClass()`, `send(const wire::SessionConfig&)`, `setEventHandler(...)`, `pumpEvents()`, `beginFrame()`, `endFrame(uint32_t frameNumber)`, `shouldQuit()`. **Fluid**. Introduced in PR #11 (engine/render/bridge split); actively evolving.
+- sokol_gfx is the only live backend (bgfx removed — 🎯T38/T98). Consumers call `sg_*` after opening `Context::swapchainPass()`.
+- `ge::Pass` — move-only RAII pass (swapchain / offscreen). **Stable**.
+- `ge::Sprite` — move-only owning textured quad (🎯T135). **Stable**.
+- `ge::sprite` / `svg` / `png` / `text` / `debug` factories — **Stable** / **Needs review** collectively.
+- `ge::RenderHost` — abstract host interface used internally by direct / server paths. **Fluid**.
 
 ### Protocol types and constants (`wire::`)
 
@@ -178,7 +185,7 @@ ge is consumed via `-include $(ge)/Module.mk`. The contract below is what apps r
 | `APP_SHADERS` | — | `.bin` shader targets under `$(BUILD_DIR)`. | **Stable** |
 | `BUILD_DIR` | `build` | Output root. | **Stable** |
 | `CXX` / `CC` | `clang++` / `clang` | Compilers. | **Stable** |
-| `CXXFLAGS` | `$(ge/CXXFLAGS_BASE) -Isrc` | Overrides OK, must retain `$(ge/INCLUDES)` and `$(ge/BGFX_ALL_INCLUDES)`. | **Stable** |
+| `CXXFLAGS` | `$(ge/CXXFLAGS_BASE) -Isrc` | Overrides OK; must retain `$(ge/INCLUDES)`. | **Stable** |
 | `SDL_CFLAGS` | `-I$(ge)/vendor/sdl3/include` | SDL3 headers. | **Stable** |
 | `FRAMEWORKS` | `$(ge/FRAMEWORKS)` | macOS/iOS frameworks; extend with `+=`. | **Stable** |
 | `APP_LIBS` | `$(ge/BOX2D_OBJ)` | Extra app static libs. | **Needs review**. |
@@ -195,14 +202,13 @@ All namespaced `ge/`; read-only from the consumer.
 
 | Category | Variables | Stability |
 |---|---|---|
-| Includes / flags | `ge/INCLUDES`, `ge/BGFX_ALL_INCLUDES`, `ge/CXXFLAGS_BASE`, `ge/FRAMEWORKS` | **Stable** |
-| Library targets | `ge/LIB` (`libge.a`), `ge/BGFX_LIBS` (`libbgfx.a libbimg.a libbx.a`) | **Stable** |
+| Includes / flags | `ge/INCLUDES`, `ge/CXXFLAGS_BASE`, `ge/FRAMEWORKS` | **Stable** |
+| Library targets | `ge/LIB` (`libge.a`) | **Stable** |
 | | `ge/SDL_LIBS` (prebuilt SDL3 stack) | **Needs review** (hard-coded macos-arm64 paths) |
 | Source / object lists | `ge/SRC`, `ge/OBJ`, `ge/SRC_DIRECT`, `ge/SRC_BROKERED`, `ge/TEST_SRC`, `ge/TEST_OBJ` | **Needs review** (direct/brokered split is internal) |
 | | `ge/BOX2D_OBJ` | **Stable** |
 | | `ge/TRIANGLE_OBJ` | **Fluid** |
-| Shaders | `ge/RENDER_SHADERS`, `ge/APP_SHADERS_GLES`, `ge/RENDER_SHADERS_GLES`, `ge/SHADERC`, `ge/SHADER_DIR`, `ge/SHADERC_VARYINGDEF` | **Stable** |
-| | `ge/SHADERC_PROFILE`, `ge/SHADERC_PLATFORM` | **Needs review** |
+| Shaders | `ge/SHADER_DIR`, sokol-shdc outputs under `$(BUILD_DIR)/…/shaders` | **Stable** / **Needs review** |
 | Binaries | `ge/PLAYER` (`bin/player`) | **Stable** |
 | | `ge/IMGDIFF` (`bin/imgdiff`) | **Fluid** |
 | Test matrix | `ge/CELLS`, `ge/CHECK_CELLS` | **Stable** |
@@ -216,7 +222,7 @@ All namespaced `ge/`; read-only from the consumer.
 | Target | Purpose | Stability |
 |---|---|---|
 | `all`, `run`, `clean` | Standard lifecycle. | **Stable** |
-| `ge/debug` | Debug-variant binary (`bin/$(APP_NAME)-debug`, `-O0 -g -DDEBUG -DBX_CONFIG_DEBUG=1`). | **Stable** |
+| `ge/debug` | Debug-variant binary (`bin/$(APP_NAME)-debug`). | **Stable** |
 | `ge/player`, `ge/imgdiff` | Engine tools. | **Stable** / **Fluid** |
 | `ge/init`, `compile_commands.json` | Dev setup + clangd DB. | **Stable** |
 | `depgraph`, `clean-depgraph` | Dependency-graph SVG. | **Fluid** |
@@ -292,56 +298,27 @@ All share the ASCII prefix `GE2` (`0x474532xx`).
 
 Carried by `kVideoStreamMagic` frames; intercepted by the stream relay, not forwarded verbatim. Payload: `[1-byte flags][optional SPS/PPS][NAL data]`. **Needs review** (internal relay↔player contract).
 
-### Server sideband WebSocket protocol
+### Server sideband (stream path)
 
-- `/ws/server` text JSON and binary frames.
-- Hello (first frame): `{ "type": "hello", "name": <server-name>, "pid": <n>, "version": 6 }`. Relay/session setup rejects mismatched versions.
-- Server → relay text (historical control sideband; control plane is now app-channel) `type`s: `log`, `preview`, `preview_bin`, `accel`, `tweaks`, plus opaque `<any> { type, data }`.
-- relay → server text (historical; player_attached/detached remain on stream sideband) `type`s: `player_attached`, `player_detached`, `tweak_set`, `tweak_reset`.
-- **Needs review** — set of sideband types is growing; may be renamed before 1.0.
+Server-mode builds dial spyder's stream relay (`GE_SERVER` / default `127.0.0.1:3030`).
+Hello + wire frames use `wire::kProtocolVersion`. Control plane (tweaks, logs, state,
+screenshots) is **not** the stream sideband — it is the **app-channel**
+(`SPYDER_APP_CHANNEL`, compiled out under `NDEBUG`; see `appchannel.h`).
 
-### Stream-relay connection addresses
+Historical ged text sideband types (`log`, `preview`, `tweak_*`, …) are **removed**
+with the daemon. Do not document them as live API.
 
-- Default spyder stream relay `:3030` (historical ged was `:42069`) (all interfaces). **Stable**.
-- `GE_STREAM_ADDR` / legacy `GE_DAEMON_ADDR` env var (iOS) in `host:port` format. **Stable**.
-- `--port <n>` CLI override. **Stable**.
-- LAN IP discovery via UDP dial against `8.8.8.8:53`. **Needs review** (air-gapped networks).
+### Dev control plane (spyder — not ge)
 
-### ~~ged HTTP / WebSocket routes~~ (removed)
+| Surface | Where | Stability |
+|---|---|---|
+| Stream relay (H.264 + wire) | spyder `serve` default `:3030` | **Stable** (spyder owns routes) |
+| App-channel msgpack RPC | `SPYDER_APP_CHANNEL=host:port` | **Stable** (ge client; spyder server) |
+| MCP / dashboard / `app_exec` | spyder | **Fluid** (spyder versioned surface) |
+| `make release-surface-test` | ge | **Stable** (T145 NDEBUG + non-server symbol oracle) |
 
-| Route | Method | Purpose | Stability |
-|---|---|---|---|
-| `/api/info` | GET | Server state: `{connected, servers[], sessions}` | **Stable** |
-| `/api/url` | GET | QR pairing URL `{url: "ge-remote://ip:port"}` | **Stable** |
-| `/api/qr` | GET | QR code PNG 256×256 | **Stable** |
-| `/api/state/{type}` | GET | Cached sideband state | **Needs review** |
-| `/api/tweaks` | GET | Alias for `/api/state/tweaks` | **Needs review** |
-| `/api/servers/{id}/select` | POST | Switch all players to server | **Needs review** |
-| `/api/sessions/{sid}/server/{serverID}` | POST | Switch session to server by ID | **Needs review** |
-| `/api/sessions/{sid}/select/{serverName}` | POST | Switch session by name (player-driven) | **Stable** |
-| `/api/sideband` | POST | Forward arbitrary JSON to server(s) | **Needs review** |
-| `/api/tweaks`, `/api/tweaks/reset` | POST | Back-compat wrappers for sideband | **Needs review** |
-| `/api/stop` | POST | SIGINT game server(s) | **Needs review** |
-| `/quitquitquit` | POST | Graceful self-shutdown (supersession) | **Fluid** (internal) |
-| `/ws/wire` | WebSocket | Player binary wire bridge; `?name=...&preference=...` | **Stable** |
-| `/ws/server` | WebSocket | Game server sideband | **Stable** |
-| `/ws/server/wire/{sid}` | WebSocket | Per-session wire from server | **Stable** |
-| `/ws/logs` | WebSocket | Dashboard log stream | **Needs review** |
-| `/ws/preview` | WebSocket | Dashboard preview frames | **Needs review** |
-| `/ws/stream/{sid}` | WebSocket | Browser-playable fMP4 H.264 stream | **Needs review** |
-
-### ~~ged `/mcp`~~ (removed — use spyder MCP / app_exec)
-
-**Removed.** Spyder serves MCP at `http://127.0.0.1:3030/mcp` (`app_exec`).
-
-| Tool | Inputs | Output | Stability |
-|---|---|---|---|
-| `info` | — | Same as `GET /api/info` | **Stable** |
-| `tweak_list` | — | Cached `tweaks` sideband state | **Stable** |
-| `tweak_get` | `name: string` | Tweak object | **Stable** |
-| `tweak_set` | `name`, `value: number` | Confirmation | **Needs review** (numeric only; arrays/bools not yet) |
-| `tweak_reset` | `name?: string` | Confirmation | **Stable** |
-| `logs` | `count?: number` (def 20, max 200) | Newline-separated JSON entries | **Stable** |
+The retired ged HTTP/WebSocket/MCP route catalogue is **gone** (Plateau P). Use
+spyder's docs for current control-plane endpoints.
 
 ### Player launch-param protocol
 
@@ -359,7 +336,7 @@ Carried by `kVideoStreamMagic` frames; intercepted by the stream relay, not forw
 | Priority | Method | Consumed-once? | Stability |
 |---|---|---|---|
 | 1 | `-stream_addr` (legacy `-ged_addr`) "host:port"` launch arg (→ NSUserDefaults) | Yes | **Stable** |
-| 2 | `GE_DAEMON_ADDR` env var (via `devicectl … -e`) | No | **Stable** |
+| 2 | `GE_STREAM_ADDR` / legacy `GE_DAEMON_ADDR` env var | No | **Stable** |
 | 3 | Simulator auto-connect `localhost:3030` | N/A | **Needs review** (hardcoded port) |
 | 4 | QR code scan (fallback) | N/A | **Stable** |
 
@@ -379,27 +356,12 @@ Carried by `kVideoStreamMagic` frames; intercepted by the stream relay, not forw
 - `<app>/shaders/varying.def.sc` must declare `vec3 a_position : POSITION` — `vec2` triggers a glsl-optimizer NaN-clip defect in `-p 300_es` on Android GLES. **Stable** (workaround documented).
 - App-supplied `.sc` files live under `$(ge/SHADER_DIR)` (default `shaders/`); `APP_SHADERS` lists their `.bin` outputs. **Stable**.
 
-#### Shader compilation
+#### Shader compilation (sokol-shdc)
 
-| Target | `--platform` | `-p` | Output |
-|---|---|---|---|
-| macOS / iOS (Metal) | `osx` | `metal` | `$(BUILD_DIR)/shaders/*.bin` |
-| Android (Vulkan / SPIRV) | `android` | `spirv` | `$(BUILD_DIR)/shaders-gles/*.bin` |
+- App shaders: `.glsl` → generated headers under `$(BUILD_DIR)/…/shaders` via sokol-shdc.
+- `GE_SHDC_LANGS` must include the languages needed per platform (Metal + `spirv_vk` for Android Vulkan). **Stable**.
+- Engine sprites/debug ship with internal sokol programs (no consumer bgfx `.sc` pipeline). **Stable**.
 
-- `ge/SHADERC_PROFILE` default `metal`; `ge/SHADERC_PLATFORM` default `osx`. **Stable**.
-- Android uses bgfx Vulkan backend via SPIRV shaders; GLES profiles (`300_es` / `310_es`) are intentionally not used. **Stable**.
-- The Android Gradle `syncAssets` task flattens `build/shaders-gles/` and `build/ge/shaders-gles/` into `assets/build/shaders/` and `assets/build/ge/shaders/` respectively. **Stable**.
-
-#### ge-provided shaders
-
-- `src/render/shaders/ge_compose_vs.sc` / `ge_compose_fs.sc` — fullscreen-quad compose pass.
-- Engine-internal `varying.def.sc` declares `v_texcoord0 : TEXCOORD0`, `a_position : POSITION`, `a_texcoord0 : TEXCOORD0`. **Stable**.
-- Bound sampler: `s_tex` at slot 0. **Stable**.
-
-#### Cross-platform caveats
-
-- Android GLES glsl-optimizer `vec4(vec2, f, f)` bug → workaround via `vec3 a_position` + `vec4(a_position, 1.0)`. **Stable**.
-- Android emulator EGL 3.1 `BAD_CONFIG` on Apple-Silicon host → switched to Vulkan / SPIRV. **Stable**.
 
 ### Asset-manifest format
 
@@ -517,11 +479,10 @@ contract:
 
 ### Wire + stream-relay API
 
-- [ ] **Sideband message set consolidation**: the open set of `/ws/server` text types should be narrowed to a known enum before 1.0.
-- [ ] **`tweak_set` MCP input**: accept non-numeric values (arrays, booleans, strings).
-- [ ] **historical ged HTTP schemas** (removed): several endpoints return ad-hoc JSON; a documented schema (or OpenAPI) would make post-1.0 audits easier.
-- [ ] **Player default port is **3030** (spyder). Prefer `GE_STREAM_ADDR` / `-stream_addr` over hardcoded values.
+- [x] **Player default port is 3030** (spyder). Prefer `GE_STREAM_ADDR` / `-stream_addr` (legacy `ged_*` aliases remain).
+- [x] **Release surface oracle** (`make release-surface-test`): NDEBUG strips app-channel; non-`GE_SERVER` link drops encode symbols.
 - [ ] **Protocol version bump policy**: document when a bump is required (field added vs. structural change vs. renamed message).
+- [ ] **Standalone wire protocol doc**: concise `docs/wire-protocol.md` for second implementers.
 
 ### Build system
 
@@ -548,19 +509,19 @@ contract:
 
 ### Documentation
 
-- [ ] **Agent guide**: added in v0.1.0 (`agents-guide.md`). Keep the Gotchas list pruned against each release.
-- [ ] **Wire protocol reference doc**: concise standalone `docs/wire-protocol.md` would help second implementers (e.g. web player).
+- [x] **README matches sokol + spyder** (post Plateau P). Keep `AGENTS.md` canonical for depth.
+- [ ] **Agent guide**: keep `agents-guide.md` Gotchas pruned against each release.
 
 ---
 
-## Out of scope for 1.0
+## Out of scope for 1.0 (Plateau P parks)
 
-Features deliberately deferred beyond the first stable release:
+Deferred / set-aside after the control-plane migration; not required to ship multimaze/IAP:
 
-- **🎯T1 — WebAssembly in-process game servers.** Single-binary deployment via Wasm — substantial cross-cutting work; not required for 1.0.
-- **🎯T3 — Mip-cache manifest preflight.** Optimisation for reconnect latency. Nice-to-have.
-- **🎯T5 — In-player connection management UI.** Dashboard-driven switching (🎯T6) is the 1.0 path.
-- **🎯T9 — Device tilt parallax as a first-class RunConfig option.** Designing the `Context::parallax()` contract is non-trivial; ship without it.
-- **🎯T11.* — pigeon replacement for the stream WebSocket stack (parked).** Transport swap for LAN / internet NAT traversal. Post-1.0.
+- **🎯T1 — WebAssembly in-process game servers.**
+- **🎯T11.* — pigeon transport** (parked; WebSocket via spyder remains).
+- **🎯T128.* — command-stream ladder** (H.264 via spyder is the closed stream story).
+- **🎯T5 / T6 / T34 — player product UI / player-as-ge-app.**
+- **🎯T33.* — matrix-on-spyder reliability theme.**
 
-These remain on the bullseye frontier and are scheduled independently.
+Active ship cluster: multimaze/IAP (T69, T65.*, T74, T118) and related ergonomics — see `bullseye_frontier`.

--- a/tools/check-release-surface.sh
+++ b/tools/check-release-surface.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# 🎯T145 acceptance #2 — release surface oracle.
+#
+# Class-1 checks that a shipping (NDEBUG, non-server) consumer does not carry
+# the dev control-plane or stream-encode surfaces:
+#
+#   1. App-channel: under -DNDEBUG, appchannel.cpp collapses to empty no-ops —
+#      object is tiny and has no live channel/dial implementation.
+#   2. Stream / encode: GE_SERVER_BUILD is a separate build variant. A default
+#      (direct) link of the sample must not retain ServerSession / VideoEncoder
+#      / runServer symbols (static dead-strip of the brokered TUs that only
+#      runServer references).
+#
+# Exit 0 on pass; non-zero with a clear FAIL line otherwise.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+OUT="${TMPDIR:-/tmp}/ge-release-surface-$$"
+mkdir -p "$OUT"
+trap 'rm -rf "$OUT"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+# ── 1. appchannel under NDEBUG ─────────────────────────────────────
+INCLUDES=(
+  -std=c++20 -c
+  -Iinclude
+  -Ivendor/include
+  -Ivendor/github.com/gabime/spdlog/include
+  -Ivendor/github.com/chriskohlhoff/asio/include
+  -Ivendor/github.com/libsdl-org/SDL/include
+  -Ivendor/sdl3/include
+  -DASIO_STANDALONE
+)
+
+if ! clang++ "${INCLUDES[@]}" -o "$OUT/appchannel-debug.o" src/appchannel.cpp 2>"$OUT/dbg.err"; then
+  cat "$OUT/dbg.err" >&2
+  fail "could not compile appchannel.cpp (debug)"
+fi
+if ! clang++ "${INCLUDES[@]}" -DNDEBUG -o "$OUT/appchannel-release.o" src/appchannel.cpp 2>"$OUT/rel.err"; then
+  cat "$OUT/rel.err" >&2
+  fail "could not compile appchannel.cpp (-DNDEBUG)"
+fi
+
+DBG_SZ=$(wc -c <"$OUT/appchannel-debug.o" | tr -d ' ')
+REL_SZ=$(wc -c <"$OUT/appchannel-release.o" | tr -d ' ')
+# Local (non-export) Channel class is the live implementation; stubs have none.
+DBG_CH=$(nm "$OUT/appchannel-debug.o" 2>/dev/null | grep -c 'appchannel.*Channel' || true)
+REL_CH=$(nm "$OUT/appchannel-release.o" 2>/dev/null | grep -c 'appchannel.*Channel' || true)
+
+# Debug TU is megabytes (full msgpack channel); NDEBUG stubs are a few KB.
+if [[ "$DBG_SZ" -lt 100000 ]]; then
+  fail "debug appchannel.o unexpectedly small ($DBG_SZ bytes) — compile may have failed open"
+fi
+if [[ "$REL_SZ" -gt 50000 ]]; then
+  fail "NDEBUG appchannel.o still large ($REL_SZ bytes; debug=$DBG_SZ) — feature not stripped"
+fi
+if [[ "$DBG_CH" -lt 1 ]]; then
+  fail "debug appchannel.o missing Channel symbols (oracle needle drifted?)"
+fi
+if [[ "$REL_CH" -gt 0 ]]; then
+  fail "NDEBUG appchannel.o still contains Channel symbols ($REL_CH) — live channel remains"
+fi
+pass "appchannel is empty under NDEBUG (debug=${DBG_SZ}B/${DBG_CH} Channel → release=${REL_SZ}B/${REL_CH} Channel)"
+
+# ── 2. default (direct) sample link has no stream/encode symbols ───
+SAMPLE_BIN="sample/tiltbuggy/bin/tiltbuggy"
+if [[ ! -x "$SAMPLE_BIN" ]]; then
+  echo "  (building sample/tiltbuggy for symbol scan…)"
+  make -C sample/tiltbuggy -j"$(sysctl -n hw.ncpu 2>/dev/null || echo 4)" >/dev/null
+fi
+[[ -x "$SAMPLE_BIN" ]] || fail "no sample binary at $SAMPLE_BIN"
+
+FORBIDDEN_RE='VideoEncoder|ServerSession|runServer'
+if nm -gU "$SAMPLE_BIN" 2>/dev/null | grep -E ' [TSDBtsdb] ' | grep -Eq "$FORBIDDEN_RE"; then
+  echo "--- defined stream/encode symbols in $SAMPLE_BIN ---" >&2
+  nm -gU "$SAMPLE_BIN" 2>/dev/null | grep -E ' [TSDBtsdb] ' | grep -E "$FORBIDDEN_RE" >&2 || true
+  fail "default (non-GE_SERVER) binary retains stream/encode symbols"
+fi
+pass "default sample binary has no defined ServerSession/VideoEncoder/runServer symbols"
+
+if ! grep -q 'GE_SERVER_BUILD' src/SessionHost.mm; then
+  fail "SessionHost.mm no longer gates runServer on GE_SERVER_BUILD"
+fi
+pass "runServer remains compile-gated on GE_SERVER_BUILD"
+
+echo "OK: release surface checks passed (T145 acceptance #2)"

--- a/tools/ios-build/build_project.rb
+++ b/tools/ios-build/build_project.rb
@@ -313,6 +313,7 @@ module GE
         [
           File.join(proj_rel, 'src'),
           File.join(proj_rel, 'include'),
+          File.join(proj_rel, 'vendor/include'),   # consumer's vendored headers (harmless if absent)
           File.join(ge_rel, 'include'),
           File.join(ge_rel, 'vendor/include'),
           # Header-only deps + SDL3 stack — lifted from their submodules

--- a/tools/ios-build/test_build_project.rb
+++ b/tools/ios-build/test_build_project.rb
@@ -291,6 +291,9 @@ class BuildProjectTest < Minitest::Test
       "consumer app shader output dir must be on the include path"
     assert_match %r{\$\(SRCROOT\)/\.\./ge/vendor/github\.com/floooh/sokol}, paths,
       "sokol_gfx.h vendor dir must be on the include path"
+    # Consumer vendor/include (e.g. yourworld2's dr_mp3.h) — harmless if absent.
+    assert_match %r{\$\(SRCROOT\)/\.\./vendor/include}, paths,
+      "consumer vendor/include must be on the header search path"
   end
 
   # bgfx/bx/bimg are gone post-T38; the generated xcodeproj must not


### PR DESCRIPTION
Resolves the four post–Plateau P gaps called out after the ged→spyder cutover.

## Changes
1. **README** — sokol_gfx + spyder architecture; no Dawn/WebGPU tables.
2. **T145 acceptance #2** — `make release-surface-test` proves NDEBUG strips app-channel and default (non-`GE_SERVER`) sample link drops encode/stream symbols. Wired into `make bullseye`.
3. **Open PRs** — landed the #166 one-liner (`vendor/include` header path) + test; closed #166 and draft #140 (superseded by T107).
4. **STABILITY.md** — snapshot v0.74.0; sokol session/render; spyder control plane; ged route tables removed; bgfx build vars removed.

## Verify
```bash
make release-surface-test
make dispatch-null-safety-test
make ruby-test
```