### PR TITLE
🎯T110: headless iOS device enrollment (register_devices)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,11 +483,25 @@ Two signing paths, deliberately separate. `build_project.rb` owns the `CODE_SIGN
 
 **The Apple model in one line:** a *certificate* says **who** signed; a *provisioning profile* says **what that signature may do** (which app, which devices — or any device for App Store — which entitlements). The cert's display name (`Apple Development: MARCELO CANTOS`) names the *member*; the `TeamIdentifier` (`SWA3H3N7TW`) is what attributes the build to **Squz**. They are not the same entity — a dev cert under Team Squz is still a Squz build.
 
-**A new device needs one-time enrollment.** `-allowProvisioningUpdates` reuses *already-registered* devices but will **not** enroll a brand-new one headlessly (`error: Device … isn't registered`). Today: connect it and Run once from Xcode (which enrolls it), then every later CLI build/deploy just works. The headless equivalent — a `fastlane register_devices` step keyed on the ASC API key — is the open piece of 🎯T110; until it lands, a never-before-seen device needs that single Xcode Run. Enrollment is **once per device, ever** — not per build.
+**A new device needs one-time enrollment (headless).** `-allowProvisioningUpdates` reuses *already-registered* devices but will **not** enroll a brand-new UDID (`error: Device … isn't registered`). Enroll without Xcode:
+
+```bash
+# Discovers connected devices (spyder inventory, else xctrace) and registers
+# their hardware UDIDs with the Developer Portal via the ASC API key.
+make ge/ios-register-devices
+
+# Or one explicit device:
+make ge/ios-register-devices UDID=00008110-… NAME="iPhone 13"
+
+# Or enroll then build in one shot:
+REGISTER_DEVICES=1 make ge/ios-device
+```
+
+Requires the same ASC API key env as ship (`APP_STORE_CONNECT_API_KEY_*`, or `~/.appstoreconnect/api_key.json` — see `docs/release-setup.md`). Uses fastlane lane `register_dev_devices` (ge `fastlane/Fastfile`). Enrollment is **once per device, ever** — re-runs are add-only no-ops for known UDIDs. Use **hardware** UDIDs (`00008110-…`), not CoreDevice UUIDs from `devicectl`.
 
 **Deployment floor is iOS 16.3** (`build_project.rb` default). Dropping to iOS 15 buys ~2–4% of old/weak/low-spend devices and costs `@available` guards around the iOS-16+ orientation-lock stack — not worth it.
 
-**Installing to a device:** modern devices via `spyder deploy_app` (or Apple `devicectl`, iOS 17+ only); iOS ≤16 devices use go-ios's lockdown path (spyder's high-level deploy/launch/screenshot assume the iOS-17 RemoteXPC tunnel — gap tracked as spyder 🎯T78).
+**Installing to a device:** modern devices via `spyder deploy_app` (or Apple `devicectl`, iOS 17+ only); iOS ≤16 devices use go-ios's lockdown path (spyder's high-level deploy/launch/screenshot assume the iOS-17 RemoteXPC tunnel — gap tracked as spyder 🎯T78). Spyder is the usual *installer*, not a dependency of the signing/enrollment path.
 
 ### iOS orientation lock (iPadOS 26+)
 

--- a/Module.mk
+++ b/Module.mk
@@ -716,17 +716,20 @@ ge/ios-device-release: $(APP_SHADERS) $(ge/RENDER_SHADERS)
 
 # ── iOS physical-device DEVELOPMENT build (deploy to your own devices) ─
 # `make ge/ios-device` builds a Debug, development-signed .app for installing
-# on a developer's own registered test devices. GE_IOS_SIGNING=development makes
-# build_project.rb emit Automatic signing + Apple Development (no match), and
-# `-allowProvisioningUpdates` lets Xcode mint/renew the per-developer dev cert,
-# create the Team Provisioning Profile, and register any connected+trusted
-# device. No shared certs, no match passphrase — each developer signs with their
-# own identity (the ship path stays on match AppStore via ge/ios-device-release).
+# on a developer's own *already-registered* test devices.
+# GE_IOS_SIGNING=development → Automatic + Apple Development (no match);
+# `-allowProvisioningUpdates` mints/renews the per-developer cert + Team
+# Provisioning Profile for devices the portal already knows. It does NOT
+# enroll a brand-new UDID — use `make ge/ios-register-devices` first (🎯T110).
+# Optional: REGISTER_DEVICES=1 make ge/ios-device  enrolls then builds.
 .PHONY: ge/ios-device
 ge/ios-device: $(APP_SHADERS) $(ge/RENDER_SHADERS)
 	@if [ ! -d ios ]; then \
 	    echo "ios/ not found — run 'make ge/ios-init APP_ID=... APP_NAME=...' first"; \
 	    exit 1; \
+	fi
+	@if [ "$(REGISTER_DEVICES)" = "1" ]; then \
+	    $(MAKE) ge/ios-register-devices; \
 	fi
 	GE_IOS_SIGNING=development bundle exec ruby ios/project.rb
 	cd ios && xcodebuild \
@@ -735,6 +738,22 @@ ge/ios-device: $(APP_SHADERS) $(ge/RENDER_SHADERS)
 	    -derivedDataPath build-device-dev \
 	    -allowProvisioningUpdates \
 	    build
+
+# ── iOS device enrollment (Developer Portal) — 🎯T110 ────────────────
+# Headless UDID registration via ASC API key + fastlane register_devices.
+# Once per device, ever. Idempotent. Does not require Xcode GUI.
+#
+#   make ge/ios-register-devices
+#   make ge/ios-register-devices UDID=00008110-… NAME="iPhone 13"
+#   DEVICES_FILE=./devices.txt make ge/ios-register-devices
+#   make ge/ios-register-devices LIST_ONLY=1   # discovery smoke, no ASC call
+.PHONY: ge/ios-register-devices
+ge/ios-register-devices:
+	@flags=""; \
+	  [ "$(LIST_ONLY)" = "1" ] && flags="$$flags --list-only"; \
+	  [ "$(DRY_RUN)" = "1" ] && flags="$$flags --dry-run"; \
+	  UDID="$(UDID)" NAME="$(NAME)" DEVICES_FILE="$(DEVICES_FILE)" \
+	    $(ge)/tools/ios-register-devices.sh $$flags
 
 # (ge player iOS physical-device build target retired in 🎯T73.3 — see
 # the player section above.)

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -442,9 +442,10 @@ targets:
     discovered: 2026-04-12
   T110:
     name: ge has an IDE-free iOS development build + deploy path (per-developer signing, headless device registration)
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 3.0
     acceptance:
     - build_project.rb supports a :development signing mode (CODE_SIGN_STYLE=Automatic + Apple Development, no match profile) selectable via GE_IOS_SIGNING=development; the default stays :appstore so the release/match path is unchanged.
     - '`make ge/ios-device` builds a Debug, development-signed .app and pairs it with `xcodebuild -allowProvisioningUpdates`, so each developer signs with their own cert (no match, no shared secret) and installs on the team''s registered devices.'
@@ -460,6 +461,7 @@ targets:
     - dev-workflow
     origin: manual
     discovered: 2026-06-07
+    achieved: 2026-07-11
   T111:
     name: expose-frame-perf-metrics-via-callback
     status: achieved

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -71,6 +71,25 @@ bundle exec fastlane sync_certs
 # double-check MATCH_PASSWORD and the squz/certs SSH key.
 ```
 
+## Step 4b — Enroll a new test device (🎯T110, optional)
+
+Physical-device **development** installs need the device UDID on the team.
+Do this **once per device**, without opening Xcode:
+
+```sh
+# Auto-discover connected devices (spyder or xctrace) and register them
+# with the Developer Portal via the ASC API key from Step 1–2.
+make ge/ios-register-devices
+
+# Then build a Debug, Automatic-signed .app:
+make ge/ios-device
+# Install via spyder / devicectl as usual.
+```
+
+`REGISTER_DEVICES=1 make ge/ios-device` enrolls then builds. Re-running
+registration is safe (add-only). Hardware UDIDs only (`00008110-…`), not
+CoreDevice UUIDs from `devicectl list devices`.
+
 ## Step 5 — Run ship-preflight
 
 ```sh

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,6 +67,53 @@ platform :ios do
     )
   end
 
+  # ── 🎯T110 headless device enrollment ─────────────────────────────────
+  # Registers hardware UDIDs with the Apple Developer Portal so Automatic
+  # development signing can include them without an Xcode GUI "Run".
+  # Prefer `make ge/ios-register-devices` (auto-discovers connected devices).
+  # Pass devices_file: (UDID\\tName per line) or devices: {"Name"=>"UDID"}.
+  desc "Register physical iOS devices with the Developer Portal (ASC API key)."
+  desc "Idempotent add-only. 🎯T110 — the open piece that closes IDE-free onboarding."
+  lane :register_dev_devices do |opts|
+    devices      = opts[:devices]
+    devices_file = opts[:devices_file] || ENV["FL_REGISTER_DEVICES_FILE"]
+
+    # Prefer the devices: hash form — devices_file parsing is picky about the
+    # Apple sample UDID layout. When only a file is supplied, parse
+    # "UDID\\tName" lines (optional "Device ID\\tDevice Name" header) into a hash.
+    if devices.nil? && devices_file && !devices_file.to_s.empty?
+      path = File.expand_path(devices_file.to_s)
+      UI.user_error!("devices_file not found: #{path}") unless File.file?(path)
+      devices = {}
+      File.readlines(path, chomp: true).each do |line|
+        next if line.strip.empty?
+        next if line.start_with?("Device ID")
+        # Accept TAB or multiple spaces as separator.
+        udid, name = line.split(/\t+|\s{2,}/, 2)
+        next if udid.nil? || udid.strip.empty?
+        udid = udid.strip
+        name = (name || udid).strip
+        # Name must be unique in the hash; disambiguate collisions.
+        if devices.key?(name)
+          name = "#{name} (#{udid[-4..]})"
+        end
+        devices[name] = udid
+      end
+      UI.user_error!("devices_file produced an empty device list: #{path}") if devices.empty?
+      UI.message("Parsed #{devices.size} device(s) from #{path}")
+    end
+
+    if devices.nil? || devices.empty?
+      UI.user_error!("register_dev_devices needs devices: or devices_file: (or make ge/ios-register-devices)")
+    end
+
+    team = opts[:team_id] || ENV["REGISTER_DEVICES_TEAM_ID"] || ENV["APPLE_TEAM_ID"]
+    args = { devices: devices, api_key: asc_api_key }
+    args[:team_id] = team if team && !team.to_s.empty?
+    register_devices(args)
+    UI.success("Devices registered (or already present) on the Developer Portal")
+  end
+
   # ── 🎯T64.2 ship lanes ──────────────────────────────────────────────────
 
   desc "Build the IPA via gym, using the resolved match certs."

--- a/tools/ios-register-devices.sh
+++ b/tools/ios-register-devices.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# tools/ios-register-devices.sh — 🎯T110 headless iOS device enrollment
+#
+# Registers physical iOS device UDIDs with the Apple Developer Portal via the
+# App Store Connect API key + fastlane `register_devices`, so a never-before-
+# seen device does NOT require an Xcode GUI "Run".
+#
+# Inputs (first match wins):
+#   1. UDID=… [NAME=…]              single device (NAME defaults to UDID)
+#   2. DEVICES_FILE=path            Apple-style file: "UDID<TAB>Name" per line
+#                                   (optional header "Device ID\tDevice Name")
+#   3. (none)                       auto-discover via spyder, else xcrun xctrace
+#
+# Flags:
+#   --list-only   print devices and exit (no ASC call)
+#   --dry-run     show what would be registered; do not call Apple
+#
+# Required env for a real registration (same contract as ship preflight):
+#   APP_STORE_CONNECT_API_KEY_KEY_ID
+#   APP_STORE_CONNECT_API_KEY_ISSUER_ID
+#   APP_STORE_CONNECT_API_KEY_KEY_PATH   path to AuthKey_*.p8
+# Or:
+#   APP_STORE_CONNECT_API_KEY_PATH       path to api_key.json (auto-mapped)
+#
+# Optional:
+#   APPLE_TEAM_ID / REGISTER_DEVICES_TEAM_ID
+#
+# Usage:
+#   make ge/ios-register-devices
+#   make ge/ios-register-devices UDID=00008110-… NAME="iPhone 13"
+#   DEVICES_FILE=./devices.txt make ge/ios-register-devices
+#   tools/ios-register-devices.sh --list-only
+#
+# Enrollment is once per device, ever — safe to re-run (idempotent add-only).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+list_only=0
+dry_run=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --list-only) list_only=1; shift ;;
+    --dry-run)   dry_run=1; shift ;;
+    -h|--help)
+      sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1 (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+is_hardware_udid() {
+  [[ "$1" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$ ]]
+}
+
+# Emit "UDID<TAB>Name" lines. Prefer spyder inventory; fall back to xctrace.
+discover_devices() {
+  if command -v spyder >/dev/null 2>&1; then
+    if spyder devices 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+if not isinstance(data, list) or not data:
+    sys.exit(1)
+n = 0
+for d in data:
+    if not isinstance(d, dict):
+        continue
+    plat = (d.get("platform") or "ios").lower()
+    if plat not in ("ios", "ipados"):
+        continue
+    udid = d.get("uuid") or d.get("udid") or ""
+    name = d.get("alias") or d.get("name") or udid
+    parts = udid.split("-")
+    # Hardware UDID: 8 hex + 16 hex. CoreDevice UUIDs are 8-4-4-4-12 — skip.
+    if len(parts) == 2 and len(parts[0]) == 8 and len(parts[1]) == 16:
+        print(f"{udid}\t{name}")
+        n += 1
+sys.exit(0 if n else 1)
+'; then
+      return 0
+    fi
+  fi
+
+  if command -v xcrun >/dev/null 2>&1; then
+    xcrun xctrace list devices 2>/dev/null | python3 -c '
+import re, sys
+pat = re.compile(
+    r"^(.+?)\s+\([^)]*\)\s+\(([0-9A-Fa-f]{8}-[0-9A-Fa-f]{16})\)\s*$"
+)
+seen = set()
+for line in sys.stdin:
+    line = line.rstrip("\n")
+    if "Simulator" in line:
+        continue
+    m = pat.match(line)
+    if not m:
+        continue
+    name, udid = m.group(1).strip(), m.group(2)
+    if udid in seen:
+        continue
+    seen.add(udid)
+    print(f"{udid}\t{name}")
+sys.exit(0 if seen else 1)
+'
+    return $?
+  fi
+  return 1
+}
+
+load_asc_env_from_json() {
+  local json_path="$1"
+  eval "$(python3 - "$json_path" <<'PY'
+import json, os, shlex, sys
+from pathlib import Path
+d = json.load(open(sys.argv[1]))
+print(f"export APP_STORE_CONNECT_API_KEY_KEY_ID={shlex.quote(d['key_id'])}")
+print(f"export APP_STORE_CONNECT_API_KEY_ISSUER_ID={shlex.quote(d['issuer_id'])}")
+key_path = os.environ.get("APP_STORE_CONNECT_API_KEY_KEY_PATH", "")
+if not key_path:
+    p = Path.home() / ".appstoreconnect" / "private_keys" / f"AuthKey_{d['key_id']}.p8"
+    if not p.is_file() and d.get("key"):
+        p.parent.mkdir(parents=True, exist_ok=True)
+        key = d["key"]
+        if not key.startswith("-----"):
+            # Spaceship accepts raw base64 key body wrapped as PEM.
+            key = "-----BEGIN PRIVATE KEY-----\n" + key.strip() + "\n-----END PRIVATE KEY-----\n"
+        p.write_text(key)
+        p.chmod(0o600)
+    if p.is_file():
+        print(f"export APP_STORE_CONNECT_API_KEY_KEY_PATH={shlex.quote(str(p))}")
+PY
+)"
+}
+
+tmp_devices=""
+owned_tmp=0
+cleanup() {
+  if [ "$owned_tmp" -eq 1 ] && [ -n "$tmp_devices" ]; then
+    rm -f "$tmp_devices"
+  fi
+}
+trap cleanup EXIT
+
+if [ -n "${UDID:-}" ]; then
+  if ! is_hardware_udid "$UDID"; then
+    echo "ERROR: UDID='$UDID' is not a hardware UDID (8 hex - 16 hex)." >&2
+    echo "       CoreDevice identifiers from devicectl are not accepted by the portal." >&2
+    exit 1
+  fi
+  tmp_devices="$(mktemp)"
+  owned_tmp=1
+  printf '%s\t%s\n' "$UDID" "${NAME:-$UDID}" >"$tmp_devices"
+elif [ -n "${DEVICES_FILE:-}" ]; then
+  if [ ! -f "$DEVICES_FILE" ]; then
+    echo "ERROR: DEVICES_FILE='$DEVICES_FILE' not found" >&2
+    exit 1
+  fi
+  tmp_devices="$DEVICES_FILE"
+else
+  tmp_devices="$(mktemp)"
+  owned_tmp=1
+  if ! discover_devices >"$tmp_devices"; then
+    echo "ERROR: no physical iOS devices discovered." >&2
+    echo "  Connect+trust a device, or pass UDID=… NAME=…, or DEVICES_FILE=…" >&2
+    exit 1
+  fi
+fi
+
+echo "── Devices to register ──"
+count=0
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    ""|"Device ID"*) continue ;;
+  esac
+  udid="${line%%	*}"
+  name="${line#*	}"
+  [ "$udid" = "$name" ] && name="(unnamed)"
+  printf '  %s  %s\n' "$udid" "$name"
+  count=$((count + 1))
+done <"$tmp_devices"
+
+if [ "$count" -eq 0 ]; then
+  echo "ERROR: device list is empty" >&2
+  exit 1
+fi
+
+if [ "$list_only" -eq 1 ]; then
+  exit 0
+fi
+
+# Resolve ASC credentials
+if [ -z "${APP_STORE_CONNECT_API_KEY_PATH:-}" ] && [ -f "$HOME/.appstoreconnect/api_key.json" ]; then
+  export APP_STORE_CONNECT_API_KEY_PATH="$HOME/.appstoreconnect/api_key.json"
+fi
+if [ -n "${APP_STORE_CONNECT_API_KEY_PATH:-}" ] && [ -f "$APP_STORE_CONNECT_API_KEY_PATH" ]; then
+  load_asc_env_from_json "$APP_STORE_CONNECT_API_KEY_PATH"
+fi
+
+missing=()
+for v in APP_STORE_CONNECT_API_KEY_KEY_ID APP_STORE_CONNECT_API_KEY_ISSUER_ID APP_STORE_CONNECT_API_KEY_KEY_PATH; do
+  if [ -z "${!v:-}" ]; then missing+=("$v"); fi
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "ERROR: missing ASC API key env: ${missing[*]}" >&2
+  echo "  See ge/docs/release-setup.md or place ~/.appstoreconnect/api_key.json" >&2
+  exit 1
+fi
+if [ ! -f "$APP_STORE_CONNECT_API_KEY_KEY_PATH" ]; then
+  echo "ERROR: KEY_PATH='$APP_STORE_CONNECT_API_KEY_KEY_PATH' is not a file" >&2
+  exit 1
+fi
+
+export REGISTER_DEVICES_TEAM_ID="${APPLE_TEAM_ID:-${REGISTER_DEVICES_TEAM_ID:-SWA3H3N7TW}}"
+
+# Prefer consumer repo (imports ge Fastfile); fall back to ge.
+REPO_ROOT="$(git rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git -C "$GE_ROOT" rev-parse --show-toplevel)"
+fi
+run_dir="$REPO_ROOT"
+if [ ! -f "$run_dir/Gemfile" ] && [ -f "$GE_ROOT/Gemfile" ]; then
+  run_dir="$GE_ROOT"
+fi
+
+echo "── Registering via ASC API (team ${REGISTER_DEVICES_TEAM_ID}) ──"
+if [ "$dry_run" -eq 1 ]; then
+  echo "(dry-run) cd $run_dir && bundle exec fastlane ios register_dev_devices devices_file:$tmp_devices"
+  exit 0
+fi
+
+(
+  cd "$run_dir"
+  if [ -f fastlane/Fastfile ]; then
+    bundle exec fastlane ios register_dev_devices "devices_file:$tmp_devices"
+  else
+    # Invoke ge's Fastfile directly when the cwd has no fastlane/ tree.
+    bundle exec fastlane ios register_dev_devices "devices_file:$tmp_devices" \
+      --verbose 2>&1 || \
+    FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane ios register_dev_devices \
+      "devices_file:$tmp_devices" -c "$GE_ROOT/fastlane/Fastfile"
+  fi
+)
+
+echo "OK: devices submitted to the Developer Portal (add-only; known UDIDs are no-ops)."
+echo "    Next: make ge/ios-device   # Automatic signing includes newly-registered devices"


### PR DESCRIPTION
## Summary
Closes 🎯T110 — IDE-free iOS development path is complete, including the open
headless-enrollment piece.

## What
- `tools/ios-register-devices.sh` — discover hardware UDIDs (spyder → xctrace), register via ASC API key
- `fastlane ios register_dev_devices` — parses UDID/Name file into `devices:` hash, calls `register_devices`
- `make ge/ios-register-devices` (+ `LIST_ONLY=1`, `DRY_RUN=1`, `UDID=`/`NAME=`/`DEVICES_FILE=`)
- `REGISTER_DEVICES=1 make ge/ios-device` enrolls then builds
- AGENTS.md + release-setup.md document the flow
- Corrects Module.mk comment: `-allowProvisioningUpdates` does **not** enroll new UDIDs

## Verify
```bash
make ge/ios-register-devices LIST_ONLY=1
make ge/ios-register-devices          # live ASC (idempotent)
make ruby-test                        # T110 signing mode tests still green
```

Live oracle: registered Jevons + Minicades Test iPhone on team SWA3H3N7TW (`Successfully registered new devices`).