### PR TITLE
fix: remap parallax into live display orientation

### DIFF
--- a/include/ge/SessionHost.h
+++ b/include/ge/SessionHost.h
@@ -396,10 +396,11 @@ public:
 
     // Current parallax delta in screen-local radians: x is rotation
     // around the screen-X axis (forward/back tilt), y is rotation
-    // around the screen-Y axis (left/right tilt). Already scaled by
-    // SessionHostConfig.parallaxFactor and absorbed by the engine's
-    // EMA baseline (sustained tilts settle to zero, so the value is
-    // always small).
+    // around the screen-Y axis (left/right tilt). Remapped from the
+    // device-hardware attitude frame using the live display orientation
+    // (same table as rotateAccelToScreen — portrait/landscape/flipped).
+    // Already scaled by SessionHostConfig.parallaxFactor and absorbed by
+    // the engine's EMA baseline (sustained tilts settle to zero).
     //
     // Returns {0, 0} when parallaxFactor == 0, on platforms with no
     // attitude sensor (desktop), and during the first ~τ seconds of a

--- a/src/AccelScreen_test.cpp
+++ b/src/AccelScreen_test.cpp
@@ -59,3 +59,13 @@ TEST_CASE("rotateAccelToScreen landscape then inverse-like round trip via flippe
     CHECK(near(d[0], 4.f));
     CHECK(near(d[1], 3.f));
 }
+
+// Parallax uses the same 2D remap on the small-angle (rx, ry) pair extracted
+// from the attitude delta quaternion (see DirectRenderHost::updateParallax).
+TEST_CASE("parallax angle pair remaps with rotateAccelToScreen in landscape") {
+    // Device-frame pitch (about device-X) should become screen-Y in landscape.
+    float d[3] = {1.f, 0.f, 0.f};  // rx=1, ry=0
+    rotateAccelToScreen(SDL_ORIENTATION_LANDSCAPE, d);
+    CHECK(near(d[0], 0.f));
+    CHECK(near(d[1], 1.f));
+}

--- a/src/render/DirectRenderHost.mm
+++ b/src/render/DirectRenderHost.mm
@@ -350,10 +350,14 @@ struct DirectRenderHost::Impl {
     // attitude provider polled per frame; baseline is the EMA-tracked
     // neutral, delta is computed inverse(baseline) * current and
     // projected to screen-XY radians, scaled by parallaxFactor.
+    // lastParallaxOrient: when the UI rotates (portrait↔landscape), the
+    // device-frame quaternion axes no longer map to screen axes — reset the
+    // EMA baseline so we don't get a one-shot jump until τ settles.
     float parallaxFactor = 0.0f;
     std::unique_ptr<AttitudeProvider> attitude;
     bool   baselineSet = false;
     la::float4 baseline{0, 0, 0, 1};
+    SDL_DisplayOrientation lastParallaxOrient = SDL_ORIENTATION_UNKNOWN;
 
     // 🎯T44 / 🎯T45 callbacks — set by runDirect after factory.
     std::function<void()> onBackPressed;
@@ -1266,6 +1270,21 @@ la::float2 DirectRenderHost::updateParallax() {
     if (i_->parallaxFactor <= 0.0f || !i_->attitude || !i_->attitude->valid()) {
         return {0, 0};
     }
+
+    // Live UI orientation — same source as SENSOR_UPDATE screen-framing.
+    // CMAttitude / Android GAME_ROTATION_VECTOR are device-hardware framed;
+    // without this remap, landscape swaps pitch/yaw relative to the pixels.
+    SDL_DisplayOrientation orient = SDL_ORIENTATION_UNKNOWN;
+    if (i_->sokolCtx) {
+        if (SDL_DisplayID disp = SDL_GetDisplayForWindow(i_->sokolCtx->window())) {
+            orient = SDL_GetCurrentDisplayOrientation(disp);
+        }
+    }
+    if (orient != i_->lastParallaxOrient) {
+        i_->lastParallaxOrient = orient;
+        i_->baselineSet = false;  // re-seed baseline in the new frame
+    }
+
     // Quaternion EMA: with α small the result stays close to a unit
     // quaternion, so plain componentwise lerp is fine — no slerp, no
     // renormalization needed (drift is self-correcting under
@@ -1293,10 +1312,13 @@ la::float2 DirectRenderHost::updateParallax() {
         binv.w * cur.z + binv.x * cur.y - binv.y * cur.x + binv.z * cur.w,
         binv.w * cur.w - binv.x * cur.x - binv.y * cur.y - binv.z * cur.z,
     };
-    // Small-angle approximation: rotation around the screen-X axis is
-    // 2 * d.x radians, around screen-Y is 2 * d.y. Sign matches "tilt
-    // toward +axis = positive value".
-    return la::float2{2.0f * d.x, 2.0f * d.y} * i_->parallaxFactor;
+    // Small-angle approx in *device* frame: rx≈2dx about device-X, ry≈2dy
+    // about device-Y. Remap to screen-local axes (same table as accel).
+    float screen[3] = {2.0f * d.x, 2.0f * d.y, 0.0f};
+    rotateAccelToScreen(orient, screen);
+    // Sign: "tilt toward +screen-axis = positive" — consumers (e.g. esfera)
+    // may invert for natural peek polarity.
+    return la::float2{screen[0], screen[1]} * i_->parallaxFactor;
 }
 
 bool DirectRenderHost::shouldQuit() const {


### PR DESCRIPTION
## Summary
`updateParallax()` treated attitude-delta small-angle components as already screen-local. They are device-hardware framed (same as raw accel). Landscape therefore swapped pitch/yaw relative to the UI.

- Apply `rotateAccelToScreen` (same table as `SENSOR_UPDATE`) to the (rx, ry) pair.
- Re-seed the EMA baseline when display orientation changes so portrait↔landscape does not jump for ~1s.

## Test plan
- [x] `make unit-test` (343 cases) including new landscape remap check
- [ ] Device: esfera with `parallaxFactor > 0` in landscape + portrait