### PR TITLE
STABILITY snapshot for legacy-path gitignore

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -2,7 +2,7 @@
 
 **Pre-1.0 stability tracking for the `ge` engine.**
 
-Snapshot as of: **v0.78.0** (parallax display-orientation remap; prebuilds recooked).
+Snapshot as of: **v0.79.0** (gitignore legacy tools/android + web residue for clean consumer submodules).
 
 ---
 


### PR DESCRIPTION
## Summary
- Bumps STABILITY snapshot to **v0.79.0**.
- Content already on master via #189 (gitignore for legacy `tools/android` + `web` residue).

## Test plan
- [x] No code/prebuild changes; verify-prebuilds CI only
